### PR TITLE
V4 token indexing + explicit Permit2 bot-selling flow

### DIFF
--- a/scripts/evm-indexer.mjs
+++ b/scripts/evm-indexer.mjs
@@ -6,6 +6,7 @@ import {
   parseAbiItem,
   getAddress,
 } from 'viem';
+import { createServer as createViteServer } from 'vite';
 import fs from 'fs';
 
 // Robust .env.local loader
@@ -80,9 +81,37 @@ const LOSS_POOL_ABI = parseAbi([
   'function getUnallocatedBalance(address token) view returns (uint256)',
 ]);
 
+// V4: unlike V3's per-token BondingCurveCreated, there is one shared factory whose
+// TokenLaunched event is the only on-chain record of "a V4 token exists" — there is no
+// per-token curve contract to independently discover from, so this event IS the discovery
+// mechanism (see discoverV4TokensInRange below), not just a convenience.
+const V4_FACTORY_ABI = parseAbi([
+  'event TokenLaunched(address indexed token, address indexed creator, bytes32 poolId)',
+]);
+const ERC20_SYMBOL_ABI = parseAbi(['function symbol() view returns (string)']);
+
 const INCENTIFI_BONDING_CURVE_FACTORY = (process.env.VITE_INCENTIFI_BONDING_CURVE_FACTORY || '0xa0143de84fba1753b887e4e32941e4fb342e473f');
 const LOSS_REWARD_POOL = (process.env.VITE_LOSS_REWARD_POOL || '0x697bda9db5a297a9cd9ed969bbf2549d0527dcdf');
 const INCENTIFI_SWAP_ROUTER = (process.env.VITE_INCENTIFI_SWAP_ROUTER || '0x4c1f4197b5eebb6cc15c37e053f963a56787575e');
+const INCENTIFI_V4_FACTORY = (process.env.VITE_INCENTIFI_V4_FACTORY || '0xdEca2efDB578B6E5F298885b97F64d52f92f5Aa9');
+
+// Reference ETH/USD used for price_usd — kept numerically identical to
+// src/lib/bondingCurve.ts's REFERENCE_ETH_USD (also 2500) so V3 and V4 rows in
+// token_market_snapshots_evm are computed on the same basis.
+const REFERENCE_ETH_USD = 2500;
+
+// Conservative floor for the one-time V4 TokenLaunched historical catch-up scan (see
+// discoverV4TokensInRange). NOT derived from a binary search on eth_getCode/eth_getBytecode
+// — this RPC only retains full state (balances, code) for roughly the last 5,600-6,000
+// blocks (empirically measured against real responses; confirmed independently the hard
+// way while building test/hardhat/loss-reward-fork.test.ts), so a getCode-based binary
+// search for the V4 factory's real deployment block is unreliable for anything older than
+// that. getLogs, in contrast, has been repeatedly confirmed to work correctly across much
+// older block ranges on this same RPC. This floor was chosen by chunked getLogs scanning
+// from a wide starting point and confirming it still finds the real, known TokenLaunched
+// events (TESTTT among them) with room to spare — comfortably before the V4 factory's
+// actual deployment, not an exact value that could go stale as more blocks pass.
+const V4_DISCOVERY_FLOOR_BLOCK = 54_600_000n;
 
 // This process indexes on-chain trade events into `holder_cost_basis` for ALL
 // registered tokens in one loop (not one worker per token), so it reports a single
@@ -438,6 +467,139 @@ export async function updateMarketSnapshot(tokenAddress, symbol, curveAddress) {
   }
 }
 
+// ============================================================================
+// V4 token discovery + market snapshot indexing
+// ============================================================================
+// V4 has no per-token curve contract to read state from directly (unlike V3's
+// IncentifiBondingCurve) — every launched token shares one hook instance, keyed by a
+// PoolId derived from the token's PoolKey. src/lib/bondingCurveV4.ts's
+// fetchV4CurveState() already implements the full pre-/post-graduation state-reading
+// logic (hook.curveStates(poolId) pre-graduation, StateView.getSlot0(poolId)
+// post-graduation) and is the single, already-verified source of truth for it — reused
+// here via Vite's SSR module loader rather than re-derived, so there is exactly one
+// implementation of this logic for the whole app to ever drift out of sync with. This
+// is heavier than a plain import (a Vite dev server has to spin up once), which is an
+// acceptable one-time startup cost for a long-running indexer process; it is NOT
+// re-created per call, per tick, or per token.
+
+let v4ModulePromise = null;
+async function getV4Module() {
+  if (!v4ModulePromise) {
+    v4ModulePromise = (async () => {
+      const viteServer = await createViteServer({ server: { middlewareMode: true }, appType: 'custom' });
+      return viteServer.ssrLoadModule('/src/lib/bondingCurveV4.ts');
+    })();
+  }
+  return v4ModulePromise;
+}
+
+// lowercase token address -> symbol, for every V4 token discovered so far this process.
+const v4TokenSymbolCache = new Map();
+// Block through which V4 TokenLaunched events have been scanned. Starts unset until
+// discoverV4TokensInRange's one-time historical catch-up (see runIndexer) has run, so the
+// per-tick incremental scan below never fires against an unpopulated cache.
+let v4LastScannedBlock = null;
+
+async function getLogsWithRetry(params, { retries = 3, baseDelayMs = 500 } = {}) {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await client.getLogs(params);
+    } catch (err) {
+      if (attempt >= retries) throw err;
+      await new Promise((resolve) => setTimeout(resolve, baseDelayMs * (attempt + 1)));
+    }
+  }
+}
+
+/**
+ * Scans [fromBlock, toBlock] in 5,000-block chunks (this RPC's per-call range cap, same
+ * limit already respected everywhere else in this file) for real TokenLaunched events on
+ * the V4 factory, resolving and caching each newly-discovered token's real ERC20 symbol()
+ * directly from-chain (independent of whatever the `tokens` table may or may not have —
+ * that table's row is a best-effort client-side write from the launch flow and can be
+ * missing even for a real, successfully-launched token). Retries each chunk on transient
+ * RPC failure rather than silently skipping it, since a skipped chunk here would mean
+ * permanently missing a real token launch, not just a delayed retry on the next tick (this
+ * function is also used for the one-time historical catch-up, where there is no "next
+ * tick" to self-heal on).
+ */
+export async function discoverV4TokensInRange(fromBlock, toBlock, { chunkSize = 5000n } = {}) {
+  let from = fromBlock;
+  while (from <= toBlock) {
+    const to = from + chunkSize > toBlock ? toBlock : from + chunkSize;
+    const logs = await getLogsWithRetry({
+      address: getAddress(INCENTIFI_V4_FACTORY),
+      event: parseAbiItem('event TokenLaunched(address indexed token, address indexed creator, bytes32 poolId)'),
+      fromBlock: from,
+      toBlock: to,
+    });
+
+    for (const log of logs) {
+      const tokenAddr = log.args.token.toLowerCase();
+      if (v4TokenSymbolCache.has(tokenAddr)) continue;
+      try {
+        const symbol = await client.readContract({
+          address: getAddress(tokenAddr),
+          abi: ERC20_SYMBOL_ABI,
+          functionName: 'symbol',
+        });
+        v4TokenSymbolCache.set(tokenAddr, symbol);
+        console.log(`[V4 DISCOVERY] Found V4 token ${symbol} (${tokenAddr}) launched at block ${log.blockNumber}`);
+      } catch (err) {
+        console.warn(`[V4 DISCOVERY] Could not read symbol() for newly-discovered V4 token ${tokenAddr}: ${err.message}`);
+      }
+    }
+
+    from = to + 1n;
+  }
+}
+
+/**
+ * Updates token_market_snapshots_evm for a single V4 token from its real, live on-chain
+ * state, in the same row shape V3 snapshots use so home/page.tsx's existing
+ * snapshot-based rendering picks it up with no V4-specific branching needed there.
+ */
+export async function updateV4MarketSnapshot(tokenAddress, symbol, fetchV4CurveState) {
+  try {
+    const state = await fetchV4CurveState(tokenAddress, REFERENCE_ETH_USD);
+    const priceEth = state.currentPriceEth || 0;
+    // Mirrors V3's own liquidity_eth approximation (real ETH reserve, doubled to
+    // represent both sides of the pool) for consistency between V3 and V4 rows in the
+    // same table — see updateMarketSnapshot above.
+    const liquidityEth = (Number(state.realEthReserve) / 1e18) * 2;
+
+    let lossPoolTvlEth = 0;
+    try {
+      const tvl = await client.readContract({
+        address: getAddress(LOSS_REWARD_POOL),
+        abi: LOSS_POOL_ABI,
+        functionName: 'getUnallocatedBalance',
+        args: [getAddress(tokenAddress)],
+      });
+      lossPoolTvlEth = Number(tvl) / 1e18;
+    } catch {
+      // Ignore
+    }
+
+    const { error: snapErr } = await supabase.from('token_market_snapshots_evm').upsert({
+      token_address: tokenAddress.toLowerCase(),
+      symbol: symbol.toUpperCase(),
+      price_eth: priceEth,
+      price_usd: priceEth * REFERENCE_ETH_USD,
+      liquidity_eth: liquidityEth,
+      market_cap_usd: state.marketCapUsd || 0,
+      loss_pool_tvl_eth: lossPoolTvlEth,
+      updated_at: new Date().toISOString(),
+    });
+
+    if (snapErr) {
+      throw new Error(`[DB ERROR] Failed to upsert token_market_snapshots_evm (V4 ${symbol}): ${snapErr.code} ${snapErr.message}`);
+    }
+  } catch (err) {
+    console.warn(`Could not update V4 market snapshot for ${symbol}:`, err.message);
+  }
+}
+
 /**
  * Main Indexer Poller Loop
  */
@@ -445,9 +607,26 @@ export async function runIndexer() {
   console.log('--- Starting Incentifi EVM Indexer ---');
   console.log(`RPC: ${RPC_URL}`);
   console.log(`Factory: ${INCENTIFI_BONDING_CURVE_FACTORY}`);
+  console.log(`V4 Factory: ${INCENTIFI_V4_FACTORY}`);
 
   let lastPolledBlock = 0n;
   const curveAddressCache = new Map();
+
+  // One-time V4 TokenLaunched historical catch-up: without this, the per-tick
+  // incremental scan below (which only ever looks at the current tick's small block
+  // window) would never see a V4 token launched before this process started — there is
+  // no `tokens`-table-style registry this side can fall back on, since the whole point
+  // of event-based discovery is to work independently of that (see the V4 section's
+  // header comment above for why). Runs once, before the poller loop begins.
+  try {
+    const catchupEndBlock = await client.getBlockNumber();
+    console.log(`[V4 DISCOVERY] Running one-time historical catch-up scan (block ${V4_DISCOVERY_FLOOR_BLOCK} → ${catchupEndBlock})...`);
+    await discoverV4TokensInRange(V4_DISCOVERY_FLOOR_BLOCK, catchupEndBlock);
+    v4LastScannedBlock = catchupEndBlock;
+    console.log(`[V4 DISCOVERY] Historical catch-up complete. Found ${v4TokenSymbolCache.size} V4 token(s) so far.`);
+  } catch (err) {
+    console.error('[V4 DISCOVERY] Historical catch-up scan failed — V4 tokens will not be indexed until this succeeds on a future restart:', err.message);
+  }
 
   setInterval(async () => {
     try {
@@ -480,6 +659,29 @@ export async function runIndexer() {
       // Cap chunk size to 5,000 blocks to prevent RPC timeout/range errors
       const CHUNK_SIZE = 5000n;
       const toBlock = currentBlock > fromBlock + CHUNK_SIZE ? fromBlock + CHUNK_SIZE : currentBlock;
+
+      // V4: independent of the `tokens` table (see the V4 section's header comment) and
+      // of whether any V3 tokens exist, so this runs unconditionally every tick, in its
+      // own try/catch so a V4-specific hiccup never blocks V3 indexing for this tick.
+      if (v4LastScannedBlock !== null) {
+        try {
+          // Guard against toBlock (bounded by the unrelated V3 cursor's own chunking)
+          // ever being behind v4LastScannedBlock — keeps this cursor monotonic even if
+          // V3's own cursor is temporarily lagging chain head for some other reason.
+          if (toBlock > v4LastScannedBlock) {
+            await discoverV4TokensInRange(v4LastScannedBlock + 1n, toBlock);
+            v4LastScannedBlock = toBlock;
+          }
+          if (v4TokenSymbolCache.size > 0) {
+            const v4Module = await getV4Module();
+            for (const [tokenAddr, symbol] of v4TokenSymbolCache) {
+              await updateV4MarketSnapshot(tokenAddr, symbol, v4Module.fetchV4CurveState);
+            }
+          }
+        } catch (err) {
+          console.warn('[V4] Discovery/snapshot pass failed this tick (will retry next tick):', err.message);
+        }
+      }
 
       // 1. Fetch active tokens
       const { data: tokens, error: tokensErr } = await supabase.from('tokens').select('mint_address, symbol');

--- a/src/lib/permit2.ts
+++ b/src/lib/permit2.ts
@@ -1,0 +1,164 @@
+import { encodeFunctionData, parseAbi, getAddress } from 'viem';
+import { getEvmProvider, publicClient, waitForTransactionReceipt } from './evmNetwork';
+import { PERMIT2_ADDRESS, UNIVERSAL_ROUTER_ADDRESS } from './uniswapAddresses';
+
+// ----------------------------------------------------------------------------
+// "Allow external bots to sell this token" — a deliberately separate, explicitly
+// user-initiated action. NEVER call enableExternalBotSelling() from the buy/sell flow:
+// silently bundling a broad, indefinite approval into an unrelated action is the exact
+// shape of a wallet-drainer dark pattern, even though the mechanism itself (Permit2,
+// UniversalRouter) is standard, real Uniswap infrastructure. Every step here is a plain
+// on-chain transaction the caller's own wallet signs and pays gas for — no signatures,
+// no relayer. (A gasless, relayer-paid version was considered and deliberately deferred:
+// Permit2.permit() is callable by anyone once signed, so a public relay endpoint needs
+// its own scoping/rate-limiting work before it's safe to stand up.)
+//
+// Why this is needed at all: this launchpad's token template
+// (contracts/IncentifiLaunchToken.sol) has no EIP-2612 permit() — independently confirmed
+// on real deployed bytecode (DOMAIN_SEPARATOR() and nonces() both revert) — so there is no
+// gasless way to grant Permit2 an ERC20 allowance. A third-party trading bot that routes
+// sells through Permit2 + UniversalRouter (a common pattern for generic, non-Incentifi-
+// aware bots) can only do so once BOTH of the two approvals below exist.
+// ----------------------------------------------------------------------------
+
+const ERC20_ALLOWANCE_ABI = parseAbi([
+  'function allowance(address owner, address spender) view returns (uint256)',
+  'function approve(address spender, uint256 amount) returns (bool)',
+]);
+
+const PERMIT2_ABI = parseAbi([
+  'function allowance(address owner, address token, address spender) view returns (uint160 amount, uint48 expiration, uint48 nonce)',
+  'function approve(address token, address spender, uint160 amount, uint48 expiration) external',
+]);
+
+const MAX_UINT256 = (1n << 256n) - 1n;
+const MAX_UINT160 = (1n << 160n) - 1n;
+
+// Permit2's own point over a plain ERC20 approval is that its allowances expire — using
+// MAX_UINT48 (effectively forever) throws that away and just reproduces the same
+// "approved forever" problem a year down the line instead of never. One year is long
+// enough that re-approval is rare, short enough that a compromised/abandoned router
+// address doesn't stay armed indefinitely. Exported so the UI can show the real expiry
+// date computed at approval time, not a value re-derived (and liable to drift) elsewhere.
+export const PERMIT2_APPROVAL_DURATION_SECONDS = 365n * 24n * 60n * 60n;
+
+// A remaining-validity floor for "still counts as enabled" — short enough that this
+// genuinely reflects on-chain reality (not just "was it ever approved"), long enough that
+// the status check isn't itself flapping day-to-day as a real approval nears its real
+// expiry. Chosen independently of PERMIT2_APPROVAL_DURATION_SECONDS on purpose: a fresh
+// approval clears this floor by ~360 days of margin.
+const MIN_REMAINING_VALIDITY_SECONDS = 5n * 24n * 60n * 60n;
+
+// Treated as "already approved" without requiring an exact bit-for-bit match against
+// MAX_UINT256/MAX_UINT160 — a prior, merely-very-large approval still counts. Mirrors the
+// same near-max convention Uniswap's own frontend uses for ERC20/Permit2 allowances.
+const NEAR_MAX_UINT256_THRESHOLD = MAX_UINT256 / 2n;
+const NEAR_MAX_UINT160_THRESHOLD = MAX_UINT160 / 2n;
+
+export interface ExternalBotSellingStatus {
+  erc20ApprovedToPermit2: boolean;
+  permit2ApprovedToRouter: boolean;
+  fullyEnabled: boolean;
+  /** Null if there is no (or an expired/insufficient) Permit2-level approval yet. */
+  permit2ExpiresAt: Date | null;
+}
+
+/**
+ * Read-only check — safe to call anytime, no wallet transaction involved.
+ */
+export async function getExternalBotSellingStatus(
+  tokenAddress: string,
+  ownerAddress: string
+): Promise<ExternalBotSellingStatus> {
+  const token = getAddress(tokenAddress);
+  const owner = getAddress(ownerAddress);
+
+  const erc20Allowance = await publicClient.readContract({
+    address: token,
+    abi: ERC20_ALLOWANCE_ABI,
+    functionName: 'allowance',
+    args: [owner, PERMIT2_ADDRESS],
+  });
+  const erc20ApprovedToPermit2 = erc20Allowance > NEAR_MAX_UINT256_THRESHOLD;
+
+  const [amount, expiration] = await publicClient.readContract({
+    address: PERMIT2_ADDRESS,
+    abi: PERMIT2_ABI,
+    functionName: 'allowance',
+    args: [owner, token, UNIVERSAL_ROUTER_ADDRESS],
+  });
+  const expirationBig = BigInt(expiration);
+  const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
+  const permit2ApprovedToRouter =
+    BigInt(amount) > NEAR_MAX_UINT160_THRESHOLD && expirationBig > nowSeconds + MIN_REMAINING_VALIDITY_SECONDS;
+
+  return {
+    erc20ApprovedToPermit2,
+    permit2ApprovedToRouter,
+    fullyEnabled: erc20ApprovedToPermit2 && permit2ApprovedToRouter,
+    permit2ExpiresAt: permit2ApprovedToRouter ? new Date(Number(expirationBig) * 1000) : null,
+  };
+}
+
+export type EnableBotSellingStep = 'erc20-approve' | 'permit2-approve';
+
+/**
+ * Runs whichever of the two on-chain approvals aren't already in place, in order, each
+ * as its own wallet-prompted, wallet-paid transaction. Safe to call repeatedly — already-
+ * satisfied steps are skipped (checked fresh via getExternalBotSellingStatus each time).
+ */
+export async function enableExternalBotSelling(
+  tokenAddress: string,
+  onStep?: (step: EnableBotSellingStep, txHash: string) => void
+): Promise<{ steps: EnableBotSellingStep[] }> {
+  const provider = getEvmProvider();
+  if (!provider) throw new Error('No EVM wallet detected. Please connect your wallet.');
+
+  const accounts = (await provider.request({ method: 'eth_accounts' })) as string[];
+  const sender = accounts?.[0];
+  if (!sender) throw new Error('Wallet is connected, but no active account was found.');
+
+  const token = getAddress(tokenAddress);
+  const owner = getAddress(sender);
+  const performed: EnableBotSellingStep[] = [];
+
+  const status = await getExternalBotSellingStatus(token, owner);
+
+  if (!status.erc20ApprovedToPermit2) {
+    const data = encodeFunctionData({
+      abi: ERC20_ALLOWANCE_ABI,
+      functionName: 'approve',
+      args: [PERMIT2_ADDRESS, MAX_UINT256],
+    });
+    const txHash = (await provider.request({
+      method: 'eth_sendTransaction',
+      params: [{ from: owner, to: token, data }],
+    })) as string;
+    await waitForTransactionReceipt(txHash, { description: 'Permit2 token approval' });
+    performed.push('erc20-approve');
+    onStep?.('erc20-approve', txHash);
+  }
+
+  if (!status.permit2ApprovedToRouter) {
+    // uint48 expiration, NOT uint256 — only the ERC20 approve() above takes a real
+    // uint256 max. A one-year-out timestamp fits comfortably (uint48 covers dates far
+    // past any realistic expiration here); passing the wrong width either throws at
+    // encoding or truncates silently, so this is deliberately computed as a plain unix
+    // timestamp rather than reused from the uint160/uint256 constants above.
+    const expiration = BigInt(Math.floor(Date.now() / 1000)) + PERMIT2_APPROVAL_DURATION_SECONDS;
+    const data = encodeFunctionData({
+      abi: PERMIT2_ABI,
+      functionName: 'approve',
+      args: [token, UNIVERSAL_ROUTER_ADDRESS, MAX_UINT160, expiration],
+    });
+    const txHash = (await provider.request({
+      method: 'eth_sendTransaction',
+      params: [{ from: owner, to: PERMIT2_ADDRESS, data }],
+    })) as string;
+    await waitForTransactionReceipt(txHash, { description: 'Universal Router Permit2 approval' });
+    performed.push('permit2-approve');
+    onStep?.('permit2-approve', txHash);
+  }
+
+  return { steps: performed };
+}

--- a/src/lib/uniswapAddresses.ts
+++ b/src/lib/uniswapAddresses.ts
@@ -63,6 +63,20 @@ export const INCENTIFI_V4_HOOK = String(
   import.meta.env.VITE_INCENTIFI_V4_HOOK || '0x5bBcf2CDAAA00c285eEc903AA1E2aB9142782888'
 ).trim() as `0x${string}`;
 
+// Canonical Uniswap Permit2 + UniversalRouter deployments on Robinhood Chain mainnet.
+// Independently verified on-chain before use here: both addresses have real deployed
+// bytecode; Permit2.DOMAIN_SEPARATOR() returns a real, non-zero value; Permit2.allowance()
+// responds with the expected (uint160 amount, uint48 expiration, uint48 nonce) shape.
+// Used by src/lib/permit2.ts's "allow external bots to sell this token" flow — a
+// deliberately separate, explicitly-labeled action, never bundled into buyToken/sellToken.
+export const PERMIT2_ADDRESS = String(
+  import.meta.env.VITE_PERMIT2_ADDRESS || '0x000000000022D473030F116dDEE9F6B43aC78BA3'
+).trim() as `0x${string}`;
+
+export const UNIVERSAL_ROUTER_ADDRESS = String(
+  import.meta.env.VITE_UNIVERSAL_ROUTER_ADDRESS || '0x8876789976dEcBfCbBbe364623C63652db8C0904'
+).trim() as `0x${string}`;
+
 export const WETH_ADDRESS = String(
   import.meta.env.VITE_WETH_ADDRESS || '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73'
 ).trim() as `0x${string}`;

--- a/src/pages/token-preview/page.tsx
+++ b/src/pages/token-preview/page.tsx
@@ -66,6 +66,11 @@ import {
   calculateGrossEthForTokens,
   TOTAL_TOKEN_SUPPLY,
 } from '../../lib/bondingCurve';
+import {
+  getExternalBotSellingStatus,
+  enableExternalBotSelling,
+  type ExternalBotSellingStatus,
+} from '../../lib/permit2';
 import IncentifiPriceChart, { type ChartPoint, type Trade, type TradeSide } from './IncentifiPriceChart';
 
 type TokenData = {
@@ -259,6 +264,13 @@ const TokenPreviewPage = () => {
   const [unlocking, setUnlocking] = useState(false);
   const [authError, setAuthError] = useState<string | null>(null);
 
+  // "Allow external bots to sell this token" — deliberately separate from the loss-reward
+  // state above and from the buy/sell flow entirely. See src/lib/permit2.ts's header
+  // comment for why this must always be its own explicit action.
+  const [botSellingStatus, setBotSellingStatus] = useState<ExternalBotSellingStatus | null>(null);
+  const [enablingBotSelling, setEnablingBotSelling] = useState(false);
+  const [botSellingMsg, setBotSellingMsg] = useState<string | null>(null);
+
   // Fetch live ETH/USD price from Coinbase
   useEffect(() => {
     let cancelled = false;
@@ -312,6 +324,49 @@ const TokenPreviewPage = () => {
       }
     } catch (err: any) {
       console.warn('Loss reward data load issue:', err);
+    }
+  };
+
+  const loadBotSellingStatus = async () => {
+    if (!tokenData?.mintAddress || !connectedWallet) {
+      setBotSellingStatus(null);
+      return;
+    }
+    try {
+      const status = await getExternalBotSellingStatus(tokenData.mintAddress, connectedWallet);
+      setBotSellingStatus(status);
+    } catch (err: any) {
+      console.warn('Could not load external-bot-selling status:', err);
+    }
+  };
+
+  useEffect(() => {
+    loadBotSellingStatus();
+  }, [tokenData?.mintAddress, connectedWallet]);
+
+  const handleEnableBotSelling = async () => {
+    if (!connectedWallet || !tokenData?.mintAddress) return;
+    try {
+      setEnablingBotSelling(true);
+      setBotSellingMsg(null);
+      const { steps } = await enableExternalBotSelling(tokenData.mintAddress, (step) => {
+        setBotSellingMsg(
+          step === 'erc20-approve'
+            ? 'Step 1 of 2 confirmed — approving Universal Router in Permit2...'
+            : 'Step 2 of 2 confirmed...'
+        );
+      });
+      await loadBotSellingStatus();
+      setBotSellingMsg(
+        steps.length > 0
+          ? 'Done — external bots and other Uniswap-compatible tools can now sell this token for you.'
+          : 'Already enabled — nothing to do.'
+      );
+    } catch (err: any) {
+      console.error('Enable external bot selling failed:', err);
+      setBotSellingMsg(describeError(err));
+    } finally {
+      setEnablingBotSelling(false);
     }
   };
 
@@ -1918,6 +1973,54 @@ const TokenPreviewPage = () => {
     </div>
   );
 
+  // Deliberately its own card, its own button, its own copy — never merged into the
+  // buy/sell panel above. See src/lib/permit2.ts's header comment for why.
+  const renderBotSellingCard = () => {
+    if (!connectedWallet) return null;
+    return (
+      <div className="bg-[#0B1120] border border-[#1D2940] rounded-2xl p-4 sm:p-5 shadow-xl shadow-black/20">
+        <h3 className="text-white font-bold text-sm mb-1">Allow External Bots to Sell This Token</h3>
+        <p className="text-[#8DA3CD] text-[11px] leading-relaxed mb-3">
+          This lets Uniswap's Universal Router move this token from your wallet, so third-party trading bots and
+          tools (e.g. Telegram trading bots) can sell it for you. Two on-chain transactions, paid by your own wallet.
+        </p>
+
+        {botSellingStatus?.fullyEnabled ? (
+          <div className="rounded-xl bg-emerald-500/10 border border-emerald-500/20 p-3 space-y-1">
+            <div className="flex items-center gap-2">
+              <ShieldCheck className="w-4 h-4 text-emerald-400 shrink-0" />
+              <span className="text-emerald-400 text-xs font-medium">Enabled — external bots can sell this token for you.</span>
+            </div>
+            {botSellingStatus.permit2ExpiresAt && (
+              <p className="text-emerald-400/70 text-[11px] pl-6">
+                Expires {botSellingStatus.permit2ExpiresAt.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })}
+                {' '}— come back and re-enable it after that.
+              </p>
+            )}
+          </div>
+        ) : (
+          <button
+            onClick={handleEnableBotSelling}
+            disabled={enablingBotSelling}
+            className="w-full py-2.5 rounded-xl bg-gradient-to-r from-[#2563EB] to-[#1D4ED8] hover:from-[#1D4ED8] hover:to-[#1E40AF] text-white font-bold text-xs disabled:opacity-40 disabled:cursor-not-allowed transition flex items-center justify-center gap-2 shadow-md shadow-blue-500/20"
+          >
+            {enablingBotSelling ? (
+              <span>Confirm in wallet...</span>
+            ) : botSellingStatus?.erc20ApprovedToPermit2 ? (
+              <span>Finish Enabling (1 transaction left)</span>
+            ) : (
+              <span>Enable External Bot Selling (2 transactions)</span>
+            )}
+          </button>
+        )}
+
+        {botSellingMsg && (
+          <p className="text-center text-[#8DA3CD] text-[11px] mt-2">{botSellingMsg}</p>
+        )}
+      </div>
+    );
+  };
+
   const renderContractDetailsCard = () => (
     <div className="bg-[#0B1120] border border-[#1D2940] rounded-2xl p-4 sm:p-5 shadow-xl shadow-black/20">
       <h3 className="text-white font-bold text-sm mb-3">Token Contract Details</h3>
@@ -2209,6 +2312,7 @@ const TokenPreviewPage = () => {
                 {renderTradingPanel()}
                 {renderPositionCard()}
                 {renderLossRewardCard()}
+                {renderBotSellingCard()}
               </div>
 
               {/* 2. TOKEN ABOUT / DESCRIPTION */}
@@ -2365,6 +2469,7 @@ const TokenPreviewPage = () => {
               {renderTradingPanel()}
               {renderPositionCard()}
               {renderLossRewardCard()}
+              {renderBotSellingCard()}
               {renderContractDetailsCard()}
             </aside>
           </div>


### PR DESCRIPTION
## Summary
- Extends `scripts/evm-indexer.mjs` to index V4-launched tokens into `token_market_snapshots_evm`, discovered via real `TokenLaunched` events on the V4 factory (independent of the best-effort `tokens` table), reusing the real `fetchV4CurveState()` via Vite SSR rather than reimplementing it. Verified against real production data for TESTTT.
- Adds an explicit, separate "Allow External Bots to Sell This Token" flow (`src/lib/permit2.ts` + a dedicated card in `token-preview/page.tsx`): two real, user-paid on-chain transactions (ERC20 approve to Permit2, then Permit2 approve to UniversalRouter with a real 1-year expiration) — never bundled into buy/sell. Addresses third-party trading bots being unable to sell tokens from this launchpad's template, which has no EIP-2612 permit().

## Verification performed
- Typecheck and production build both pass clean.
- V4 indexer: real row confirmed in production `token_market_snapshots_evm` for TESTTT, matching an independent `fetchV4CurveState()` call exactly on price/market cap/liquidity.
- Permit2 addresses (Permit2, UniversalRouter) independently verified on-chain (real bytecode, live `DOMAIN_SEPARATOR()`/`allowance()` calls) before use.
- Permit2 `approve()` calldata (uint160 amount / uint48 expiration) simulated against the real deployed contract via `eth_call` — no revert.
- Confirmed via real on-chain bytecode that this launchpad's token template has no EIP-2612 (`DOMAIN_SEPARATOR()`/`nonces()` both revert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)