### PR TITLE
V4 hook: claims-based sell so generic bots/routers can sell pre-graduation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,24 @@ coverage/
 artifacts/
 cache/
 typechain-types/
+
+# Local-only deployment result written by scripts/deploy-v3-fixed-factory-and-router.ts
+scripts/.v3-deployment-result.json
+# Local-only resumable run state written by scripts/verify-v3-fix-mainnet.ts
+scripts/.v3-verify-state.json
+# Local-only deployment result/state written by scripts/deploy-v4-hook-production-mainnet.ts
+scripts/.v4-hook-deployment-result.json
+scripts/.v4-hook-deployment-state.json
+# Local-only resumable run state written by scripts/verify-v4-hook-production-mainnet.ts
+scripts/.v4-verify-state.json
+# Local-only deployment result/state written by scripts/deploy-v4-hook-production-logic-test-mainnet.ts
+scripts/.v4-logic-test-deployment-result.json
+scripts/.v4-logic-test-deployment-state.json
+# Local-only resumable run state written by scripts/verify-v4-hook-production-logic-test-mainnet.ts
+scripts/.v4-logic-test-verify-state.json
+# Local-only deployment result/state written by scripts/deploy-v4-hook-no-postgrad-fee-mainnet.ts
+scripts/.v4-no-postgrad-fee-deployment-result.json
+scripts/.v4-no-postgrad-fee-deployment-state.json
+# Local-only deployment result/state written by scripts/deploy-v4-hook-generic-sell-mainnet.ts
+scripts/.v4-generic-sell-deployment-result.json
+scripts/.v4-generic-sell-deployment-state.json

--- a/contracts/v4/IncentifiV4Factory.sol
+++ b/contracts/v4/IncentifiV4Factory.sol
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+// Imported through @uniswap/v4-periphery's own nested v4-core copy — same reasoning
+// as IncentifiV4Hook.sol: type identity must match what IncentifiV4Hook itself uses.
+import {IPoolManager} from "@uniswap/v4-periphery/lib/v4-core/src/interfaces/IPoolManager.sol";
+import {IHooks} from "@uniswap/v4-periphery/lib/v4-core/src/interfaces/IHooks.sol";
+import {PoolKey} from "@uniswap/v4-periphery/lib/v4-core/src/types/PoolKey.sol";
+import {PoolId, PoolIdLibrary} from "@uniswap/v4-periphery/lib/v4-core/src/types/PoolId.sol";
+import {Currency} from "@uniswap/v4-periphery/lib/v4-core/src/types/Currency.sol";
+
+import {IncentifiV4Hook} from "./IncentifiV4Hook.sol";
+
+interface IERC20 {
+    function totalSupply() external view returns (uint256);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+}
+
+interface IIncentifiToken {
+    function creator() external view returns (address);
+}
+
+/**
+ * @title IncentifiV4Factory
+ * @notice Permissionless launch entrypoint for the V4 side: registers an already-
+ *         deployed token with the shared IncentifiV4Hook, pulls its full supply into
+ *         the hook, and initializes its V4 pool at the correct $5,000-market-cap
+ *         starting price — one transaction, no manual pool creation, no manual
+ *         liquidity seeding, no admin step.
+ *
+ * @dev STATUS: UNTESTED, same standard as IncentifiV4Hook.sol — compiles (verified),
+ *      has never executed against a real PoolManager.
+ *
+ * @dev HARD DEPENDENCY NOT YET BUILT: `hook` (the constructor param) must already be
+ *      deployed at an address whose low 14 bits satisfy the permission flags
+ *      IncentifiV4Hook.getHookPermissions() declares (beforeInitialize,
+ *      beforeAddLiquidity, beforeSwap, beforeSwapReturnDelta). That requires mining a
+ *      CREATE2 salt off-chain (via periphery's HookMiner — confirmed real and gas-
+ *      prohibitive to run on-chain, see the planning notes from before this file was
+ *      written) and deploying the hook through a CREATE2 factory with that salt, once,
+ *      before this factory is deployed at all. No such deployment script exists in
+ *      this repo yet. If `hook`'s address doesn't have the right bits,
+ *      `poolManager.initialize()` below reverts for every single launch — this isn't
+ *      a per-launch concern, but it is an unaddressed gap between "this compiles" and
+ *      "this can launch a single real token," and it's the very next thing the fork
+ *      test will hit.
+ */
+contract IncentifiV4Factory {
+    using PoolIdLibrary for PoolKey;
+
+    uint256 public constant TOTAL_SUPPLY = 1_000_000_000 * 1e18;
+
+    /**
+     * @dev OPEN DESIGN QUESTION — not resolved here: what should the PoolKey's fee
+     *      actually be?
+     *
+     *      Set to 0 for now. Reasoning: during the bonding-curve phase there is no
+     *      real liquidity and no external LPs (beforeAddLiquidity blocks everyone but
+     *      the hook itself), so there is no one for a native Uniswap LP fee to pay —
+     *      our own 2%/1%/1% split is handled entirely inside the hook, independent of
+     *      this field. beforeSwap always returns a 0 fee override (no dynamic-fee
+     *      flag requested), so this value is static for the pool's lifetime.
+     *
+     *      The question I'm NOT resolving: once _graduate() actually deposits real
+     *      liquidity (currently a stub), does that liquidity ever need a nonzero
+     *      native LP fee? Since beforeAddLiquidity restricts liquidity provision to
+     *      the hook itself FOREVER (not just pre-graduation), the hook may end up
+     *      being the sole liquidity provider even post-graduation — in which case
+     *      "graduation" might mean switching from virtual-reserve pricing to a real
+     *      concentrated-liquidity curve while STILL handling the protocol fee via
+     *      custom accounting, rather than literally reproducing v3's "hand off to a
+     *      normal Uniswap pool with a standard fee tier" model. That's a real fork in
+     *      the graduation design, not something to decide as a side effect of picking
+     *      a PoolKey constant now.
+     */
+    uint24 public constant POOL_FEE = 0;
+
+    /// @dev Only meaningful once _graduate() deposits real liquidity (still a stub).
+    ///      200 chosen for consistency with the v3 side's TICK_LOWER/TICK_UPPER
+    ///      (-887200/887200, both exact multiples of 200), not for any V4-specific
+    ///      reason — revisit when graduation is actually implemented.
+    int24 public constant TICK_SPACING = 200;
+
+    IPoolManager public immutable poolManager;
+    IncentifiV4Hook public immutable hook;
+
+    mapping(address => bool) public isLaunched;
+
+    event TokenLaunched(address indexed token, address indexed creator, PoolId poolId);
+
+    error ZeroAddress();
+    error AlreadyLaunched();
+    error NotTokenCreator();
+    error InvalidTotalSupply();
+    error TransferFailed();
+
+    constructor(IPoolManager _poolManager, IncentifiV4Hook _hook) {
+        if (address(_poolManager) == address(0) || address(_hook) == address(0)) revert ZeroAddress();
+        poolManager = _poolManager;
+        hook = _hook;
+    }
+
+    /**
+     * @notice Deterministically reconstructs the PoolKey for `token`'s pool. Public so
+     *         a fork test, frontend, or router can compute it independently without
+     *         duplicating the fee/tickSpacing/hook constants.
+     * @dev currency0 is always native ETH (address(0)) and currency1 is always
+     *      `token` — always correctly ordered without a sort branch, since address(0)
+     *      is numerically the smallest possible address. Same reasoning already
+     *      documented in IncentifiV4Hook.sol for why native ETH was chosen over WETH.
+     */
+    function getPoolKey(address token) public view returns (PoolKey memory) {
+        return PoolKey({
+            currency0: Currency.wrap(address(0)),
+            currency1: Currency.wrap(token),
+            fee: POOL_FEE,
+            tickSpacing: TICK_SPACING,
+            hooks: IHooks(address(hook))
+        });
+    }
+
+    /**
+     * @notice Registers `token` with the shared hook and initializes its V4 pool.
+     * @dev Deliberately does NOT deploy the token itself — mirrors
+     *      IncentifiBondingCurveFactory.registerExistingToken()'s pattern of
+     *      registering an already-deployed token, for two concrete reasons:
+     *      (1) IncentifiLaunchToken.sol's constructor sets `creator = msg.sender`,
+     *          so if THIS factory deployed the token via `new IncentifiLaunchToken(...)`,
+     *          `creator` would incorrectly become the factory's own address, not the
+     *          real human creator's wallet — a real bug, not a style preference.
+     *      (2) Keeps IncentifiLaunchToken.sol completely untouched, consistent with
+     *          not modifying existing v3 production contracts.
+     *      The creator must deploy IncentifiLaunchToken directly (same as the current
+     *      v3 frontend flow already does) and approve() this factory for the full
+     *      supply before calling this function — the same two-transaction shape v3
+     *      already has, not a new burden, but also not yet a single click.
+     *
+     * @dev OPEN QUESTION, not resolved here: this factory does not check whether
+     *      `token` was already registered with the V3 IncentifiBondingCurveFactory
+     *      (or vice versa) — a token could in principle end up with both a v3 curve
+     *      and a v4 pool simultaneously. Whether that should be blocked, allowed, or
+     *      whether the two systems need a shared registry is a cross-system question
+     *      I'm flagging rather than guessing at.
+     */
+    function launchToken(address token) external returns (PoolId poolId) {
+        if (token == address(0)) revert ZeroAddress();
+        if (isLaunched[token]) revert AlreadyLaunched();
+
+        address creator = msg.sender;
+        try IIncentifiToken(token).creator() returns (address tokenCreator) {
+            if (tokenCreator != creator) revert NotTokenCreator();
+        } catch {
+            revert NotTokenCreator();
+        }
+
+        uint256 supply = IERC20(token).totalSupply();
+        if (supply != TOTAL_SUPPLY) revert InvalidTotalSupply();
+
+        isLaunched[token] = true;
+
+        // Pull the full supply from the creator into the hook BEFORE registering —
+        // IncentifiV4Hook._beforeInitialize checks its own balance against
+        // TOTAL_SUPPLY and reverts if this hasn't already happened.
+        if (!IERC20(token).transferFrom(creator, address(hook), supply)) revert TransferFailed();
+
+        hook.registerToken(token, creator);
+
+        PoolKey memory key = getPoolKey(token);
+        poolManager.initialize(key, hook.launchSqrtPriceX96());
+
+        poolId = key.toId();
+        emit TokenLaunched(token, creator, poolId);
+    }
+}

--- a/contracts/v4/IncentifiV4Hook.sol
+++ b/contracts/v4/IncentifiV4Hook.sol
@@ -1,0 +1,933 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+// NOTE: imported via @uniswap/v4-periphery's OWN nested v4-core copy
+// (node_modules/@uniswap/v4-periphery/lib/v4-core/), not the top-level
+// @uniswap/v4-core package, even though both are byte-for-byte identical
+// (confirmed via diff) and the same version (1.0.2). Uniswap/v4-periphery's
+// BaseHook.sol resolves ITS @uniswap/v4-core/... imports through its own
+// bundled lib/v4-core/ via that package's remappings.txt, so importing the
+// top-level copy here produced two structurally-identical but type-DISTINCT
+// copies of IPoolManager/Currency/Hooks.Permissions/etc. — real compiler
+// errors ("Invalid implicit conversion from contract IPoolManager to contract
+// IPoolManager", "Overriding function return types differ") the first time
+// this was compiled. Importing through the same nested path BaseHook.sol uses
+// makes every type identity match.
+import {BaseHook} from "@uniswap/v4-periphery/src/utils/BaseHook.sol";
+import {Hooks} from "@uniswap/v4-periphery/lib/v4-core/src/libraries/Hooks.sol";
+import {IPoolManager} from "@uniswap/v4-periphery/lib/v4-core/src/interfaces/IPoolManager.sol";
+import {PoolKey} from "@uniswap/v4-periphery/lib/v4-core/src/types/PoolKey.sol";
+import {PoolId, PoolIdLibrary} from "@uniswap/v4-periphery/lib/v4-core/src/types/PoolId.sol";
+import {Currency} from "@uniswap/v4-periphery/lib/v4-core/src/types/Currency.sol";
+import {BalanceDelta} from "@uniswap/v4-periphery/lib/v4-core/src/types/BalanceDelta.sol";
+import {BeforeSwapDelta, BeforeSwapDeltaLibrary, toBeforeSwapDelta} from "@uniswap/v4-periphery/lib/v4-core/src/types/BeforeSwapDelta.sol";
+import {SwapParams, ModifyLiquidityParams} from "@uniswap/v4-periphery/lib/v4-core/src/types/PoolOperation.sol";
+import {TickMath} from "@uniswap/v4-periphery/lib/v4-core/src/libraries/TickMath.sol";
+// LiquidityAmounts is imported from periphery's TOP-LEVEL path (not the nested
+// lib/v4-core one everything else here uses) deliberately: it only operates on
+// primitive uint160/uint256 values, never on a PoolKey/Currency/IPoolManager
+// struct or contract instance, so the type-identity problem documented above
+// (why every other import here goes through the nested path) does not apply to
+// it — there is no struct/contract type for the two copies to disagree about.
+import {LiquidityAmounts} from "@uniswap/v4-periphery/src/libraries/LiquidityAmounts.sol";
+
+interface IERC20 {
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address recipient, uint256 amount) external returns (bool);
+}
+
+interface ILossRewardPool {
+    function depositReward(address token) external payable;
+}
+
+/**
+ * @title IncentifiV4Hook
+ * @notice A SHARED Uniswap V4 hook: one deployed instance serves every Incentifi
+ *         token's pool, holding per-pool state in `curveStates` keyed by PoolId.
+ *         This is a deliberate architecture choice, not the v3 pattern of one
+ *         contract per token — see the reasoning below `getHookPermissions()`.
+ *
+ *         Reproduces contracts/IncentifiBondingCurve.sol's economics (virtual-reserve
+ *         x*y=k pricing, exact constants, 2%/1%/1% fee split, pull-payment creator fees)
+ *         as of commit 8344791, but as V4 custom accounting inside beforeSwap, instead
+ *         of a standalone external buy()/sell() contract.
+ *
+ * @dev STATUS: UNTESTED. This compiles (verified) and the delta math below is derived
+ *      directly from reading the actual installed v4-core PoolManager.sol/Hooks.sol source
+ *      (not from memory of the API), but nothing here has executed against a real
+ *      PoolManager yet. Do not treat this as working until the fork test proves it.
+ *
+ * @dev PAIRING CURRENCY: native ETH (Currency.wrap(address(0))), not WETH. Two reasons:
+ *      (1) V4 supports native ETH as a first-class currency, avoiding a wrap/unwrap
+ *          round-trip on every trade that the v3 architecture needed.
+ *      (2) address(0) is numerically the smallest possible address, so currency0 is
+ *          *always* ETH and currency1 is *always* the Incentifi token, for every pool,
+ *          unconditionally. This structurally eliminates the "token address < WETH
+ *          address" ordering bug class that required a dedicated fix
+ *          (_computeSqrtPriceX96 in IncentifiBondingCurve.sol) on the v3 side. There is
+ *          no equivalent bug surface here because there is no ordering ambiguity to get
+ *          wrong in the first place.
+ *      If WETH parity with the v3 pools is wanted instead, this assumption needs
+ *      revisiting throughout — flagging now rather than silently deciding it forever.
+ */
+contract IncentifiV4Hook is BaseHook {
+    using PoolIdLibrary for PoolKey;
+
+    // ------------------------------------------------------------------------
+    // Economic constants — ported exactly from IncentifiBondingCurve.sol @ 8344791.
+    // Unchanged: preserves the same $5,000 starting market cap and $69,000
+    // graduation target as the v3 curve.
+    // ------------------------------------------------------------------------
+    uint256 public constant TOTAL_SUPPLY = 1_000_000_000 * 1e18;
+    uint256 public constant VIRTUAL_ETH = 2_156_250_000_000_000_000; // 2.15625 ETH
+    uint256 public constant VIRTUAL_TOKEN = 78_125_000_000_000_000_000_000_000; // 78,125,000 tokens
+    uint256 public constant INVARIANT_K = 2_324_707_031_250_000_000_000_000_000_000_000_000_000_000_000; // 2.32470703125e45
+    uint256 public constant GRADUATION_ETH_TARGET = 5_853_863_234_375_000_000; // 5.853863234375 ETH
+
+    uint256 public constant PROTOCOL_FEE_BPS = 200; // 2.00% total
+    uint256 public constant CREATOR_FEE_BPS = 100; // 1.00%
+    uint256 public constant LOSS_REWARD_FEE_BPS = 100; // 1.00%
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+
+    /// @dev Deliberately oversized exact-input magnitude for _graduate()'s
+    /// corrective swap, so the swap is always bounded by its sqrtPriceLimitX96
+    /// (the actual target price) rather than by this nominal amount — the
+    /// standard "swap up to a price limit" pattern. Never actually paid in full;
+    /// the real, much smaller amount that PoolManager actually consumes is read
+    /// back from the swap's returned delta and settled exactly.
+    int256 private constant _GRADUATION_SWAP_SENTINEL = type(int128).max;
+
+    // ------------------------------------------------------------------------
+    // Immutables
+    // ------------------------------------------------------------------------
+
+    /// @notice The only address permitted to call registerToken() — validation of
+    /// creator identity / total-supply / etc. lives in the factory, mirroring how
+    /// IncentifiBondingCurveFactory.sol validates before deploying a v3 curve.
+    /// @dev NOT immutable, and deliberately not a constructor param — a genuine
+    /// circular dependency, not a test convenience: this hook's own deployment
+    /// address must be mined via CREATE2 to satisfy the permission-bit requirement
+    /// BEFORE IncentifiV4Factory (which takes this hook's address as its own
+    /// constructor arg) can be deployed. If `factory` were a constructor param here,
+    /// neither contract could be deployed first. Resolved with the standard pattern
+    /// for this exact problem: deploy the hook, deploy the factory (now that the
+    /// hook exists to reference), then wire them together with one one-time call —
+    /// not a per-launch admin step, a one-time system bootstrap step.
+    address public factory;
+    address public immutable lossRewardPool;
+    /// @dev The only address allowed to call setFactory() once. Not an ongoing admin
+    /// role: setFactory() is one-time-only (reverts if `factory` is already set), so
+    /// this has no power after bootstrap.
+    /// @dev Passed explicitly as a constructor arg rather than recorded from
+    /// `msg.sender` — this hook is deployed via CREATE2 through the standard
+    /// singleton deployer factory (0x4e59b44847b379578588920cA78FbF26c0B4956C,
+    /// confirmed deployed on Robinhood Chain), which means `msg.sender` during this
+    /// constructor's execution would be that FACTORY PROXY, not the actual deployer's
+    /// EOA. Recording `msg.sender` here would make setFactory() permanently
+    /// uncallable by anyone with a private key. Caught by reasoning through the
+    /// deployment path before attempting it, not from a failed deployment.
+    address public immutable deployer;
+
+    // ------------------------------------------------------------------------
+    // Per-pool state (shared-hook model)
+    // ------------------------------------------------------------------------
+    struct TokenCurveState {
+        address token;
+        address creator;
+        bool initialized;
+        bool graduated;
+        uint256 realEthReserve;
+        uint256 realTokenReserve;
+    }
+
+    mapping(PoolId => TokenCurveState) public curveStates;
+
+    /// @notice Pull-payment creator balances, GLOBAL across every token this hook
+    /// serves (keyed by creator address, not by pool) — a single creator who
+    /// launches multiple tokens accrues into one claimable balance, and claims once
+    /// via claimCreatorFees() regardless of which of their tokens earned the fee.
+    mapping(address => uint256) public creatorBalances;
+
+    /// @notice token => creator, set by the factory via registerToken() before it
+    /// calls PoolManager.initialize(). Consumed and cleared by _beforeInitialize().
+    mapping(address => address) public pendingCreator;
+
+    /// @notice Leftover ETH/token from _graduate()'s reserve-ratio-vs-marginal-
+    /// price mismatch (see _graduate()'s doc comment), keyed by PoolId so it is
+    /// never confused with any other pool's dust or claim. Written once, at
+    /// graduation, alongside the GraduationLiquidityDeployed event — the event is
+    /// history; these mappings are the live, queryable record.
+    ///
+    /// @dev Deliberately kept SEPARATE from creatorBalances, even though both are
+    /// "real ETH sitting in this contract, not yet spent anywhere": creatorBalances
+    /// is a claimable entitlement (someone can withdraw it via claimCreatorFees()),
+    /// while ethDustBalances/tokenDustBalances are only a bookkeeping record of
+    /// value that has NO withdrawal path today (see the token-dust question this
+    /// was raised over) — merging them into one ledger would make an unclaimed
+    /// creator fee and an unspendable dust remainder indistinguishable from a
+    /// single mapping read, which is exactly the "hard to account for" risk this
+    /// pair of mappings exists to close off. tokenDustBalances is close to
+    /// redundant with IERC20(token).balanceOf(address(this)) post-graduation
+    /// (nothing else touches that balance once graduated — see the _beforeSwap
+    /// pass-through), but is recorded anyway for parity with ethDustBalances,
+    /// which has no such convenient equivalent (native ETH is one pooled balance
+    /// shared across every token this hook serves, unlike each token's own
+    /// self-isolating ERC20 balance).
+    mapping(PoolId => uint256) public ethDustBalances;
+    mapping(PoolId => uint256) public tokenDustBalances;
+
+    // ------------------------------------------------------------------------
+    // Events
+    // ------------------------------------------------------------------------
+    event TokenRegistered(address indexed token, address indexed creator);
+    event CurveInitialized(address indexed token, address indexed creator, PoolId poolId);
+    event Bought(PoolId indexed poolId, address indexed trader, uint256 ethIn, uint256 tokensOut, uint256 creatorFee, uint256 lossPoolFee);
+    event Sold(PoolId indexed poolId, address indexed trader, uint256 tokensIn, uint256 ethOut, uint256 creatorFee, uint256 lossPoolFee);
+    event CreatorFeesClaimed(address indexed creator, uint256 amount);
+    event Graduated(PoolId indexed poolId, address indexed token, uint256 finalEthReserve, uint256 finalTokenReserve);
+    /// @param ethDust,tokenDust Real, honestly-reported leftover from the reserve-
+    /// ratio-vs-marginal-price mismatch inherent to migrating a virtual-offset
+    /// bonding curve into a real concentrated-liquidity position — see the long
+    /// comment on _graduate() for why this isn't (and can't cheaply be) zero.
+    event GraduationLiquidityDeployed(
+        PoolId indexed poolId,
+        uint128 bootstrapLiquidity,
+        uint128 finalLiquidity,
+        uint160 correctedSqrtPriceX96,
+        uint256 ethDust,
+        uint256 tokenDust
+    );
+    /// @notice Emitted once per post-graduation swap, buy or sell, whenever the
+    /// 2% fee is actually collected — the graduated-pool equivalent of Bought/Sold,
+    /// deliberately a separate event rather than overloading those two: this fee
+    /// is computed from real AMM-priced amounts, not virtual-curve math, and
+    /// intentionally does not carry a token amount (buys only know the ETH side
+    /// at fee-collection time; see _beforeSwap's graduated branch).
+    event GraduatedFeeCollected(PoolId indexed poolId, bool zeroForOne, uint256 creatorFee, uint256 lossPoolFee);
+
+    // ------------------------------------------------------------------------
+    // Errors
+    // ------------------------------------------------------------------------
+    error OnlyFactory();
+    error ZeroAddress();
+    error ZeroAmount();
+    error AlreadyPending();
+    error TokenNotRegistered();
+    error AlreadyInitialized();
+    error InsufficientSupply();
+    error MustPairWithNativeEth();
+    error WrongStartingPrice();
+    error PoolNotInitialized();
+    error OnlyExactInputSupported();
+    error InsufficientReserve();
+    error SlippageExceeded();
+    error NoBalanceToClaim();
+    error CannotAddLiquidity();
+    error EthTransferFailed();
+    error TokenTransferFailed();
+    error OnlyDeployer();
+    error FactoryAlreadySet();
+    // Graduation-liquidity-specific — see _graduate()'s doc comment. Both would
+    // indicate a real accounting bug in the corrective-swap/mint math, not a
+    // condition expected to ever actually trigger.
+    error GraduationSwapDirectionInvalid();
+    error GraduationMintUnexpectedCredit();
+    /// @dev A real sell against a graduated pool must always leave the core pool
+    /// owing the trader ETH (delta.amount0() > 0) — this would only fire if the
+    /// real AMM math itself is somehow inverted, not a condition expected to
+    /// ever actually trigger.
+    error GraduatedFeeUnexpectedDirection();
+
+    constructor(IPoolManager _poolManager, address _lossRewardPool, address _deployer) BaseHook(_poolManager) {
+        if (_lossRewardPool == address(0) || _deployer == address(0)) revert ZeroAddress();
+        lossRewardPool = _lossRewardPool;
+        deployer = _deployer;
+    }
+
+    /// @notice One-time wiring of the factory address, called once immediately after
+    /// both this hook and IncentifiV4Factory are deployed. Not callable again once
+    /// set, and not callable by anyone other than whoever deployed this specific
+    /// hook instance — see the `factory` field's doc comment for why this exists.
+    function setFactory(address _factory) external {
+        if (msg.sender != deployer) revert OnlyDeployer();
+        if (factory != address(0)) revert FactoryAlreadySet();
+        if (_factory == address(0)) revert ZeroAddress();
+        factory = _factory;
+    }
+
+    // ------------------------------------------------------------------------
+    // Hook permissions
+    // ------------------------------------------------------------------------
+    /**
+     * @dev SIX flags as of the post-graduation fee change below — originally four
+     *      (see git history for the earlier reasoning: "afterSwap unneeded, every
+     *      swap is fully absorbed pre-graduation"). That reasoning still holds
+     *      for the PRE-graduation path; it stopped holding once graduated pools
+     *      needed to keep charging a fee while letting the REAL AMM price the
+     *      trade, because a sell's ETH output isn't known until the core pool has
+     *      actually run — see _afterSwap's own doc comment for why that specific
+     *      case is what forced this hook to finally need afterSwap for real.
+     *      - BEFORE_INITIALIZE: validate + finalize a pending token registration at
+     *        the correct starting price before the pool exists.
+     *      - BEFORE_ADD_LIQUIDITY: revert unless caller == address(this) (pre-
+     *        graduation only) — blocks every external LP, protecting the internal
+     *        reserve accounting exactly the way Doppler's own beforeAddLiquidity
+     *        does (pattern studied, not copied — Doppler is BUSL-1.1, this is an
+     *        independent ~3-line reimplementation of an obvious idea).
+     *      - BEFORE_SWAP + BEFORE_SWAP_RETURNS_DELTA: pre-graduation, the full
+     *        custom-accounting override (pricing, fee split, settlement, reserve
+     *        updates, graduation trigger). Post-graduation, BEFORE_SWAP now ALSO
+     *        does the buy-side fee skim (see _beforeSwap's graduated branch).
+     *      - AFTER_SWAP + AFTER_SWAP_RETURNS_DELTA: NEW. Needed exclusively for
+     *        the post-graduation SELL-side fee — the only case in this whole
+     *        contract where a fee has to be computed from a real, core-pool-priced
+     *        output rather than from an input amount or virtual-curve math known
+     *        in advance.
+     */
+    function getHookPermissions() public pure override returns (Hooks.Permissions memory) {
+        return Hooks.Permissions({
+            beforeInitialize: true,
+            afterInitialize: false,
+            beforeAddLiquidity: true,
+            afterAddLiquidity: false,
+            beforeRemoveLiquidity: false,
+            afterRemoveLiquidity: false,
+            beforeSwap: true,
+            afterSwap: true,
+            beforeDonate: false,
+            afterDonate: false,
+            beforeSwapReturnDelta: true,
+            afterSwapReturnDelta: true,
+            afterAddLiquidityReturnDelta: false,
+            afterRemoveLiquidityReturnDelta: false
+        });
+    }
+
+    // ------------------------------------------------------------------------
+    // Permissionless launch registration (called by IncentifiV4Factory)
+    // ------------------------------------------------------------------------
+    /**
+     * @notice Records `creator` as the pending creator for `token`, ahead of the
+     *         factory calling PoolManager.initialize() for that token's pool.
+     * @dev Gated to `factory` only — this contract trusts the factory to have
+     *      already validated token.creator() / total supply / etc., mirroring
+     *      IncentifiBondingCurveFactory.registerExistingToken()'s validation.
+     *      The factory must transfer the token's full TOTAL_SUPPLY to this hook
+     *      BEFORE calling PoolManager.initialize() — _beforeInitialize checks for
+     *      that balance and reverts if it isn't there yet.
+     */
+    function registerToken(address token, address creator) external {
+        if (msg.sender != factory) revert OnlyFactory();
+        if (token == address(0) || creator == address(0)) revert ZeroAddress();
+        if (pendingCreator[token] != address(0)) revert AlreadyPending();
+
+        pendingCreator[token] = creator;
+        emit TokenRegistered(token, creator);
+    }
+
+    function _beforeInitialize(address, PoolKey calldata key, uint160 sqrtPriceX96)
+        internal
+        override
+        returns (bytes4)
+    {
+        if (!key.currency0.isAddressZero()) revert MustPairWithNativeEth();
+
+        address token = Currency.unwrap(key.currency1);
+        address creator = pendingCreator[token];
+        if (creator == address(0)) revert TokenNotRegistered();
+
+        PoolId poolId = key.toId();
+        TokenCurveState storage state = curveStates[poolId];
+        if (state.initialized) revert AlreadyInitialized();
+
+        uint256 balance = IERC20(token).balanceOf(address(this));
+        if (balance < TOTAL_SUPPLY) revert InsufficientSupply();
+
+        // Defend against anyone initializing at a wrong price: PoolManager.initialize()
+        // is permissionless at the PoolManager level, so without this check a
+        // front-runner could initialize this exact PoolKey at an arbitrary price before
+        // the factory's own initialize() call lands. Only the one correct $5,000
+        // starting price (VIRTUAL_TOKEN / VIRTUAL_ETH ratio) is accepted.
+        if (sqrtPriceX96 != launchSqrtPriceX96()) revert WrongStartingPrice();
+
+        state.token = token;
+        state.creator = creator;
+        state.initialized = true;
+        state.realEthReserve = 0;
+        state.realTokenReserve = TOTAL_SUPPLY;
+
+        delete pendingCreator[token];
+
+        emit CurveInitialized(token, creator, poolId);
+        return BaseHook.beforeInitialize.selector;
+    }
+
+    /// @dev Pre-graduation, liquidity may ONLY come from this hook itself (the
+    ///      _graduate() mint below) — an external LP adding liquidity while the
+    ///      curve is still active would corrupt the full-absorption invariant this
+    ///      hook depends on (a real, non-zero-liquidity core pool would start
+    ///      partially filling swaps itself, which _beforeSwap's OnlyExactInputSupported
+    ///      / full-absorption math does not account for). Once graduated, this
+    ///      pool is a genuine, permanently-real AMM pool with no more curve
+    ///      invariant to protect — so, unlike the permanently-hook-only v3 LP
+    ///      position (minted once, then burned/locked forever), this DOES open up
+    ///      to any external LP after graduation, same as a completely standard,
+    ///      permissionless V4 pool. Flagging this as a deliberate departure from
+    ///      v3's parity, not an oversight.
+    function _beforeAddLiquidity(address caller, PoolKey calldata key, ModifyLiquidityParams calldata, bytes calldata)
+        internal
+        view
+        override
+        returns (bytes4)
+    {
+        if (caller != address(this) && !curveStates[key.toId()].graduated) revert CannotAddLiquidity();
+        return BaseHook.beforeAddLiquidity.selector;
+    }
+
+    // ------------------------------------------------------------------------
+    // Core custom-accounting swap logic
+    // ------------------------------------------------------------------------
+    /**
+     * @dev Delta-application semantics below are transcribed from the ACTUAL
+     *      Hooks.sol I read (v4-core 1.0.2), not assumed:
+     *
+     *        amountToSwap = params.amountSpecified;
+     *        amountToSwap += hookReturn.getSpecifiedDelta();
+     *        revert if (exactInput && amountToSwap > 0)   // exactInput = original amountSpecified < 0
+     *
+     *      We only support exact-input swaps (amountSpecified < 0) — this hook has
+     *      no real liquidity backing it, so any amount left for the "core" pool to
+     *      process after our delta would hit a liquidity-less pool and revert
+     *      anyway; full absorption is the only valid mode, and OnlyExactInputSupported
+     *      documents that as a deliberate constraint, not an oversight.
+     *
+     *      Setting hookDeltaSpecified = -params.amountSpecified makes amountToSwap
+     *      land at exactly 0 — the core pool does nothing, all economics are ours.
+     *
+     *      Router's own final delta (from Hooks.afterSwap: swapDelta = coreDelta -
+     *      hookDelta, and coreDelta is (0,0) here since amountToSwap is 0) works out
+     *      to -hookDelta. Confirmed sign convention from Hooks.sol/CurrencySettler.sol
+     *      (test-path reference, read but not imported): positive hook delta = hook
+     *      take()s that amount FROM the PoolManager; negative = hook settle()s
+     *      (pays) that amount INTO the PoolManager.
+     *
+     *      BUY (zeroForOne, ETH -> TOKEN): specified = currency0 (ETH). We take() the
+     *      buyer's incoming ETH (hookDeltaSpecified > 0), and settle() the token
+     *      output (hookDeltaUnspecified < 0) so the router can take() it out for the
+     *      buyer. SELL is the mirror image with the specified/unspecified currencies
+     *      swapped and native-ETH settle() replacing ERC20 settle().
+     *
+     * @dev KNOWN GAP vs. IncentifiBondingCurve.buy(): the v3 contract clamps grossEth
+     *      to the graduation boundary and refunds any excess directly from within
+     *      buy() itself, because it holds msg.value directly. That refund mechanism
+     *      does not translate here: a hook that only partially absorbs
+     *      amountSpecified leaves the remainder for the core (liquidity-less) pool to
+     *      process, which would revert. This version does NOT clamp/refund — an
+     *      overshooting buy is accepted in full, and any excess beyond the exact
+     *      graduation target is carried into the reserve that gets migrated at
+     *      graduation rather than refunded to the buyer. If exact-target clamping
+     *      with a refund is required, it has to happen one layer up, in whichever
+     *      router originates the swap (compute the clamped amount via a view call
+     *      before ever submitting the swap, refund any excess before calling
+     *      PoolManager.unlock()) — flagging this now since it's a real, unresolved
+     *      difference from the v3 UX, and it's a concrete data point for the still-
+     *      open router-vs-Universal-Router decision: Universal Router has no way to
+     *      run our pre-swap clamping logic, which argues toward a custom router.
+     */
+    function _beforeSwap(address, PoolKey calldata key, SwapParams calldata params, bytes calldata)
+        internal
+        override
+        returns (bytes4, BeforeSwapDelta, uint24)
+    {
+        PoolId poolId = key.toId();
+        TokenCurveState storage state = curveStates[poolId];
+        if (!state.initialized) revert PoolNotInitialized();
+
+        // Both the pre- and post-graduation paths require exact input, for two
+        // different reasons: pre-graduation, there's no real liquidity for the
+        // core pool to partially fill against (full absorption is the only valid
+        // mode). Post-graduation, an exact-output swap would mean the fee itself
+        // (computed as a percentage of an input or a real AMM output) is not
+        // well-defined before the core pool runs — exact input keeps the fee
+        // math identical in shape to the pre-graduation curve's own convention.
+        if (params.amountSpecified >= 0) revert OnlyExactInputSupported();
+        uint256 amountIn = uint256(-params.amountSpecified);
+        if (amountIn == 0) revert ZeroAmount();
+
+        // POST-GRADUATION: real AMM execution, hook now skims a 2% fee instead of
+        // fully absorbing the trade. Two genuinely different mechanisms depending
+        // on direction — see the doc comment on _afterSwap for why the sell side
+        // can't be handled here.
+        if (state.graduated) {
+            if (params.zeroForOne) {
+                // BUY: fee is a cut of the ETH being paid IN — known right now,
+                // before the core pool even runs, so it can come straight off
+                // amountToSwap via the specified-delta mechanism (Hooks.sol:
+                // amountToSwap += hookDeltaSpecified). The core pool then only
+                // ever sees amountIn - fee, and prices real AMM output on that
+                // net amount — mirrors _executeBuy's grossEth-based fee exactly,
+                // just paid out of a smaller pool of ETH than the trader's full
+                // amountIn (the fee never reaches the AMM at all).
+                uint256 creatorFee = amountIn / 100;
+                uint256 lossPoolFee = amountIn / 100;
+                uint256 totalFee = creatorFee + lossPoolFee;
+                _collectGraduatedFee(state, poolId, true, creatorFee, lossPoolFee);
+                return (BaseHook.beforeSwap.selector, toBeforeSwapDelta(_toInt128(totalFee), 0), 0);
+            } else {
+                // SELL: the fee has to be a cut of the ETH coming OUT, which the
+                // real AMM hasn't computed yet at this point in execution — no
+                // adjustment here at all (full amountIn reaches the core pool
+                // unmodified); _afterSwap collects the fee once the real output
+                // is known.
+                return (BaseHook.beforeSwap.selector, BeforeSwapDeltaLibrary.ZERO_DELTA, 0);
+            }
+        }
+
+        int128 hookDeltaSpecified = int128(-params.amountSpecified);
+        int128 hookDeltaUnspecified;
+
+        if (params.zeroForOne) {
+            // BUY: ETH in (specified, currency0), TOKEN out (unspecified, currency1)
+            uint256 tokensOut = _executeBuy(state, poolId, key, amountIn);
+            hookDeltaUnspecified = -_toInt128(tokensOut);
+        } else {
+            // SELL: TOKEN in (specified, currency1), ETH out (unspecified, currency0)
+            uint256 netEthOut = _executeSell(state, poolId, amountIn);
+            hookDeltaUnspecified = -_toInt128(netEthOut);
+        }
+
+        BeforeSwapDelta delta = toBeforeSwapDelta(hookDeltaSpecified, hookDeltaUnspecified);
+        return (BaseHook.beforeSwap.selector, delta, 0);
+    }
+
+    /**
+     * @dev The ONLY reason this hook implements a real afterSwap at all. A
+     *      post-graduation SELL's ETH output is priced by the real core pool's
+     *      own concentrated-liquidity math, which does not run until AFTER
+     *      beforeSwap has already returned — so "2% of the real output" cannot
+     *      be computed inside beforeSwap the way the buy-side fee can. afterSwap
+     *      receives `delta`, the core pool's own genuine computed swap result
+     *      (confirmed from the actual installed Hooks.sol: this is the RAW
+     *      per-swap delta passed into afterSwap, before this hook's own
+     *      beforeSwap adjustment is subtracted out — i.e. real, unmodified AMM
+     *      output, not something this hook already touched).
+     *
+     *      Sign/assignment confirmed the same way every other delta in this file
+     *      was: for a sell (zeroForOne = false, exact input), Hooks.afterSwap's
+     *      hookDelta assembly uses (unspecified, specified) order for the
+     *      (amount0, amount1) pair, so returning a positive hookDeltaUnspecified
+     *      here becomes hookDelta.amount0 = +fee, and swapDelta.amount0 =
+     *      coreDelta.amount0 - fee — i.e. the trader's final receivable amount is
+     *      reduced by exactly `fee`, and this hook's own currency0 ledger is
+     *      credited by exactly `fee`, ready to take().
+     *
+     *      BUY needs no afterSwap handling at all — the fee was already fully
+     *      resolved in beforeSwap — so this returns 0 unconditionally whenever
+     *      zeroForOne is true, or the pool hasn't graduated.
+     */
+    function _afterSwap(address, PoolKey calldata key, SwapParams calldata params, BalanceDelta delta, bytes calldata)
+        internal
+        override
+        returns (bytes4, int128)
+    {
+        PoolId poolId = key.toId();
+        TokenCurveState storage state = curveStates[poolId];
+        if (!state.graduated || params.zeroForOne) {
+            return (BaseHook.afterSwap.selector, 0);
+        }
+
+        int128 grossEthOutSigned = delta.amount0();
+        if (grossEthOutSigned <= 0) revert GraduatedFeeUnexpectedDirection();
+        uint256 grossEthOut = uint256(uint128(grossEthOutSigned));
+
+        uint256 creatorFee = grossEthOut / 100;
+        uint256 lossPoolFee = grossEthOut / 100;
+        _collectGraduatedFee(state, poolId, false, creatorFee, lossPoolFee);
+
+        return (BaseHook.afterSwap.selector, _toInt128(creatorFee + lossPoolFee));
+    }
+
+    /// @dev Shared by both post-graduation fee paths. The specified/unspecified
+    /// delta mechanism only ever CREDITS this hook's own currency ledger for the
+    /// fee amount — it does not move real ETH. This take()s that real ETH out of
+    /// PoolManager (always native currency0, matching the pre-graduation
+    /// convention that fees are always ETH-denominated regardless of buy/sell
+    /// direction) and immediately splits it exactly like _executeBuy/_executeSell
+    /// already do: half to the creator's pull-payment balance, half deposited
+    /// into LossRewardPool for real.
+    function _collectGraduatedFee(TokenCurveState storage state, PoolId poolId, bool zeroForOne, uint256 creatorFee, uint256 lossPoolFee)
+        internal
+    {
+        uint256 totalFee = creatorFee + lossPoolFee;
+        if (totalFee == 0) return;
+        _takeNative(totalFee);
+        if (creatorFee > 0) creatorBalances[state.creator] += creatorFee;
+        if (lossPoolFee > 0) ILossRewardPool(lossRewardPool).depositReward{value: lossPoolFee}(state.token);
+        emit GraduatedFeeCollected(poolId, zeroForOne, creatorFee, lossPoolFee);
+    }
+
+    /// @dev Mirrors IncentifiBondingCurve.buy() exactly (minus the clamp/refund — see
+    ///      the KNOWN GAP note above), executed as V4 settlement instead of a direct
+    ///      payable call. Fee-on-transfer safety for the token leg comes from V4's
+    ///      own sync()/settle() semantics (balance measured before/after, not a
+    ///      trusted nominal amount) — the same principle as the v3 fix, provided by
+    ///      the platform this time instead of hand-rolled.
+    function _executeBuy(TokenCurveState storage state, PoolId poolId, PoolKey calldata key, uint256 grossEth) internal returns (uint256 tokensOut) {
+        uint256 creatorFee = grossEth / 100;
+        uint256 lossPoolFee = grossEth / 100;
+        uint256 netEth = grossEth - creatorFee - lossPoolFee;
+
+        uint256 newEth = VIRTUAL_ETH + state.realEthReserve + netEth;
+        tokensOut = (VIRTUAL_TOKEN + state.realTokenReserve) - (INVARIANT_K / newEth);
+        if (tokensOut > state.realTokenReserve) revert InsufficientReserve();
+
+        // Take the buyer's ETH from the PoolManager (settled in by the router).
+        _takeNative(grossEth);
+
+        state.realEthReserve += netEth;
+        state.realTokenReserve -= tokensOut;
+
+        if (creatorFee > 0) creatorBalances[state.creator] += creatorFee;
+        if (lossPoolFee > 0) ILossRewardPool(lossRewardPool).depositReward{value: lossPoolFee}(state.token);
+
+        // Settle the token output to the PoolManager so the router can take() it for
+        // the buyer. Measures our own balance delta around the transfer — real
+        // fee-on-transfer safety on the outbound leg too, not just trusted on the
+        // strength of V4's own sync/settle for the inbound leg.
+        _settleToken(state.token, tokensOut);
+
+        emit Bought(poolId, tx.origin, grossEth, tokensOut, creatorFee, lossPoolFee);
+
+        if (state.realEthReserve >= GRADUATION_ETH_TARGET && !state.graduated) {
+            _graduate(state, poolId, key);
+        }
+    }
+
+    /// @dev Mirrors IncentifiBondingCurve.sell() exactly.
+    function _executeSell(TokenCurveState storage state, PoolId poolId, uint256 tokensIn) internal returns (uint256 netEthOut) {
+        // Take the seller's tokens from the PoolManager (settled in by the router),
+        // measuring the actual amount received rather than trusting `tokensIn` —
+        // fee-on-transfer safety on the inbound leg, matching the v3 fix's pattern.
+        uint256 actualTokensIn = _takeToken(state.token, tokensIn);
+        if (actualTokensIn == 0) revert ZeroAmount();
+
+        uint256 currentEth = VIRTUAL_ETH + state.realEthReserve;
+        uint256 currentToken = VIRTUAL_TOKEN + state.realTokenReserve;
+        uint256 newToken = currentToken + actualTokensIn;
+        uint256 newEth = INVARIANT_K / newToken;
+        uint256 grossEthOut = currentEth - newEth;
+        if (grossEthOut > state.realEthReserve) revert InsufficientReserve();
+
+        uint256 creatorFee = grossEthOut / 100;
+        uint256 lossPoolFee = grossEthOut / 100;
+        netEthOut = grossEthOut - creatorFee - lossPoolFee;
+
+        state.realEthReserve -= grossEthOut;
+        state.realTokenReserve += actualTokensIn;
+
+        if (creatorFee > 0) creatorBalances[state.creator] += creatorFee;
+        if (lossPoolFee > 0) ILossRewardPool(lossRewardPool).depositReward{value: lossPoolFee}(state.token);
+
+        _settleNative(netEthOut);
+
+        emit Sold(poolId, tx.origin, actualTokensIn, netEthOut, creatorFee, lossPoolFee);
+    }
+
+    // ------------------------------------------------------------------------
+    // Pull-payment creator claims — same accounting shape as
+    // IncentifiBondingCurve.claimCreatorFees(), just global across pools instead
+    // of scoped to one curve's fixed creator.
+    // ------------------------------------------------------------------------
+    function claimCreatorFees() external {
+        uint256 amount = creatorBalances[msg.sender];
+        if (amount == 0) revert NoBalanceToClaim();
+
+        creatorBalances[msg.sender] = 0;
+        (bool success,) = msg.sender.call{value: amount}("");
+        if (!success) revert EthTransferFailed();
+
+        emit CreatorFeesClaimed(msg.sender, amount);
+    }
+
+    // ------------------------------------------------------------------------
+    // Graduation — real V4 liquidity deposit.
+    //
+    // THE PROBLEM THIS SOLVES (genuinely V4-specific — there is no v3 equivalent
+    // to copy): v3's _graduate() creates its Uniswap V3 pool for the FIRST TIME
+    // at graduation, computing that pool's initial sqrtPriceX96 directly FROM the
+    // exact real reserve amounts being deposited
+    // (_computeSqrtPriceX96(amount0Desired, amount1Desired)) — so there is no
+    // pre-existing on-chain price to reconcile, by construction. This V4 hook's
+    // pool, by contrast, was already initialized and tradeable at
+    // PoolManager.initialize() time — that instant on-chain discoverability from
+    // launch, proven in the Stage 2 fork test, was an explicit design goal — and
+    // Stage 3's fork test independently confirmed (via StateView, before/after a
+    // real swap) that full-absorption swaps never move the core pool's own
+    // tracked price. So by the time graduation is reached, PoolManager's slot0
+    // for this pool is STILL sitting at the original $5,000-market-cap launch
+    // price, while the curve's real economics have moved the fair price far
+    // below that (this curve's price only ever falls as more ETH comes in).
+    // Mint a real liquidity position at that stale price with no correction, and
+    // the very first post-graduation swapper gets a massive, structural
+    // arbitrage against the newly seeded liquidity — a real solvency bug, not a
+    // cosmetic one.
+    //
+    // THE FIX: mint a small bootstrap position at the stale price (just enough
+    // real liquidity to trade against), execute one real, hook-bypassed
+    // corrective swap that walks the core pool's tracked price down to the
+    // curve's true final marginal price (bounded exactly by sqrtPriceLimitX96,
+    // so it cannot overshoot), then mint the bulk of the remaining reserves as a
+    // second position at the now-correct price. Both positions are full-range
+    // (TickMath.minUsableTick/maxUsableTick for this pool's tickSpacing) and use
+    // the same salt, so they merge into a single combined position.
+    //
+    // WHY THE CORRECTIVE SWAP DOESN'T RE-TRIGGER THIS HOOK'S OWN ABSORPTION
+    // LOGIC: confirmed by reading the actual installed Hooks.sol — both
+    // `Hooks.beforeSwap` and `Hooks.afterSwap` short-circuit to a pure no-op
+    // (hook not called at all, core pool processes the full amount) whenever
+    // `msg.sender == address(self)`, i.e. whenever the pool's OWN hook contract
+    // is the one calling PoolManager.swap() directly. Since this function IS the
+    // hook contract calling poolManager.swap() on itself, the corrective swap
+    // runs against pure core-pool AMM math with zero hook interference — no
+    // separate "migrating" flag needed, this is a built-in V4 safety mechanism.
+    //
+    // HONEST LIMITATION, not hidden: a bonding curve with virtual-reserve offsets
+    // has a real accumulated reserve ratio (ETH raised : tokens unsold) that
+    // generally does NOT equal its own marginal-price ratio at that same point —
+    // they are different quantities by construction. That means neither mint
+    // below is guaranteed to consume both real assets down to zero
+    // (LiquidityAmounts.getLiquidityForAmounts always picks whichever asset is
+    // limiting at the given price and sizes liquidity to fully use only that
+    // one). Any leftover of the non-limiting asset after the final mint stays in
+    // this contract's own balance, unused — a small, bounded, and reported (via
+    // GraduationLiquidityDeployed) imperfection, not swept under the rug. A
+    // future iteration could mint a second, narrower range to deploy it, or
+    // donate it to the pool; deliberately left unimplemented rather than faked.
+    // ------------------------------------------------------------------------
+    function _graduate(TokenCurveState storage state, PoolId poolId, PoolKey calldata key) internal {
+        state.graduated = true;
+
+        uint256 ethAvailable = state.realEthReserve;
+        uint256 tokensAvailable = state.realTokenReserve;
+
+        emit Graduated(poolId, state.token, ethAvailable, tokensAvailable);
+
+        if (ethAvailable == 0 || tokensAvailable == 0) {
+            // Nothing real to seed as liquidity. Not expected to trigger given
+            // GRADUATION_ETH_TARGET > 0 and the curve's invariant guaranteeing
+            // some unsold supply remains at that target — but the state flip
+            // above still stands regardless; explicitly not treated as an error.
+            return;
+        }
+
+        int24 tickSpacing = key.tickSpacing;
+        int24 tickLower = TickMath.minUsableTick(tickSpacing);
+        int24 tickUpper = TickMath.maxUsableTick(tickSpacing);
+        uint160 sqrtPriceLowerX96 = TickMath.getSqrtPriceAtTick(tickLower);
+        uint160 sqrtPriceUpperX96 = TickMath.getSqrtPriceAtTick(tickUpper);
+        bytes32 salt = bytes32(0);
+
+        // --- Step 1: small bootstrap position at the pool's current (stale)
+        // tracked price, purely so the corrective swap below has real liquidity
+        // to trade against. Sized as 0.1% of the real reserves — small enough
+        // that its own stale-price mispricing is immaterial, since the very next
+        // step corrects the price it trades at.
+        uint256 bootstrapEth = ethAvailable / 1000;
+        uint256 bootstrapTokens = tokensAvailable / 1000;
+        uint160 stalePriceX96 = launchSqrtPriceX96(); // == this pool's actual current slot0, by construction
+
+        uint128 bootstrapLiquidity = LiquidityAmounts.getLiquidityForAmounts(
+            stalePriceX96, sqrtPriceLowerX96, sqrtPriceUpperX96, bootstrapEth, bootstrapTokens
+        );
+        (BalanceDelta bootstrapDelta,) = poolManager.modifyLiquidity(
+            key,
+            ModifyLiquidityParams({
+                tickLower: tickLower,
+                tickUpper: tickUpper,
+                liquidityDelta: int256(uint256(bootstrapLiquidity)),
+                salt: salt
+            }),
+            ""
+        );
+        // Capture what the bootstrap mint ACTUALLY cost, not the nominal
+        // bootstrapEth/bootstrapTokens allocation — LiquidityAmounts.getLiquidityForAmounts
+        // conservatively rounds its liquidity estimate so as never to exceed the
+        // desired amounts, meaning the real amount modifyLiquidity() ends up
+        // requiring can be slightly LESS than what was budgeted. Discarding that
+        // difference (as an earlier version of this function did) doesn't lose
+        // the funds — they're still sitting safely in this contract — but it does
+        // make ethDust/tokenDust under-report the true leftover, which defeats
+        // the whole point of tracking it. Threading the actual paid amounts
+        // through means any such rounding "savings" flow into the final mint's
+        // available balance instead (getting genuinely deployed as liquidity)
+        // rather than becoming untracked residue.
+        (uint256 bootstrapEthPaid, uint256 bootstrapTokensPaid) = _settleMintDelta(state.token, bootstrapDelta);
+
+        // --- Step 2: corrective swap. zeroForOne = true (pay ETH, receive
+        // token) moves price DOWN, which is the correct direction here — this
+        // curve's price (tokens per ETH) only ever falls as more ETH comes in,
+        // so the true final marginal price is always <= the stale launch price.
+        // Bounded by sqrtPriceLimitX96 = the curve's actual final marginal
+        // price, computed the same way launchSqrtPriceX96() computes the launch
+        // price — just fed the FINAL virtual-adjusted reserves instead of the
+        // initial ones.
+        uint160 targetSqrtPriceX96 = _computeSqrtPriceX96(VIRTUAL_ETH + ethAvailable, VIRTUAL_TOKEN + tokensAvailable);
+
+        BalanceDelta correctiveDelta = poolManager.swap(
+            key,
+            SwapParams({zeroForOne: true, amountSpecified: -_GRADUATION_SWAP_SENTINEL, sqrtPriceLimitX96: targetSqrtPriceX96}),
+            ""
+        );
+        int128 correctiveEthDelta = correctiveDelta.amount0();
+        int128 correctiveTokenDelta = correctiveDelta.amount1();
+
+        // Sanity: this self-swap must cost us ETH and pay us tokens, matching
+        // the zeroForOne=true direction requested — never the reverse.
+        if (correctiveEthDelta > 0 || correctiveTokenDelta < 0) revert GraduationSwapDirectionInvalid();
+
+        uint256 ethSpentOnCorrection = uint256(uint128(-correctiveEthDelta));
+        uint256 tokensReceivedFromCorrection = uint256(uint128(correctiveTokenDelta));
+        _settleNative(ethSpentOnCorrection);
+        uint256 actualTokensReceived = _takeToken(state.token, tokensReceivedFromCorrection);
+
+        // --- Step 3: final position, using everything not already committed to
+        // the bootstrap mint or spent/received in the corrective swap, minted at
+        // the now-corrected price.
+        uint256 ethRemaining = ethAvailable - bootstrapEthPaid - ethSpentOnCorrection;
+        uint256 tokensRemaining = tokensAvailable - bootstrapTokensPaid + actualTokensReceived;
+
+        uint128 finalLiquidity = LiquidityAmounts.getLiquidityForAmounts(
+            targetSqrtPriceX96, sqrtPriceLowerX96, sqrtPriceUpperX96, ethRemaining, tokensRemaining
+        );
+        (BalanceDelta finalDelta,) = poolManager.modifyLiquidity(
+            key,
+            ModifyLiquidityParams({
+                tickLower: tickLower,
+                tickUpper: tickUpper,
+                liquidityDelta: int256(uint256(finalLiquidity)),
+                salt: salt
+            }),
+            ""
+        );
+        (uint256 ethDeployed, uint256 tokensDeployed) = _settleMintDelta(state.token, finalDelta);
+
+        // Whatever's left in the hook's own balance after both mints is the
+        // honest, reported dust described above — not deposited anywhere.
+        // Written to storage (not just emitted) so it is a live, queryable,
+        // per-pool record rather than something only recoverable by scanning
+        // event logs — see the mappings' own doc comment for why this is kept
+        // separate from creatorBalances.
+        uint256 ethDust = ethRemaining - ethDeployed;
+        uint256 tokenDust = tokensRemaining - tokensDeployed;
+        ethDustBalances[poolId] = ethDust;
+        tokenDustBalances[poolId] = tokenDust;
+
+        emit GraduationLiquidityDeployed(poolId, bootstrapLiquidity, finalLiquidity, targetSqrtPriceX96, ethDust, tokenDust);
+    }
+
+    /// @dev Settles a modifyLiquidity() mint's negative (owed-to-pool) deltas. A
+    /// plain mint should never return a positive delta (that would mean the pool
+    /// owes US on a pure add) — a positive value here reverts loudly rather than
+    /// being silently take()n, matching this file's no-silent-failures
+    /// convention. Returns the exact (ETH, token) amounts actually paid in.
+    function _settleMintDelta(address token, BalanceDelta delta) internal returns (uint256 ethPaid, uint256 tokensPaid) {
+        int128 ethDelta = delta.amount0();
+        int128 tokenDelta = delta.amount1();
+        if (ethDelta > 0 || tokenDelta > 0) revert GraduationMintUnexpectedCredit();
+        ethPaid = uint256(uint128(-ethDelta));
+        tokensPaid = uint256(uint128(-tokenDelta));
+        if (ethPaid > 0) _settleNative(ethPaid);
+        if (tokensPaid > 0) _settleToken(token, tokensPaid);
+    }
+
+    // ------------------------------------------------------------------------
+    // Settlement helpers — reimplemented directly against IPoolManager (the
+    // reference pattern in v4-core's test/utils/CurrencySettler.sol is
+    // test-only and not meant to be imported into production contracts; this is
+    // an independent implementation of the same publicly-documented
+    // sync/transfer/settle and take mechanics, not a copy).
+    // ------------------------------------------------------------------------
+    function _takeNative(uint256 amount) internal {
+        poolManager.take(Currency.wrap(address(0)), address(this), amount);
+    }
+
+    function _settleNative(uint256 amount) internal {
+        poolManager.settle{value: amount}();
+    }
+
+    /// @return actualReceived The measured balance delta on the PoolManager, not
+    /// the nominal `amount` — fee-on-transfer safe by construction.
+    function _takeToken(address token, uint256 amount) internal returns (uint256 actualReceived) {
+        uint256 balanceBefore = IERC20(token).balanceOf(address(this));
+        poolManager.take(Currency.wrap(token), address(this), amount);
+        actualReceived = IERC20(token).balanceOf(address(this)) - balanceBefore;
+    }
+
+    function _settleToken(address token, uint256 amount) internal {
+        poolManager.sync(Currency.wrap(token));
+        bool success = IERC20(token).transfer(address(poolManager), amount);
+        if (!success) revert TokenTransferFailed();
+        poolManager.settle();
+    }
+
+    // ------------------------------------------------------------------------
+    // Math helpers
+    // ------------------------------------------------------------------------
+
+    /// @dev sqrtPriceX96 for a pool where amount0 = amount of currency0 (native ETH)
+    ///      and amount1 = amount of currency1 (the Incentifi token) at the target
+    ///      price. Computed as sqrt(amount1) * 2^96 / sqrt(amount0) rather than the
+    ///      more direct sqrt(amount1 * 2^192 / amount0), to avoid the 512-bit
+    ///      intermediate multiplication that direct form would need — same technique
+    ///      already used and fork-test-verified (0 ppm error) in
+    ///      IncentifiBondingCurve._computeSqrtPriceX96, reused here for the launch
+    ///      price instead of the graduation price.
+    /// @notice The single source of truth for the correct $5,000-market-cap starting
+    ///         price, exposed publicly so IncentifiV4Factory calls this directly
+    ///         instead of recomputing the same math independently — duplicating
+    ///         security-critical price math in two contracts is exactly how it
+    ///         silently drifts apart later.
+    /// @dev FIXED (real bug, found via a fork-test sanity check, not inspection):
+    ///      this used to compute _computeSqrtPriceX96(VIRTUAL_ETH, VIRTUAL_TOKEN) —
+    ///      i.e. as if realTokenReserve were 0 at launch. It is not: the curve's
+    ///      TRUE starting state has realTokenReserve == TOTAL_SUPPLY (the entire
+    ///      unsold supply sits in the curve before the first buy), exactly the
+    ///      same "VIRTUAL_TOKEN + state.realTokenReserve" pattern _executeBuy,
+    ///      _executeSell, and _graduate's corrective-swap target all already use
+    ///      correctly. Omitting + TOTAL_SUPPLY here set the pool's real, on-chain
+    ///      PoolManager.initialize() price at an implied ~27.6 ETH market cap
+    ///      (verified numerically from the actual on-chain sqrtPriceX96) instead
+    ///      of the intended ~2 ETH (~$5,000) — coincidentally close to this
+    ///      curve's own ~$69K GRADUATION valuation, not its $5K launch valuation.
+    ///      This did NOT affect trade economics (buy/sell math never calls this
+    ///      function), only what PoolManager/StateView report as the pool's price
+    ///      before the first trade — but that is exactly the on-chain
+    ///      discoverability this V4 rewrite exists to provide, so it matters.
+    function launchSqrtPriceX96() public pure returns (uint160) {
+        return _computeSqrtPriceX96(VIRTUAL_ETH, VIRTUAL_TOKEN + TOTAL_SUPPLY);
+    }
+
+    function _computeSqrtPriceX96(uint256 amount0, uint256 amount1) internal pure returns (uint160) {
+        uint256 sqrtAmount0 = _sqrt(amount0);
+        uint256 sqrtAmount1 = _sqrt(amount1);
+        return uint160((sqrtAmount1 << 96) / sqrtAmount0);
+    }
+
+    function _sqrt(uint256 x) internal pure returns (uint256 y) {
+        if (x == 0) return 0;
+        uint256 z = (x + 1) / 2;
+        y = x;
+        while (z < y) {
+            y = z;
+            z = (x / z + z) / 2;
+        }
+    }
+
+    function _toInt128(uint256 x) internal pure returns (int128) {
+        require(x <= uint256(uint128(type(int128).max)), "overflow");
+        return int128(uint128(x));
+    }
+
+    receive() external payable {}
+}

--- a/contracts/v4/IncentifiV4HookGenericSell.sol
+++ b/contracts/v4/IncentifiV4HookGenericSell.sol
@@ -1,0 +1,858 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+// NOTE: imported via @uniswap/v4-periphery's OWN nested v4-core copy
+// (node_modules/@uniswap/v4-periphery/lib/v4-core/), not the top-level
+// @uniswap/v4-core package, even though both are byte-for-byte identical
+// (confirmed via diff) and the same version (1.0.2). Uniswap/v4-periphery's
+// BaseHook.sol resolves ITS @uniswap/v4-core/... imports through its own
+// bundled lib/v4-core/ via that package's remappings.txt, so importing the
+// top-level copy here produced two structurally-identical but type-DISTINCT
+// copies of IPoolManager/Currency/Hooks.Permissions/etc. — real compiler
+// errors ("Invalid implicit conversion from contract IPoolManager to contract
+// IPoolManager", "Overriding function return types differ") the first time
+// this was compiled. Importing through the same nested path BaseHook.sol uses
+// makes every type identity match.
+import {BaseHook} from "@uniswap/v4-periphery/src/utils/BaseHook.sol";
+import {Hooks} from "@uniswap/v4-periphery/lib/v4-core/src/libraries/Hooks.sol";
+import {IPoolManager} from "@uniswap/v4-periphery/lib/v4-core/src/interfaces/IPoolManager.sol";
+import {PoolKey} from "@uniswap/v4-periphery/lib/v4-core/src/types/PoolKey.sol";
+import {PoolId, PoolIdLibrary} from "@uniswap/v4-periphery/lib/v4-core/src/types/PoolId.sol";
+import {Currency, CurrencyLibrary} from "@uniswap/v4-periphery/lib/v4-core/src/types/Currency.sol";
+import {BalanceDelta} from "@uniswap/v4-periphery/lib/v4-core/src/types/BalanceDelta.sol";
+import {BeforeSwapDelta, BeforeSwapDeltaLibrary, toBeforeSwapDelta} from "@uniswap/v4-periphery/lib/v4-core/src/types/BeforeSwapDelta.sol";
+import {SwapParams, ModifyLiquidityParams} from "@uniswap/v4-periphery/lib/v4-core/src/types/PoolOperation.sol";
+import {TickMath} from "@uniswap/v4-periphery/lib/v4-core/src/libraries/TickMath.sol";
+// LiquidityAmounts is imported from periphery's TOP-LEVEL path (not the nested
+// lib/v4-core one everything else here uses) deliberately: it only operates on
+// primitive uint160/uint256 values, never on a PoolKey/Currency/IPoolManager
+// struct or contract instance, so the type-identity problem documented above
+// (why every other import here goes through the nested path) does not apply to
+// it — there is no struct/contract type for the two copies to disagree about.
+import {LiquidityAmounts} from "@uniswap/v4-periphery/src/libraries/LiquidityAmounts.sol";
+
+interface IERC20 {
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address recipient, uint256 amount) external returns (bool);
+}
+
+interface ILossRewardPool {
+    function depositReward(address token) external payable;
+}
+
+/**
+ * @title IncentifiV4HookGenericSell
+ * @notice IncentifiV4HookNoPostGradFee (this file's logic source, verbatim — see
+ *         PROVENANCE) with ONE mechanical change: a pre-graduation SELL receives
+ *         the seller's tokens as ERC-6909 claims (PoolManager.mint) instead of a
+ *         physical PoolManager.take(). Nothing about pricing, fees, reserves,
+ *         graduation, or the post-graduation ZERO_DELTA pass-through changes.
+ *
+ * @dev WHY THIS FILE EXISTS — a real, root-caused production incident, not a
+ *      hypothetical. Third-party trading bots could BUY every token launched
+ *      through the NoPostGradFee hook (real mainnet transactions routing through
+ *      the real PoolManager and paying the real 1% LossRewardPool fee) but could
+ *      never SELL one pre-graduation: every attempt died in the bot's own
+ *      pre-broadcast simulation, no transaction hash, while sells through
+ *      IncentifiV4Router worked. It was chased first as an approval problem (it
+ *      was not — the bot already held an unlimited direct allowance on every
+ *      token). The actual cause is settlement ORDER. NoPostGradFee's
+ *      _executeSell physically take()s the seller's tokens out of PoolManager
+ *      synchronously inside beforeSwap; that only succeeds if the tokens were
+ *      settled INTO PoolManager BEFORE swap() was called — which only
+ *      IncentifiV4Router does (its _executeSell's documented sync→transfer→
+ *      settle-then-swap dance). Every generic V4 router (UniversalRouter, that
+ *      bot, GenericV4Bot, all of them) uses the standard order — swap() FIRST,
+ *      settle AFTER — so the hook's take() fires against a PoolManager that has
+ *      never held one unit of a fresh token, and the ERC20 transfer inside take()
+ *      reverts for real insufficient balance. Buys never hit this because the
+ *      hook take()s NATIVE ETH there, and PoolManager holds real ETH from every
+ *      other pool that it can momentarily borrow against; a freshly-launched
+ *      token has no such shared reserve. Every generic-caller sell ever tested
+ *      before this was POST-graduation, where the hook passes through and the
+ *      constraint cannot apply — which is exactly how it went unnoticed.
+ *
+ * @dev THE FIX, and why it is safe (verified against the installed v4-core
+ *      PoolManager.sol source, not assumed): PoolManager.mint(to, id, amount) is
+ *      _accountDelta(currency, -amount, msg.sender) plus a bare
+ *      balanceOf[to][id] += amount — it moves NO tokens, unlike take(), which
+ *      additionally does currency.transfer(). In beforeSwap this hook is
+ *      credited +tokensIn (hookDeltaSpecified); mint() debits exactly that, so
+ *      the hook's delta nets to zero with no physical backing required at that
+ *      instant. The swapper's -tokensIn delta is then settled by the caller
+ *      AFTER swap(), in standard order — and PoolManager's own sync()/settle()
+ *      measures the real amount delivered, so if a fee-on-transfer token
+ *      delivers less, the caller's delta never reaches zero and the whole
+ *      unlock reverts (CurrencyNotSettled). Inbound fee-on-transfer safety is
+ *      therefore ENFORCED by PoolManager itself, more strictly than the old
+ *      balance-delta measurement could — this hook may trust `tokensIn`
+ *      exactly. Claims are always 1:1 backed by tokens already physically
+ *      inside PoolManager (deposited by the sellers' own settles), so they are
+ *      spent via burn() — which CREDITS the hook's delta, offsetting an outbound
+ *      debit — wherever this hook previously settled physical tokens out: a
+ *      BUY's token output and graduation's two liquidity mints (see _payToken).
+ *      _graduate()'s corrective-swap take() is unchanged: by then PoolManager
+ *      physically holds the bootstrap mint's tokens, so that take() is backed.
+ *      Native ETH handling is deliberately unchanged (proven working for
+ *      generic callers on real mainnet); its borrow-against-shared-reserve
+ *      dependency is real but is not this bug and is out of scope here.
+ *
+ * @dev PROVENANCE: contracts/v4/IncentifiV4HookNoPostGradFee.sol copied
+ *      verbatim (the exact lineage deployed at
+ *      0x5bBcf2CDAAA00c285eEc903AA1E2aB9142782888 and trading on real mainnet),
+ *      then edited ONLY in: the contract name, one import (CurrencyLibrary), one
+ *      `using` line, _executeSell's intake, _executeBuy's and _settleMintDelta's
+ *      outbound token leg (now _payToken), and the two new helpers. Diff the
+ *      two files to see every change; there are no others. Same four
+ *      permission flags, so the same CREATE2 REQUIRED_FLAGS (0x2888) apply.
+ *
+ * @dev Tokens already launched on the old hook are permanently bound to it (a
+ *      pool's hook address is immutable) and stay sellable only through
+ *      IncentifiV4Router pre-graduation. This hook only helps launches made
+ *      through a factory pointed at it.
+ *
+ * @dev PAIRING CURRENCY: native ETH (Currency.wrap(address(0))), not WETH. Two reasons:
+ *      (1) V4 supports native ETH as a first-class currency, avoiding a wrap/unwrap
+ *          round-trip on every trade that the v3 architecture needed.
+ *      (2) address(0) is numerically the smallest possible address, so currency0 is
+ *          *always* ETH and currency1 is *always* the Incentifi token, for every pool,
+ *          unconditionally. This structurally eliminates the "token address < WETH
+ *          address" ordering bug class that required a dedicated fix
+ *          (_computeSqrtPriceX96 in IncentifiBondingCurve.sol) on the v3 side. There is
+ *          no equivalent bug surface here because there is no ordering ambiguity to get
+ *          wrong in the first place.
+ */
+contract IncentifiV4HookGenericSell is BaseHook {
+    using PoolIdLibrary for PoolKey;
+    using CurrencyLibrary for Currency;
+
+    // ------------------------------------------------------------------------
+    // Economic constants — FULL PRODUCTION SCALE, identical to
+    // IncentifiV4Hook.sol. Unlike IncentifiV4HookTestnet.sol (this file's logic
+    // source), these are NOT scaled down: real $5,000 starting market cap, real
+    // $69,000 graduation target.
+    // ------------------------------------------------------------------------
+    uint256 public constant TOTAL_SUPPLY = 1_000_000_000 * 1e18;
+    uint256 public constant VIRTUAL_ETH = 2_156_250_000_000_000_000; // 2.15625 ETH
+    uint256 public constant VIRTUAL_TOKEN = 78_125_000_000_000_000_000_000_000; // 78,125,000 tokens
+    uint256 public constant INVARIANT_K = 2_324_707_031_250_000_000_000_000_000_000_000_000_000_000_000; // 2.32470703125e45
+    uint256 public constant GRADUATION_ETH_TARGET = 5_853_863_234_375_000_000; // 5.853863234375 ETH
+
+    uint256 public constant PROTOCOL_FEE_BPS = 200; // 2.00% total (pre-graduation only)
+    uint256 public constant CREATOR_FEE_BPS = 100; // 1.00%
+    uint256 public constant LOSS_REWARD_FEE_BPS = 100; // 1.00%
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+
+    /// @dev Deliberately oversized exact-input magnitude for _graduate()'s
+    /// corrective swap, so the swap is always bounded by its sqrtPriceLimitX96
+    /// (the actual target price) rather than by this nominal amount — the
+    /// standard "swap up to a price limit" pattern. Never actually paid in full;
+    /// the real, much smaller amount that PoolManager actually consumes is read
+    /// back from the swap's returned delta and settled exactly.
+    int256 private constant _GRADUATION_SWAP_SENTINEL = type(int128).max;
+
+    // ------------------------------------------------------------------------
+    // Immutables
+    // ------------------------------------------------------------------------
+
+    /// @notice The only address permitted to call registerToken() — validation of
+    /// creator identity / total-supply / etc. lives in the factory, mirroring how
+    /// IncentifiBondingCurveFactory.sol validates before deploying a v3 curve.
+    /// @dev NOT immutable, and deliberately not a constructor param — a genuine
+    /// circular dependency, not a test convenience: this hook's own deployment
+    /// address must be mined via CREATE2 to satisfy the permission-bit requirement
+    /// BEFORE IncentifiV4Factory (which takes this hook's address as its own
+    /// constructor arg) can be deployed. If `factory` were a constructor param here,
+    /// neither contract could be deployed first. Resolved with the standard pattern
+    /// for this exact problem: deploy the hook, deploy the factory (now that the
+    /// hook exists to reference), then wire them together with one one-time call —
+    /// not a per-launch admin step, a one-time system bootstrap step.
+    address public factory;
+    address public immutable lossRewardPool;
+    /// @dev The only address allowed to call setFactory() once. Not an ongoing admin
+    /// role: setFactory() is one-time-only (reverts if `factory` is already set), so
+    /// this has no power after bootstrap.
+    /// @dev Passed explicitly as a constructor arg rather than recorded from
+    /// `msg.sender` — this hook is deployed via CREATE2 through the standard
+    /// singleton deployer factory (0x4e59b44847b379578588920cA78FbF26c0B4956C,
+    /// confirmed deployed on Robinhood Chain), which means `msg.sender` during this
+    /// constructor's execution would be that FACTORY PROXY, not the actual deployer's
+    /// EOA. Recording `msg.sender` here would make setFactory() permanently
+    /// uncallable by anyone with a private key. Caught by reasoning through the
+    /// deployment path before attempting it, not from a failed deployment.
+    address public immutable deployer;
+
+    // ------------------------------------------------------------------------
+    // Per-pool state (shared-hook model)
+    // ------------------------------------------------------------------------
+    struct TokenCurveState {
+        address token;
+        address creator;
+        bool initialized;
+        bool graduated;
+        uint256 realEthReserve;
+        uint256 realTokenReserve;
+    }
+
+    mapping(PoolId => TokenCurveState) public curveStates;
+
+    /// @notice Pull-payment creator balances, GLOBAL across every token this hook
+    /// serves (keyed by creator address, not by pool) — a single creator who
+    /// launches multiple tokens accrues into one claimable balance, and claims once
+    /// via claimCreatorFees() regardless of which of their tokens earned the fee.
+    mapping(address => uint256) public creatorBalances;
+
+    /// @notice token => creator, set by the factory via registerToken() before it
+    /// calls PoolManager.initialize(). Consumed and cleared by _beforeInitialize().
+    mapping(address => address) public pendingCreator;
+
+    /// @notice Leftover ETH/token from _graduate()'s reserve-ratio-vs-marginal-
+    /// price mismatch (see _graduate()'s doc comment), keyed by PoolId so it is
+    /// never confused with any other pool's dust or claim. Written once, at
+    /// graduation, alongside the GraduationLiquidityDeployed event — the event is
+    /// history; these mappings are the live, queryable record.
+    ///
+    /// @dev Deliberately kept SEPARATE from creatorBalances, even though both are
+    /// "real ETH sitting in this contract, not yet spent anywhere": creatorBalances
+    /// is a claimable entitlement (someone can withdraw it via claimCreatorFees()),
+    /// while ethDustBalances/tokenDustBalances are only a bookkeeping record of
+    /// value that has NO withdrawal path today (see the token-dust question this
+    /// was raised over) — merging them into one ledger would make an unclaimed
+    /// creator fee and an unspendable dust remainder indistinguishable from a
+    /// single mapping read, which is exactly the "hard to account for" risk this
+    /// pair of mappings exists to close off. tokenDustBalances is close to
+    /// redundant with IERC20(token).balanceOf(address(this)) post-graduation
+    /// (nothing else touches that balance once graduated — see the _beforeSwap
+    /// pass-through), but is recorded anyway for parity with ethDustBalances,
+    /// which has no such convenient equivalent (native ETH is one pooled balance
+    /// shared across every token this hook serves, unlike each token's own
+    /// self-isolating ERC20 balance).
+    mapping(PoolId => uint256) public ethDustBalances;
+    mapping(PoolId => uint256) public tokenDustBalances;
+
+    // ------------------------------------------------------------------------
+    // Events
+    // ------------------------------------------------------------------------
+    event TokenRegistered(address indexed token, address indexed creator);
+    event CurveInitialized(address indexed token, address indexed creator, PoolId poolId);
+    event Bought(PoolId indexed poolId, address indexed trader, uint256 ethIn, uint256 tokensOut, uint256 creatorFee, uint256 lossPoolFee);
+    event Sold(PoolId indexed poolId, address indexed trader, uint256 tokensIn, uint256 ethOut, uint256 creatorFee, uint256 lossPoolFee);
+    event CreatorFeesClaimed(address indexed creator, uint256 amount);
+    event Graduated(PoolId indexed poolId, address indexed token, uint256 finalEthReserve, uint256 finalTokenReserve);
+    /// @param ethDust,tokenDust Real, honestly-reported leftover from the reserve-
+    /// ratio-vs-marginal-price mismatch inherent to migrating a virtual-offset
+    /// bonding curve into a real concentrated-liquidity position — see the long
+    /// comment on _graduate() for why this isn't (and can't cheaply be) zero.
+    event GraduationLiquidityDeployed(
+        PoolId indexed poolId,
+        uint128 bootstrapLiquidity,
+        uint128 finalLiquidity,
+        uint160 correctedSqrtPriceX96,
+        uint256 ethDust,
+        uint256 tokenDust
+    );
+
+    // ------------------------------------------------------------------------
+    // Errors
+    // ------------------------------------------------------------------------
+    error OnlyFactory();
+    error ZeroAddress();
+    error ZeroAmount();
+    error AlreadyPending();
+    error TokenNotRegistered();
+    error AlreadyInitialized();
+    error InsufficientSupply();
+    error MustPairWithNativeEth();
+    error WrongStartingPrice();
+    error PoolNotInitialized();
+    error OnlyExactInputSupported();
+    error InsufficientReserve();
+    error SlippageExceeded();
+    error NoBalanceToClaim();
+    error CannotAddLiquidity();
+    error EthTransferFailed();
+    error TokenTransferFailed();
+    error OnlyDeployer();
+    error FactoryAlreadySet();
+    // Graduation-liquidity-specific — see _graduate()'s doc comment. Both would
+    // indicate a real accounting bug in the corrective-swap/mint math, not a
+    // condition expected to ever actually trigger.
+    error GraduationSwapDirectionInvalid();
+    error GraduationMintUnexpectedCredit();
+
+    constructor(IPoolManager _poolManager, address _lossRewardPool, address _deployer) BaseHook(_poolManager) {
+        if (_lossRewardPool == address(0) || _deployer == address(0)) revert ZeroAddress();
+        lossRewardPool = _lossRewardPool;
+        deployer = _deployer;
+    }
+
+    /// @notice One-time wiring of the factory address, called once immediately after
+    /// both this hook and IncentifiV4Factory are deployed. Not callable again once
+    /// set, and not callable by anyone other than whoever deployed this specific
+    /// hook instance — see the `factory` field's doc comment for why this exists.
+    function setFactory(address _factory) external {
+        if (msg.sender != deployer) revert OnlyDeployer();
+        if (factory != address(0)) revert FactoryAlreadySet();
+        if (_factory == address(0)) revert ZeroAddress();
+        factory = _factory;
+    }
+
+    // ------------------------------------------------------------------------
+    // Hook permissions
+    // ------------------------------------------------------------------------
+    /**
+     * @dev Four flags — NOT the six IncentifiV4Hook.sol declares. No afterSwap:
+     *      - BEFORE_INITIALIZE: validate + finalize a pending token registration at
+     *        the correct starting price before the pool exists.
+     *      - BEFORE_ADD_LIQUIDITY: revert unless caller == address(this) — blocks
+     *        every external LP pre-graduation, protecting the internal reserve
+     *        accounting exactly the way Doppler's own beforeAddLiquidity does
+     *        (pattern studied, not copied — Doppler is BUSL-1.1, this is an
+     *        independent ~3-line reimplementation of an obvious idea).
+     *      - BEFORE_SWAP + BEFORE_SWAP_RETURNS_DELTA: the actual custom-accounting
+     *        override, pre-graduation only. All economics (pricing, fee split,
+     *        settlement, reserve updates, graduation trigger) happen inside
+     *        _beforeSwap. Post-graduation, _beforeSwap returns ZERO_DELTA — a
+     *        pure pass-through, no fee, no custom accounting of any kind.
+     *      AFTER_SWAP is deliberately NOT set: since every pre-graduation swap is
+     *      fully absorbed (100% custom accounting) inside beforeSwap, and every
+     *      post-graduation swap is fully passed through untouched, there is
+     *      nothing left for afterSwap to do in either regime.
+     */
+    function getHookPermissions() public pure override returns (Hooks.Permissions memory) {
+        return Hooks.Permissions({
+            beforeInitialize: true,
+            afterInitialize: false,
+            beforeAddLiquidity: true,
+            afterAddLiquidity: false,
+            beforeRemoveLiquidity: false,
+            afterRemoveLiquidity: false,
+            beforeSwap: true,
+            afterSwap: false,
+            beforeDonate: false,
+            afterDonate: false,
+            beforeSwapReturnDelta: true,
+            afterSwapReturnDelta: false,
+            afterAddLiquidityReturnDelta: false,
+            afterRemoveLiquidityReturnDelta: false
+        });
+    }
+
+    // ------------------------------------------------------------------------
+    // Permissionless launch registration (called by IncentifiV4Factory)
+    // ------------------------------------------------------------------------
+    /**
+     * @notice Records `creator` as the pending creator for `token`, ahead of the
+     *         factory calling PoolManager.initialize() for that token's pool.
+     * @dev Gated to `factory` only — this contract trusts the factory to have
+     *      already validated token.creator() / total supply / etc., mirroring
+     *      IncentifiBondingCurveFactory.registerExistingToken()'s validation.
+     *      The factory must transfer the token's full TOTAL_SUPPLY to this hook
+     *      BEFORE calling PoolManager.initialize() — _beforeInitialize checks for
+     *      that balance and reverts if it isn't there yet.
+     */
+    function registerToken(address token, address creator) external {
+        if (msg.sender != factory) revert OnlyFactory();
+        if (token == address(0) || creator == address(0)) revert ZeroAddress();
+        if (pendingCreator[token] != address(0)) revert AlreadyPending();
+
+        pendingCreator[token] = creator;
+        emit TokenRegistered(token, creator);
+    }
+
+    function _beforeInitialize(address, PoolKey calldata key, uint160 sqrtPriceX96)
+        internal
+        override
+        returns (bytes4)
+    {
+        if (!key.currency0.isAddressZero()) revert MustPairWithNativeEth();
+
+        address token = Currency.unwrap(key.currency1);
+        address creator = pendingCreator[token];
+        if (creator == address(0)) revert TokenNotRegistered();
+
+        PoolId poolId = key.toId();
+        TokenCurveState storage state = curveStates[poolId];
+        if (state.initialized) revert AlreadyInitialized();
+
+        uint256 balance = IERC20(token).balanceOf(address(this));
+        if (balance < TOTAL_SUPPLY) revert InsufficientSupply();
+
+        // Defend against anyone initializing at a wrong price: PoolManager.initialize()
+        // is permissionless at the PoolManager level, so without this check a
+        // front-runner could initialize this exact PoolKey at an arbitrary price before
+        // the factory's own initialize() call lands. Only the one correct $5,000
+        // starting price (VIRTUAL_TOKEN / VIRTUAL_ETH ratio) is accepted.
+        if (sqrtPriceX96 != launchSqrtPriceX96()) revert WrongStartingPrice();
+
+        state.token = token;
+        state.creator = creator;
+        state.initialized = true;
+        state.realEthReserve = 0;
+        state.realTokenReserve = TOTAL_SUPPLY;
+
+        delete pendingCreator[token];
+
+        emit CurveInitialized(token, creator, poolId);
+        return BaseHook.beforeInitialize.selector;
+    }
+
+    /// @dev Pre-graduation, liquidity may ONLY come from this hook itself (the
+    ///      _graduate() mint below) — an external LP adding liquidity while the
+    ///      curve is still active would corrupt the full-absorption invariant this
+    ///      hook depends on (a real, non-zero-liquidity core pool would start
+    ///      partially filling swaps itself, which _beforeSwap's OnlyExactInputSupported
+    ///      / full-absorption math does not account for). Once graduated, this
+    ///      pool is a genuine, permanently-real AMM pool with no more curve
+    ///      invariant to protect — so, unlike the permanently-hook-only v3 LP
+    ///      position (minted once, then burned/locked forever), this DOES open up
+    ///      to any external LP after graduation, same as a completely standard,
+    ///      permissionless V4 pool. Flagging this as a deliberate departure from
+    ///      v3's parity, not an oversight.
+    function _beforeAddLiquidity(address caller, PoolKey calldata key, ModifyLiquidityParams calldata, bytes calldata)
+        internal
+        view
+        override
+        returns (bytes4)
+    {
+        if (caller != address(this) && !curveStates[key.toId()].graduated) revert CannotAddLiquidity();
+        return BaseHook.beforeAddLiquidity.selector;
+    }
+
+    // ------------------------------------------------------------------------
+    // Core custom-accounting swap logic
+    // ------------------------------------------------------------------------
+    /**
+     * @dev Delta-application semantics below are transcribed from the ACTUAL
+     *      Hooks.sol I read (v4-core 1.0.2), not assumed:
+     *
+     *        amountToSwap = params.amountSpecified;
+     *        amountToSwap += hookReturn.getSpecifiedDelta();
+     *        revert if (exactInput && amountToSwap > 0)   // exactInput = original amountSpecified < 0
+     *
+     *      We only support exact-input swaps (amountSpecified < 0) — this hook has
+     *      no real liquidity backing it, so any amount left for the "core" pool to
+     *      process after our delta would hit a liquidity-less pool and revert
+     *      anyway; full absorption is the only valid mode, and OnlyExactInputSupported
+     *      documents that as a deliberate constraint, not an oversight.
+     *
+     *      Setting hookDeltaSpecified = -params.amountSpecified makes amountToSwap
+     *      land at exactly 0 — the core pool does nothing, all economics are ours.
+     *
+     *      Router's own final delta (from Hooks.afterSwap: swapDelta = coreDelta -
+     *      hookDelta, and coreDelta is (0,0) here since amountToSwap is 0) works out
+     *      to -hookDelta. Confirmed sign convention from Hooks.sol/CurrencySettler.sol
+     *      (test-path reference, read but not imported): positive hook delta = hook
+     *      take()s that amount FROM the PoolManager; negative = hook settle()s
+     *      (pays) that amount INTO the PoolManager.
+     *
+     *      BUY (zeroForOne, ETH -> TOKEN): specified = currency0 (ETH). We take() the
+     *      buyer's incoming ETH (hookDeltaSpecified > 0), and settle() the token
+     *      output (hookDeltaUnspecified < 0) so the router can take() it out for the
+     *      buyer. SELL is the mirror image with the specified/unspecified currencies
+     *      swapped and native-ETH settle() replacing ERC20 settle().
+     *
+     * @dev KNOWN GAP vs. IncentifiBondingCurve.buy(): the v3 contract clamps grossEth
+     *      to the graduation boundary and refunds any excess directly from within
+     *      buy() itself, because it holds msg.value directly. That refund mechanism
+     *      does not translate here: a hook that only partially absorbs
+     *      amountSpecified leaves the remainder for the core (liquidity-less) pool to
+     *      process, which would revert. This version does NOT clamp/refund — an
+     *      overshooting buy is accepted in full, and any excess beyond the exact
+     *      graduation target is carried into the reserve that gets migrated at
+     *      graduation rather than refunded to the buyer. Clamping with a refund
+     *      happens one layer up, in IncentifiV4Router (compute the clamped amount
+     *      via a view call before ever submitting the swap, refund any excess
+     *      before calling PoolManager.unlock()).
+     */
+    function _beforeSwap(address, PoolKey calldata key, SwapParams calldata params, bytes calldata)
+        internal
+        override
+        returns (bytes4, BeforeSwapDelta, uint24)
+    {
+        PoolId poolId = key.toId();
+        TokenCurveState storage state = curveStates[poolId];
+        if (!state.initialized) revert PoolNotInitialized();
+
+        // POST-GRADUATION PASS-THROUGH: once _graduate() has deposited real
+        // concentrated liquidity into the core pool, this hook gets out of the
+        // way entirely and lets the core AMM execute the trade against that real
+        // liquidity — returning ZERO_DELTA here means "the hook claims none of the
+        // swap amount", so the core pool processes 100% of it normally, exactly as
+        // if this were an ordinary hookless (or no-op-hook) pool. No fee of any
+        // kind (protocol, creator, or LossRewardPool) is taken on any
+        // post-graduation trade — this is the deliberate difference from
+        // IncentifiV4Hook.sol's afterSwap-based post-graduation fee mechanism.
+        //
+        // beforeSwap is a MANDATORY hook once BEFORE_SWAP_FLAG is set — PoolManager
+        // calls it on every single swap for this pool's lifetime, with no way to
+        // "turn it off". An earlier iteration of this logic unconditionally
+        // reverted here once graduated, which would have permanently bricked the
+        // pool for trading the moment graduation completed — caught while
+        // implementing the real liquidity deposit, not by inspection beforehand.
+        if (state.graduated) {
+            return (BaseHook.beforeSwap.selector, BeforeSwapDeltaLibrary.ZERO_DELTA, 0);
+        }
+
+        if (params.amountSpecified >= 0) revert OnlyExactInputSupported();
+
+        uint256 amountIn = uint256(-params.amountSpecified);
+        if (amountIn == 0) revert ZeroAmount();
+
+        int128 hookDeltaSpecified = int128(-params.amountSpecified);
+        int128 hookDeltaUnspecified;
+
+        if (params.zeroForOne) {
+            // BUY: ETH in (specified, currency0), TOKEN out (unspecified, currency1)
+            uint256 tokensOut = _executeBuy(state, poolId, key, amountIn);
+            hookDeltaUnspecified = -_toInt128(tokensOut);
+        } else {
+            // SELL: TOKEN in (specified, currency1), ETH out (unspecified, currency0)
+            uint256 netEthOut = _executeSell(state, poolId, amountIn);
+            hookDeltaUnspecified = -_toInt128(netEthOut);
+        }
+
+        BeforeSwapDelta delta = toBeforeSwapDelta(hookDeltaSpecified, hookDeltaUnspecified);
+        return (BaseHook.beforeSwap.selector, delta, 0);
+    }
+
+    /// @dev Mirrors IncentifiBondingCurve.buy() exactly (minus the clamp/refund — see
+    ///      the KNOWN GAP note above), executed as V4 settlement instead of a direct
+    ///      payable call. Fee-on-transfer safety for the token leg comes from V4's
+    ///      own sync()/settle() semantics (balance measured before/after, not a
+    ///      trusted nominal amount) — the same principle as the v3 fix, provided by
+    ///      the platform this time instead of hand-rolled.
+    function _executeBuy(TokenCurveState storage state, PoolId poolId, PoolKey calldata key, uint256 grossEth) internal returns (uint256 tokensOut) {
+        uint256 creatorFee = grossEth / 100;
+        uint256 lossPoolFee = grossEth / 100;
+        uint256 netEth = grossEth - creatorFee - lossPoolFee;
+
+        uint256 newEth = VIRTUAL_ETH + state.realEthReserve + netEth;
+        tokensOut = (VIRTUAL_TOKEN + state.realTokenReserve) - (INVARIANT_K / newEth);
+        if (tokensOut > state.realTokenReserve) revert InsufficientReserve();
+
+        // Take the buyer's ETH from the PoolManager (settled in by the router).
+        _takeNative(grossEth);
+
+        state.realEthReserve += netEth;
+        state.realTokenReserve -= tokensOut;
+
+        if (creatorFee > 0) creatorBalances[state.creator] += creatorFee;
+        if (lossPoolFee > 0) ILossRewardPool(lossRewardPool).depositReward{value: lossPoolFee}(state.token);
+
+        // Pay the token output into the PoolManager so the router can take() it for
+        // the buyer. Spends ERC-6909 claims first (tokens prior sellers already
+        // deposited physically — see _payToken), then physical balance for any
+        // remainder; either way the hook's outbound debit is offset exactly.
+        _payToken(state.token, tokensOut);
+
+        emit Bought(poolId, tx.origin, grossEth, tokensOut, creatorFee, lossPoolFee);
+
+        if (state.realEthReserve >= GRADUATION_ETH_TARGET && !state.graduated) {
+            _graduate(state, poolId, key);
+        }
+    }
+
+    /// @dev Mirrors IncentifiBondingCurve.sell() exactly in its economics. The ONE
+    ///      change from NoPostGradFee is how the seller's tokens are received —
+    ///      see the contract header's "THE FIX" for the full argument.
+    function _executeSell(TokenCurveState storage state, PoolId poolId, uint256 tokensIn) internal returns (uint256 netEthOut) {
+        // Receive the seller's tokens as ERC-6909 claims (a pure ledger entry) rather
+        // than a physical take(). A take() here only works if the caller settled the
+        // tokens INTO PoolManager BEFORE calling swap() — which only IncentifiV4Router
+        // does; every generic V4 router settles AFTER swap(), so a take() fires against
+        // a PoolManager holding none of this token and reverts. mint() needs no backing
+        // at this instant: the caller's post-swap settle() delivers the real tokens,
+        // and PoolManager's own settle accounting reverts the whole unlock if fewer
+        // arrive than `tokensIn` (fee-on-transfer), so `tokensIn` is trustworthy by
+        // construction — no balance-delta measurement is needed, or even possible, here.
+        _receiveTokenAsClaims(state.token, tokensIn);
+        uint256 actualTokensIn = tokensIn;
+        if (actualTokensIn == 0) revert ZeroAmount();
+
+        uint256 currentEth = VIRTUAL_ETH + state.realEthReserve;
+        uint256 currentToken = VIRTUAL_TOKEN + state.realTokenReserve;
+        uint256 newToken = currentToken + actualTokensIn;
+        uint256 newEth = INVARIANT_K / newToken;
+        uint256 grossEthOut = currentEth - newEth;
+        if (grossEthOut > state.realEthReserve) revert InsufficientReserve();
+
+        uint256 creatorFee = grossEthOut / 100;
+        uint256 lossPoolFee = grossEthOut / 100;
+        netEthOut = grossEthOut - creatorFee - lossPoolFee;
+
+        state.realEthReserve -= grossEthOut;
+        state.realTokenReserve += actualTokensIn;
+
+        if (creatorFee > 0) creatorBalances[state.creator] += creatorFee;
+        if (lossPoolFee > 0) ILossRewardPool(lossRewardPool).depositReward{value: lossPoolFee}(state.token);
+
+        _settleNative(netEthOut);
+
+        emit Sold(poolId, tx.origin, actualTokensIn, netEthOut, creatorFee, lossPoolFee);
+    }
+
+    // ------------------------------------------------------------------------
+    // Pull-payment creator claims — same accounting shape as
+    // IncentifiBondingCurve.claimCreatorFees(), just global across pools instead
+    // of scoped to one curve's fixed creator.
+    // ------------------------------------------------------------------------
+    function claimCreatorFees() external {
+        uint256 amount = creatorBalances[msg.sender];
+        if (amount == 0) revert NoBalanceToClaim();
+
+        creatorBalances[msg.sender] = 0;
+        (bool success,) = msg.sender.call{value: amount}("");
+        if (!success) revert EthTransferFailed();
+
+        emit CreatorFeesClaimed(msg.sender, amount);
+    }
+
+    // ------------------------------------------------------------------------
+    // Graduation — real V4 liquidity deposit. Identical to IncentifiV4Hook.sol's
+    // _graduate() — this part of the logic is unaffected by the afterSwap
+    // question, since it runs exactly once, at the graduation boundary, before
+    // any post-graduation trade (fee-bearing or not) ever occurs.
+    //
+    // THE PROBLEM THIS SOLVES (genuinely V4-specific — there is no v3 equivalent
+    // to copy): v3's _graduate() creates its Uniswap V3 pool for the FIRST TIME
+    // at graduation, computing that pool's initial sqrtPriceX96 directly FROM the
+    // exact real reserve amounts being deposited — so there is no pre-existing
+    // on-chain price to reconcile, by construction. This V4 hook's pool, by
+    // contrast, was already initialized and tradeable at PoolManager.initialize()
+    // time. So by the time graduation is reached, PoolManager's slot0 for this
+    // pool is STILL sitting at the original $5,000-market-cap launch price,
+    // while the curve's real economics have moved the fair price far below that.
+    // Mint a real liquidity position at that stale price with no correction, and
+    // the very first post-graduation swapper gets a massive, structural
+    // arbitrage against the newly seeded liquidity — a real solvency bug.
+    //
+    // THE FIX: mint a small bootstrap position at the stale price (just enough
+    // real liquidity to trade against), execute one real, hook-bypassed
+    // corrective swap that walks the core pool's tracked price down to the
+    // curve's true final marginal price (bounded exactly by sqrtPriceLimitX96,
+    // so it cannot overshoot), then mint the bulk of the remaining reserves as a
+    // second position at the now-correct price. Both positions are full-range
+    // and use the same salt, so they merge into a single combined position.
+    // ------------------------------------------------------------------------
+    function _graduate(TokenCurveState storage state, PoolId poolId, PoolKey calldata key) internal {
+        state.graduated = true;
+
+        uint256 ethAvailable = state.realEthReserve;
+        uint256 tokensAvailable = state.realTokenReserve;
+
+        emit Graduated(poolId, state.token, ethAvailable, tokensAvailable);
+
+        if (ethAvailable == 0 || tokensAvailable == 0) {
+            // Nothing real to seed as liquidity. Not expected to trigger given
+            // GRADUATION_ETH_TARGET > 0 and the curve's invariant guaranteeing
+            // some unsold supply remains at that target — but the state flip
+            // above still stands regardless; explicitly not treated as an error.
+            return;
+        }
+
+        int24 tickSpacing = key.tickSpacing;
+        int24 tickLower = TickMath.minUsableTick(tickSpacing);
+        int24 tickUpper = TickMath.maxUsableTick(tickSpacing);
+        uint160 sqrtPriceLowerX96 = TickMath.getSqrtPriceAtTick(tickLower);
+        uint160 sqrtPriceUpperX96 = TickMath.getSqrtPriceAtTick(tickUpper);
+        bytes32 salt = bytes32(0);
+
+        // --- Step 1: small bootstrap position at the pool's current (stale)
+        // tracked price, purely so the corrective swap below has real liquidity
+        // to trade against. Sized as 0.1% of the real reserves.
+        uint256 bootstrapEth = ethAvailable / 1000;
+        uint256 bootstrapTokens = tokensAvailable / 1000;
+        uint160 stalePriceX96 = launchSqrtPriceX96(); // == this pool's actual current slot0, by construction
+
+        uint128 bootstrapLiquidity = LiquidityAmounts.getLiquidityForAmounts(
+            stalePriceX96, sqrtPriceLowerX96, sqrtPriceUpperX96, bootstrapEth, bootstrapTokens
+        );
+        (BalanceDelta bootstrapDelta,) = poolManager.modifyLiquidity(
+            key,
+            ModifyLiquidityParams({
+                tickLower: tickLower,
+                tickUpper: tickUpper,
+                liquidityDelta: int256(uint256(bootstrapLiquidity)),
+                salt: salt
+            }),
+            ""
+        );
+        // Capture what the bootstrap mint ACTUALLY cost, not the nominal
+        // allocation — LiquidityAmounts.getLiquidityForAmounts conservatively
+        // rounds down, so any rounding "savings" flow into the final mint's
+        // available balance instead of becoming untracked residue.
+        (uint256 bootstrapEthPaid, uint256 bootstrapTokensPaid) = _settleMintDelta(state.token, bootstrapDelta);
+
+        // --- Step 2: corrective swap. zeroForOne = true (pay ETH, receive
+        // token) moves price DOWN, which is the correct direction here — this
+        // curve's price (tokens per ETH) only ever falls as more ETH comes in.
+        // Bounded by sqrtPriceLimitX96 = the curve's actual final marginal price.
+        uint160 targetSqrtPriceX96 = _computeSqrtPriceX96(VIRTUAL_ETH + ethAvailable, VIRTUAL_TOKEN + tokensAvailable);
+
+        BalanceDelta correctiveDelta = poolManager.swap(
+            key,
+            SwapParams({zeroForOne: true, amountSpecified: -_GRADUATION_SWAP_SENTINEL, sqrtPriceLimitX96: targetSqrtPriceX96}),
+            ""
+        );
+        int128 correctiveEthDelta = correctiveDelta.amount0();
+        int128 correctiveTokenDelta = correctiveDelta.amount1();
+
+        // Sanity: this self-swap must cost us ETH and pay us tokens, matching
+        // the zeroForOne=true direction requested — never the reverse.
+        if (correctiveEthDelta > 0 || correctiveTokenDelta < 0) revert GraduationSwapDirectionInvalid();
+
+        uint256 ethSpentOnCorrection = uint256(uint128(-correctiveEthDelta));
+        uint256 tokensReceivedFromCorrection = uint256(uint128(correctiveTokenDelta));
+        _settleNative(ethSpentOnCorrection);
+        uint256 actualTokensReceived = _takeToken(state.token, tokensReceivedFromCorrection);
+
+        // --- Step 3: final position, using everything not already committed to
+        // the bootstrap mint or spent/received in the corrective swap, minted at
+        // the now-corrected price.
+        uint256 ethRemaining = ethAvailable - bootstrapEthPaid - ethSpentOnCorrection;
+        uint256 tokensRemaining = tokensAvailable - bootstrapTokensPaid + actualTokensReceived;
+
+        uint128 finalLiquidity = LiquidityAmounts.getLiquidityForAmounts(
+            targetSqrtPriceX96, sqrtPriceLowerX96, sqrtPriceUpperX96, ethRemaining, tokensRemaining
+        );
+        (BalanceDelta finalDelta,) = poolManager.modifyLiquidity(
+            key,
+            ModifyLiquidityParams({
+                tickLower: tickLower,
+                tickUpper: tickUpper,
+                liquidityDelta: int256(uint256(finalLiquidity)),
+                salt: salt
+            }),
+            ""
+        );
+        (uint256 ethDeployed, uint256 tokensDeployed) = _settleMintDelta(state.token, finalDelta);
+
+        // Whatever's left in the hook's own balance after both mints is honest,
+        // reported dust — not deposited anywhere.
+        uint256 ethDust = ethRemaining - ethDeployed;
+        uint256 tokenDust = tokensRemaining - tokensDeployed;
+        ethDustBalances[poolId] = ethDust;
+        tokenDustBalances[poolId] = tokenDust;
+
+        emit GraduationLiquidityDeployed(poolId, bootstrapLiquidity, finalLiquidity, targetSqrtPriceX96, ethDust, tokenDust);
+    }
+
+    /// @dev Settles a modifyLiquidity() mint's negative (owed-to-pool) deltas. A
+    /// plain mint should never return a positive delta (that would mean the pool
+    /// owes US on a pure add) — a positive value here reverts loudly rather than
+    /// being silently take()n. Returns the exact (ETH, token) amounts actually paid in.
+    function _settleMintDelta(address token, BalanceDelta delta) internal returns (uint256 ethPaid, uint256 tokensPaid) {
+        int128 ethDelta = delta.amount0();
+        int128 tokenDelta = delta.amount1();
+        if (ethDelta > 0 || tokenDelta > 0) revert GraduationMintUnexpectedCredit();
+        ethPaid = uint256(uint128(-ethDelta));
+        tokensPaid = uint256(uint128(-tokenDelta));
+        if (ethPaid > 0) _settleNative(ethPaid);
+        if (tokensPaid > 0) _payToken(token, tokensPaid);
+    }
+
+    // ------------------------------------------------------------------------
+    // Settlement helpers — reimplemented directly against IPoolManager (the
+    // reference pattern in v4-core's test/utils/CurrencySettler.sol is
+    // test-only and not meant to be imported into production contracts; this is
+    // an independent implementation of the same publicly-documented
+    // sync/transfer/settle and take mechanics, not a copy).
+    // ------------------------------------------------------------------------
+    function _takeNative(uint256 amount) internal {
+        poolManager.take(Currency.wrap(address(0)), address(this), amount);
+    }
+
+    function _settleNative(uint256 amount) internal {
+        poolManager.settle{value: amount}();
+    }
+
+    /// @return actualReceived The measured balance delta on the PoolManager, not
+    /// the nominal `amount` — fee-on-transfer safe by construction.
+    function _takeToken(address token, uint256 amount) internal returns (uint256 actualReceived) {
+        uint256 balanceBefore = IERC20(token).balanceOf(address(this));
+        poolManager.take(Currency.wrap(token), address(this), amount);
+        actualReceived = IERC20(token).balanceOf(address(this)) - balanceBefore;
+    }
+
+    function _settleToken(address token, uint256 amount) internal {
+        poolManager.sync(Currency.wrap(token));
+        bool success = IERC20(token).transfer(address(poolManager), amount);
+        if (!success) revert TokenTransferFailed();
+        poolManager.settle();
+    }
+
+    // ------------------------------------------------------------------------
+    // ERC-6909 claim helpers — the ONLY new code in this file vs. NoPostGradFee.
+    // See the contract header's "THE FIX" for why each of these is safe.
+    // ------------------------------------------------------------------------
+
+    /// @dev PoolManager's ERC-6909 claim id for `token`: CurrencyLibrary.toId(),
+    ///      the exact derivation PoolManager.mint()/burn() round-trip through.
+    function _claimId(address token) internal pure returns (uint256) {
+        return Currency.wrap(token).toId();
+    }
+
+    /// @dev Resolves this hook's +amount inbound token credit as claims. mint()
+    ///      debits the hook's delta by `amount` and credits its claim balance —
+    ///      pure ledger, no token transfer, no physical backing required at this
+    ///      instant (verified against the installed PoolManager.sol, not assumed).
+    function _receiveTokenAsClaims(address token, uint256 amount) internal {
+        poolManager.mint(address(this), _claimId(token), amount);
+    }
+
+    /// @dev Resolves this hook's -amount outbound token debit. Burns claims first
+    ///      (burn() CREDITS the hook's delta by the burned amount; those tokens are
+    ///      already physically inside PoolManager, deposited by earlier sellers'
+    ///      own settles), then settles any remainder from this hook's physical
+    ///      balance exactly as NoPostGradFee always did. Either path nets the
+    ///      debit to zero; the split is invisible to the caller.
+    function _payToken(address token, uint256 amount) internal {
+        uint256 id = _claimId(token);
+        uint256 claims = poolManager.balanceOf(address(this), id);
+        uint256 fromClaims = claims < amount ? claims : amount;
+        if (fromClaims > 0) poolManager.burn(address(this), id, fromClaims);
+        uint256 remainder = amount - fromClaims;
+        if (remainder > 0) _settleToken(token, remainder);
+    }
+
+    // ------------------------------------------------------------------------
+    // Math helpers
+    // ------------------------------------------------------------------------
+
+    /// @dev sqrtPriceX96 for a pool where amount0 = amount of currency0 (native ETH)
+    ///      and amount1 = amount of currency1 (the Incentifi token) at the target
+    ///      price. Computed as sqrt(amount1) * 2^96 / sqrt(amount0) rather than the
+    ///      more direct sqrt(amount1 * 2^192 / amount0), to avoid the 512-bit
+    ///      intermediate multiplication that direct form would need.
+    /// @notice The single source of truth for the correct $5,000-market-cap starting
+    ///         price, exposed publicly so IncentifiV4Factory calls this directly
+    ///         instead of recomputing the same math independently.
+    function launchSqrtPriceX96() public pure returns (uint160) {
+        return _computeSqrtPriceX96(VIRTUAL_ETH, VIRTUAL_TOKEN + TOTAL_SUPPLY);
+    }
+
+    function _computeSqrtPriceX96(uint256 amount0, uint256 amount1) internal pure returns (uint160) {
+        uint256 sqrtAmount0 = _sqrt(amount0);
+        uint256 sqrtAmount1 = _sqrt(amount1);
+        return uint160((sqrtAmount1 << 96) / sqrtAmount0);
+    }
+
+    function _sqrt(uint256 x) internal pure returns (uint256 y) {
+        if (x == 0) return 0;
+        uint256 z = (x + 1) / 2;
+        y = x;
+        while (z < y) {
+            y = z;
+            z = (x / z + z) / 2;
+        }
+    }
+
+    function _toInt128(uint256 x) internal pure returns (int128) {
+        require(x <= uint256(uint128(type(int128).max)), "overflow");
+        return int128(uint128(x));
+    }
+
+    receive() external payable {}
+}

--- a/contracts/v4/IncentifiV4HookNoPostGradFee.sol
+++ b/contracts/v4/IncentifiV4HookNoPostGradFee.sol
@@ -1,0 +1,787 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+// NOTE: imported via @uniswap/v4-periphery's OWN nested v4-core copy
+// (node_modules/@uniswap/v4-periphery/lib/v4-core/), not the top-level
+// @uniswap/v4-core package, even though both are byte-for-byte identical
+// (confirmed via diff) and the same version (1.0.2). Uniswap/v4-periphery's
+// BaseHook.sol resolves ITS @uniswap/v4-core/... imports through its own
+// bundled lib/v4-core/ via that package's remappings.txt, so importing the
+// top-level copy here produced two structurally-identical but type-DISTINCT
+// copies of IPoolManager/Currency/Hooks.Permissions/etc. — real compiler
+// errors ("Invalid implicit conversion from contract IPoolManager to contract
+// IPoolManager", "Overriding function return types differ") the first time
+// this was compiled. Importing through the same nested path BaseHook.sol uses
+// makes every type identity match.
+import {BaseHook} from "@uniswap/v4-periphery/src/utils/BaseHook.sol";
+import {Hooks} from "@uniswap/v4-periphery/lib/v4-core/src/libraries/Hooks.sol";
+import {IPoolManager} from "@uniswap/v4-periphery/lib/v4-core/src/interfaces/IPoolManager.sol";
+import {PoolKey} from "@uniswap/v4-periphery/lib/v4-core/src/types/PoolKey.sol";
+import {PoolId, PoolIdLibrary} from "@uniswap/v4-periphery/lib/v4-core/src/types/PoolId.sol";
+import {Currency} from "@uniswap/v4-periphery/lib/v4-core/src/types/Currency.sol";
+import {BalanceDelta} from "@uniswap/v4-periphery/lib/v4-core/src/types/BalanceDelta.sol";
+import {BeforeSwapDelta, BeforeSwapDeltaLibrary, toBeforeSwapDelta} from "@uniswap/v4-periphery/lib/v4-core/src/types/BeforeSwapDelta.sol";
+import {SwapParams, ModifyLiquidityParams} from "@uniswap/v4-periphery/lib/v4-core/src/types/PoolOperation.sol";
+import {TickMath} from "@uniswap/v4-periphery/lib/v4-core/src/libraries/TickMath.sol";
+// LiquidityAmounts is imported from periphery's TOP-LEVEL path (not the nested
+// lib/v4-core one everything else here uses) deliberately: it only operates on
+// primitive uint160/uint256 values, never on a PoolKey/Currency/IPoolManager
+// struct or contract instance, so the type-identity problem documented above
+// (why every other import here goes through the nested path) does not apply to
+// it — there is no struct/contract type for the two copies to disagree about.
+import {LiquidityAmounts} from "@uniswap/v4-periphery/src/libraries/LiquidityAmounts.sol";
+
+interface IERC20 {
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address recipient, uint256 amount) external returns (bool);
+}
+
+interface ILossRewardPool {
+    function depositReward(address token) external payable;
+}
+
+/**
+ * @title IncentifiV4HookNoPostGradFee
+ * @notice The CORE IncentifiV4Hook bonding-curve + graduation logic — mining,
+ *         beforeInitialize price gating, beforeAddLiquidity restriction,
+ *         beforeSwap full-absorption pricing, and the real V4 liquidity-deposit
+ *         graduation — WITHOUT the afterSwap post-graduation fee mechanism.
+ *         Four permission flags only (beforeInitialize, beforeAddLiquidity,
+ *         beforeSwap, beforeSwapReturnDelta); no afterSwap, no
+ *         afterSwapReturnDelta. Once a pool graduates, this hook gets out of
+ *         the way entirely (a plain ZERO_DELTA pass-through in beforeSwap) and
+ *         the pool trades as a completely standard, fee-free-from-Incentifi
+ *         permissionless V4 pool — no 2% protocol fee, no creator fee, no
+ *         LossRewardPool deposit on any post-graduation trade. Pre-graduation
+ *         economics (2%/1%/1% split, pull-payment creator fees, virtual-reserve
+ *         pricing) are unchanged and identical to IncentifiV4Hook.sol.
+ *
+ * @dev PROVENANCE: there is no separate git commit for "IncentifiV4Hook.sol
+ *      before the afterSwap addition" — the whole V4 system landed in one
+ *      commit. This file is NOT a from-scratch strip-down of the current
+ *      production hook; it is contracts/v4/test-deployment/IncentifiV4HookTestnet.sol's
+ *      logic verbatim (that file already IS this exact pre-afterSwap shape —
+ *      4 permission flags, no afterSwap, no GraduatedFeeCollected, a plain
+ *      pass-through once graduated — proven on a fork AND on real Robinhood
+ *      Chain mainnet via scripts/deploy-testnet-mainnet.ts), with ONLY its
+ *      economic constants restored to full production scale
+ *      (VIRTUAL_ETH/GRADUATION_ETH_TARGET, unscaled — $5,000 launch / $69,000
+ *      graduation) and wired to the REAL production LossRewardPool instead of
+ *      a throwaway one. Reusing already-proven logic here, rather than hand-
+ *      editing IncentifiV4Hook.sol to remove afterSwap, avoids introducing a
+ *      fresh, never-tested code combination into a contract meant to touch the
+ *      real production LossRewardPool at real production economics.
+ *
+ * @dev IMPORTANT — this is the FIRST time this exact combination (production
+ *      economics + the real production LossRewardPool) has been exercised
+ *      anywhere, on a fork or otherwise: the only real-mainnet run of this
+ *      logic (this morning) used 1/50-scaled economics and a throwaway pool;
+ *      the only run against production economics (v4-hook-deployment.test.ts)
+ *      used the SIX-flag hook with afterSwap, and a fork, not this file. The
+ *      economics and graduation/liquidity-deposit MECHANICS here are unchanged
+ *      from both of those, so the risk is materially lower than deploying the
+ *      six-flag hook untested — but "materially lower" is not "zero", and this
+ *      specific combination has not itself been fork-tested end-to-end before
+ *      real deployment.
+ *
+ * @dev PAIRING CURRENCY: native ETH (Currency.wrap(address(0))), not WETH. Two reasons:
+ *      (1) V4 supports native ETH as a first-class currency, avoiding a wrap/unwrap
+ *          round-trip on every trade that the v3 architecture needed.
+ *      (2) address(0) is numerically the smallest possible address, so currency0 is
+ *          *always* ETH and currency1 is *always* the Incentifi token, for every pool,
+ *          unconditionally. This structurally eliminates the "token address < WETH
+ *          address" ordering bug class that required a dedicated fix
+ *          (_computeSqrtPriceX96 in IncentifiBondingCurve.sol) on the v3 side. There is
+ *          no equivalent bug surface here because there is no ordering ambiguity to get
+ *          wrong in the first place.
+ */
+contract IncentifiV4HookNoPostGradFee is BaseHook {
+    using PoolIdLibrary for PoolKey;
+
+    // ------------------------------------------------------------------------
+    // Economic constants — FULL PRODUCTION SCALE, identical to
+    // IncentifiV4Hook.sol. Unlike IncentifiV4HookTestnet.sol (this file's logic
+    // source), these are NOT scaled down: real $5,000 starting market cap, real
+    // $69,000 graduation target.
+    // ------------------------------------------------------------------------
+    uint256 public constant TOTAL_SUPPLY = 1_000_000_000 * 1e18;
+    uint256 public constant VIRTUAL_ETH = 2_156_250_000_000_000_000; // 2.15625 ETH
+    uint256 public constant VIRTUAL_TOKEN = 78_125_000_000_000_000_000_000_000; // 78,125,000 tokens
+    uint256 public constant INVARIANT_K = 2_324_707_031_250_000_000_000_000_000_000_000_000_000_000_000; // 2.32470703125e45
+    uint256 public constant GRADUATION_ETH_TARGET = 5_853_863_234_375_000_000; // 5.853863234375 ETH
+
+    uint256 public constant PROTOCOL_FEE_BPS = 200; // 2.00% total (pre-graduation only)
+    uint256 public constant CREATOR_FEE_BPS = 100; // 1.00%
+    uint256 public constant LOSS_REWARD_FEE_BPS = 100; // 1.00%
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+
+    /// @dev Deliberately oversized exact-input magnitude for _graduate()'s
+    /// corrective swap, so the swap is always bounded by its sqrtPriceLimitX96
+    /// (the actual target price) rather than by this nominal amount — the
+    /// standard "swap up to a price limit" pattern. Never actually paid in full;
+    /// the real, much smaller amount that PoolManager actually consumes is read
+    /// back from the swap's returned delta and settled exactly.
+    int256 private constant _GRADUATION_SWAP_SENTINEL = type(int128).max;
+
+    // ------------------------------------------------------------------------
+    // Immutables
+    // ------------------------------------------------------------------------
+
+    /// @notice The only address permitted to call registerToken() — validation of
+    /// creator identity / total-supply / etc. lives in the factory, mirroring how
+    /// IncentifiBondingCurveFactory.sol validates before deploying a v3 curve.
+    /// @dev NOT immutable, and deliberately not a constructor param — a genuine
+    /// circular dependency, not a test convenience: this hook's own deployment
+    /// address must be mined via CREATE2 to satisfy the permission-bit requirement
+    /// BEFORE IncentifiV4Factory (which takes this hook's address as its own
+    /// constructor arg) can be deployed. If `factory` were a constructor param here,
+    /// neither contract could be deployed first. Resolved with the standard pattern
+    /// for this exact problem: deploy the hook, deploy the factory (now that the
+    /// hook exists to reference), then wire them together with one one-time call —
+    /// not a per-launch admin step, a one-time system bootstrap step.
+    address public factory;
+    address public immutable lossRewardPool;
+    /// @dev The only address allowed to call setFactory() once. Not an ongoing admin
+    /// role: setFactory() is one-time-only (reverts if `factory` is already set), so
+    /// this has no power after bootstrap.
+    /// @dev Passed explicitly as a constructor arg rather than recorded from
+    /// `msg.sender` — this hook is deployed via CREATE2 through the standard
+    /// singleton deployer factory (0x4e59b44847b379578588920cA78FbF26c0B4956C,
+    /// confirmed deployed on Robinhood Chain), which means `msg.sender` during this
+    /// constructor's execution would be that FACTORY PROXY, not the actual deployer's
+    /// EOA. Recording `msg.sender` here would make setFactory() permanently
+    /// uncallable by anyone with a private key. Caught by reasoning through the
+    /// deployment path before attempting it, not from a failed deployment.
+    address public immutable deployer;
+
+    // ------------------------------------------------------------------------
+    // Per-pool state (shared-hook model)
+    // ------------------------------------------------------------------------
+    struct TokenCurveState {
+        address token;
+        address creator;
+        bool initialized;
+        bool graduated;
+        uint256 realEthReserve;
+        uint256 realTokenReserve;
+    }
+
+    mapping(PoolId => TokenCurveState) public curveStates;
+
+    /// @notice Pull-payment creator balances, GLOBAL across every token this hook
+    /// serves (keyed by creator address, not by pool) — a single creator who
+    /// launches multiple tokens accrues into one claimable balance, and claims once
+    /// via claimCreatorFees() regardless of which of their tokens earned the fee.
+    mapping(address => uint256) public creatorBalances;
+
+    /// @notice token => creator, set by the factory via registerToken() before it
+    /// calls PoolManager.initialize(). Consumed and cleared by _beforeInitialize().
+    mapping(address => address) public pendingCreator;
+
+    /// @notice Leftover ETH/token from _graduate()'s reserve-ratio-vs-marginal-
+    /// price mismatch (see _graduate()'s doc comment), keyed by PoolId so it is
+    /// never confused with any other pool's dust or claim. Written once, at
+    /// graduation, alongside the GraduationLiquidityDeployed event — the event is
+    /// history; these mappings are the live, queryable record.
+    ///
+    /// @dev Deliberately kept SEPARATE from creatorBalances, even though both are
+    /// "real ETH sitting in this contract, not yet spent anywhere": creatorBalances
+    /// is a claimable entitlement (someone can withdraw it via claimCreatorFees()),
+    /// while ethDustBalances/tokenDustBalances are only a bookkeeping record of
+    /// value that has NO withdrawal path today (see the token-dust question this
+    /// was raised over) — merging them into one ledger would make an unclaimed
+    /// creator fee and an unspendable dust remainder indistinguishable from a
+    /// single mapping read, which is exactly the "hard to account for" risk this
+    /// pair of mappings exists to close off. tokenDustBalances is close to
+    /// redundant with IERC20(token).balanceOf(address(this)) post-graduation
+    /// (nothing else touches that balance once graduated — see the _beforeSwap
+    /// pass-through), but is recorded anyway for parity with ethDustBalances,
+    /// which has no such convenient equivalent (native ETH is one pooled balance
+    /// shared across every token this hook serves, unlike each token's own
+    /// self-isolating ERC20 balance).
+    mapping(PoolId => uint256) public ethDustBalances;
+    mapping(PoolId => uint256) public tokenDustBalances;
+
+    // ------------------------------------------------------------------------
+    // Events
+    // ------------------------------------------------------------------------
+    event TokenRegistered(address indexed token, address indexed creator);
+    event CurveInitialized(address indexed token, address indexed creator, PoolId poolId);
+    event Bought(PoolId indexed poolId, address indexed trader, uint256 ethIn, uint256 tokensOut, uint256 creatorFee, uint256 lossPoolFee);
+    event Sold(PoolId indexed poolId, address indexed trader, uint256 tokensIn, uint256 ethOut, uint256 creatorFee, uint256 lossPoolFee);
+    event CreatorFeesClaimed(address indexed creator, uint256 amount);
+    event Graduated(PoolId indexed poolId, address indexed token, uint256 finalEthReserve, uint256 finalTokenReserve);
+    /// @param ethDust,tokenDust Real, honestly-reported leftover from the reserve-
+    /// ratio-vs-marginal-price mismatch inherent to migrating a virtual-offset
+    /// bonding curve into a real concentrated-liquidity position — see the long
+    /// comment on _graduate() for why this isn't (and can't cheaply be) zero.
+    event GraduationLiquidityDeployed(
+        PoolId indexed poolId,
+        uint128 bootstrapLiquidity,
+        uint128 finalLiquidity,
+        uint160 correctedSqrtPriceX96,
+        uint256 ethDust,
+        uint256 tokenDust
+    );
+
+    // ------------------------------------------------------------------------
+    // Errors
+    // ------------------------------------------------------------------------
+    error OnlyFactory();
+    error ZeroAddress();
+    error ZeroAmount();
+    error AlreadyPending();
+    error TokenNotRegistered();
+    error AlreadyInitialized();
+    error InsufficientSupply();
+    error MustPairWithNativeEth();
+    error WrongStartingPrice();
+    error PoolNotInitialized();
+    error OnlyExactInputSupported();
+    error InsufficientReserve();
+    error SlippageExceeded();
+    error NoBalanceToClaim();
+    error CannotAddLiquidity();
+    error EthTransferFailed();
+    error TokenTransferFailed();
+    error OnlyDeployer();
+    error FactoryAlreadySet();
+    // Graduation-liquidity-specific — see _graduate()'s doc comment. Both would
+    // indicate a real accounting bug in the corrective-swap/mint math, not a
+    // condition expected to ever actually trigger.
+    error GraduationSwapDirectionInvalid();
+    error GraduationMintUnexpectedCredit();
+
+    constructor(IPoolManager _poolManager, address _lossRewardPool, address _deployer) BaseHook(_poolManager) {
+        if (_lossRewardPool == address(0) || _deployer == address(0)) revert ZeroAddress();
+        lossRewardPool = _lossRewardPool;
+        deployer = _deployer;
+    }
+
+    /// @notice One-time wiring of the factory address, called once immediately after
+    /// both this hook and IncentifiV4Factory are deployed. Not callable again once
+    /// set, and not callable by anyone other than whoever deployed this specific
+    /// hook instance — see the `factory` field's doc comment for why this exists.
+    function setFactory(address _factory) external {
+        if (msg.sender != deployer) revert OnlyDeployer();
+        if (factory != address(0)) revert FactoryAlreadySet();
+        if (_factory == address(0)) revert ZeroAddress();
+        factory = _factory;
+    }
+
+    // ------------------------------------------------------------------------
+    // Hook permissions
+    // ------------------------------------------------------------------------
+    /**
+     * @dev Four flags — NOT the six IncentifiV4Hook.sol declares. No afterSwap:
+     *      - BEFORE_INITIALIZE: validate + finalize a pending token registration at
+     *        the correct starting price before the pool exists.
+     *      - BEFORE_ADD_LIQUIDITY: revert unless caller == address(this) — blocks
+     *        every external LP pre-graduation, protecting the internal reserve
+     *        accounting exactly the way Doppler's own beforeAddLiquidity does
+     *        (pattern studied, not copied — Doppler is BUSL-1.1, this is an
+     *        independent ~3-line reimplementation of an obvious idea).
+     *      - BEFORE_SWAP + BEFORE_SWAP_RETURNS_DELTA: the actual custom-accounting
+     *        override, pre-graduation only. All economics (pricing, fee split,
+     *        settlement, reserve updates, graduation trigger) happen inside
+     *        _beforeSwap. Post-graduation, _beforeSwap returns ZERO_DELTA — a
+     *        pure pass-through, no fee, no custom accounting of any kind.
+     *      AFTER_SWAP is deliberately NOT set: since every pre-graduation swap is
+     *      fully absorbed (100% custom accounting) inside beforeSwap, and every
+     *      post-graduation swap is fully passed through untouched, there is
+     *      nothing left for afterSwap to do in either regime.
+     */
+    function getHookPermissions() public pure override returns (Hooks.Permissions memory) {
+        return Hooks.Permissions({
+            beforeInitialize: true,
+            afterInitialize: false,
+            beforeAddLiquidity: true,
+            afterAddLiquidity: false,
+            beforeRemoveLiquidity: false,
+            afterRemoveLiquidity: false,
+            beforeSwap: true,
+            afterSwap: false,
+            beforeDonate: false,
+            afterDonate: false,
+            beforeSwapReturnDelta: true,
+            afterSwapReturnDelta: false,
+            afterAddLiquidityReturnDelta: false,
+            afterRemoveLiquidityReturnDelta: false
+        });
+    }
+
+    // ------------------------------------------------------------------------
+    // Permissionless launch registration (called by IncentifiV4Factory)
+    // ------------------------------------------------------------------------
+    /**
+     * @notice Records `creator` as the pending creator for `token`, ahead of the
+     *         factory calling PoolManager.initialize() for that token's pool.
+     * @dev Gated to `factory` only — this contract trusts the factory to have
+     *      already validated token.creator() / total supply / etc., mirroring
+     *      IncentifiBondingCurveFactory.registerExistingToken()'s validation.
+     *      The factory must transfer the token's full TOTAL_SUPPLY to this hook
+     *      BEFORE calling PoolManager.initialize() — _beforeInitialize checks for
+     *      that balance and reverts if it isn't there yet.
+     */
+    function registerToken(address token, address creator) external {
+        if (msg.sender != factory) revert OnlyFactory();
+        if (token == address(0) || creator == address(0)) revert ZeroAddress();
+        if (pendingCreator[token] != address(0)) revert AlreadyPending();
+
+        pendingCreator[token] = creator;
+        emit TokenRegistered(token, creator);
+    }
+
+    function _beforeInitialize(address, PoolKey calldata key, uint160 sqrtPriceX96)
+        internal
+        override
+        returns (bytes4)
+    {
+        if (!key.currency0.isAddressZero()) revert MustPairWithNativeEth();
+
+        address token = Currency.unwrap(key.currency1);
+        address creator = pendingCreator[token];
+        if (creator == address(0)) revert TokenNotRegistered();
+
+        PoolId poolId = key.toId();
+        TokenCurveState storage state = curveStates[poolId];
+        if (state.initialized) revert AlreadyInitialized();
+
+        uint256 balance = IERC20(token).balanceOf(address(this));
+        if (balance < TOTAL_SUPPLY) revert InsufficientSupply();
+
+        // Defend against anyone initializing at a wrong price: PoolManager.initialize()
+        // is permissionless at the PoolManager level, so without this check a
+        // front-runner could initialize this exact PoolKey at an arbitrary price before
+        // the factory's own initialize() call lands. Only the one correct $5,000
+        // starting price (VIRTUAL_TOKEN / VIRTUAL_ETH ratio) is accepted.
+        if (sqrtPriceX96 != launchSqrtPriceX96()) revert WrongStartingPrice();
+
+        state.token = token;
+        state.creator = creator;
+        state.initialized = true;
+        state.realEthReserve = 0;
+        state.realTokenReserve = TOTAL_SUPPLY;
+
+        delete pendingCreator[token];
+
+        emit CurveInitialized(token, creator, poolId);
+        return BaseHook.beforeInitialize.selector;
+    }
+
+    /// @dev Pre-graduation, liquidity may ONLY come from this hook itself (the
+    ///      _graduate() mint below) — an external LP adding liquidity while the
+    ///      curve is still active would corrupt the full-absorption invariant this
+    ///      hook depends on (a real, non-zero-liquidity core pool would start
+    ///      partially filling swaps itself, which _beforeSwap's OnlyExactInputSupported
+    ///      / full-absorption math does not account for). Once graduated, this
+    ///      pool is a genuine, permanently-real AMM pool with no more curve
+    ///      invariant to protect — so, unlike the permanently-hook-only v3 LP
+    ///      position (minted once, then burned/locked forever), this DOES open up
+    ///      to any external LP after graduation, same as a completely standard,
+    ///      permissionless V4 pool. Flagging this as a deliberate departure from
+    ///      v3's parity, not an oversight.
+    function _beforeAddLiquidity(address caller, PoolKey calldata key, ModifyLiquidityParams calldata, bytes calldata)
+        internal
+        view
+        override
+        returns (bytes4)
+    {
+        if (caller != address(this) && !curveStates[key.toId()].graduated) revert CannotAddLiquidity();
+        return BaseHook.beforeAddLiquidity.selector;
+    }
+
+    // ------------------------------------------------------------------------
+    // Core custom-accounting swap logic
+    // ------------------------------------------------------------------------
+    /**
+     * @dev Delta-application semantics below are transcribed from the ACTUAL
+     *      Hooks.sol I read (v4-core 1.0.2), not assumed:
+     *
+     *        amountToSwap = params.amountSpecified;
+     *        amountToSwap += hookReturn.getSpecifiedDelta();
+     *        revert if (exactInput && amountToSwap > 0)   // exactInput = original amountSpecified < 0
+     *
+     *      We only support exact-input swaps (amountSpecified < 0) — this hook has
+     *      no real liquidity backing it, so any amount left for the "core" pool to
+     *      process after our delta would hit a liquidity-less pool and revert
+     *      anyway; full absorption is the only valid mode, and OnlyExactInputSupported
+     *      documents that as a deliberate constraint, not an oversight.
+     *
+     *      Setting hookDeltaSpecified = -params.amountSpecified makes amountToSwap
+     *      land at exactly 0 — the core pool does nothing, all economics are ours.
+     *
+     *      Router's own final delta (from Hooks.afterSwap: swapDelta = coreDelta -
+     *      hookDelta, and coreDelta is (0,0) here since amountToSwap is 0) works out
+     *      to -hookDelta. Confirmed sign convention from Hooks.sol/CurrencySettler.sol
+     *      (test-path reference, read but not imported): positive hook delta = hook
+     *      take()s that amount FROM the PoolManager; negative = hook settle()s
+     *      (pays) that amount INTO the PoolManager.
+     *
+     *      BUY (zeroForOne, ETH -> TOKEN): specified = currency0 (ETH). We take() the
+     *      buyer's incoming ETH (hookDeltaSpecified > 0), and settle() the token
+     *      output (hookDeltaUnspecified < 0) so the router can take() it out for the
+     *      buyer. SELL is the mirror image with the specified/unspecified currencies
+     *      swapped and native-ETH settle() replacing ERC20 settle().
+     *
+     * @dev KNOWN GAP vs. IncentifiBondingCurve.buy(): the v3 contract clamps grossEth
+     *      to the graduation boundary and refunds any excess directly from within
+     *      buy() itself, because it holds msg.value directly. That refund mechanism
+     *      does not translate here: a hook that only partially absorbs
+     *      amountSpecified leaves the remainder for the core (liquidity-less) pool to
+     *      process, which would revert. This version does NOT clamp/refund — an
+     *      overshooting buy is accepted in full, and any excess beyond the exact
+     *      graduation target is carried into the reserve that gets migrated at
+     *      graduation rather than refunded to the buyer. Clamping with a refund
+     *      happens one layer up, in IncentifiV4Router (compute the clamped amount
+     *      via a view call before ever submitting the swap, refund any excess
+     *      before calling PoolManager.unlock()).
+     */
+    function _beforeSwap(address, PoolKey calldata key, SwapParams calldata params, bytes calldata)
+        internal
+        override
+        returns (bytes4, BeforeSwapDelta, uint24)
+    {
+        PoolId poolId = key.toId();
+        TokenCurveState storage state = curveStates[poolId];
+        if (!state.initialized) revert PoolNotInitialized();
+
+        // POST-GRADUATION PASS-THROUGH: once _graduate() has deposited real
+        // concentrated liquidity into the core pool, this hook gets out of the
+        // way entirely and lets the core AMM execute the trade against that real
+        // liquidity — returning ZERO_DELTA here means "the hook claims none of the
+        // swap amount", so the core pool processes 100% of it normally, exactly as
+        // if this were an ordinary hookless (or no-op-hook) pool. No fee of any
+        // kind (protocol, creator, or LossRewardPool) is taken on any
+        // post-graduation trade — this is the deliberate difference from
+        // IncentifiV4Hook.sol's afterSwap-based post-graduation fee mechanism.
+        //
+        // beforeSwap is a MANDATORY hook once BEFORE_SWAP_FLAG is set — PoolManager
+        // calls it on every single swap for this pool's lifetime, with no way to
+        // "turn it off". An earlier iteration of this logic unconditionally
+        // reverted here once graduated, which would have permanently bricked the
+        // pool for trading the moment graduation completed — caught while
+        // implementing the real liquidity deposit, not by inspection beforehand.
+        if (state.graduated) {
+            return (BaseHook.beforeSwap.selector, BeforeSwapDeltaLibrary.ZERO_DELTA, 0);
+        }
+
+        if (params.amountSpecified >= 0) revert OnlyExactInputSupported();
+
+        uint256 amountIn = uint256(-params.amountSpecified);
+        if (amountIn == 0) revert ZeroAmount();
+
+        int128 hookDeltaSpecified = int128(-params.amountSpecified);
+        int128 hookDeltaUnspecified;
+
+        if (params.zeroForOne) {
+            // BUY: ETH in (specified, currency0), TOKEN out (unspecified, currency1)
+            uint256 tokensOut = _executeBuy(state, poolId, key, amountIn);
+            hookDeltaUnspecified = -_toInt128(tokensOut);
+        } else {
+            // SELL: TOKEN in (specified, currency1), ETH out (unspecified, currency0)
+            uint256 netEthOut = _executeSell(state, poolId, amountIn);
+            hookDeltaUnspecified = -_toInt128(netEthOut);
+        }
+
+        BeforeSwapDelta delta = toBeforeSwapDelta(hookDeltaSpecified, hookDeltaUnspecified);
+        return (BaseHook.beforeSwap.selector, delta, 0);
+    }
+
+    /// @dev Mirrors IncentifiBondingCurve.buy() exactly (minus the clamp/refund — see
+    ///      the KNOWN GAP note above), executed as V4 settlement instead of a direct
+    ///      payable call. Fee-on-transfer safety for the token leg comes from V4's
+    ///      own sync()/settle() semantics (balance measured before/after, not a
+    ///      trusted nominal amount) — the same principle as the v3 fix, provided by
+    ///      the platform this time instead of hand-rolled.
+    function _executeBuy(TokenCurveState storage state, PoolId poolId, PoolKey calldata key, uint256 grossEth) internal returns (uint256 tokensOut) {
+        uint256 creatorFee = grossEth / 100;
+        uint256 lossPoolFee = grossEth / 100;
+        uint256 netEth = grossEth - creatorFee - lossPoolFee;
+
+        uint256 newEth = VIRTUAL_ETH + state.realEthReserve + netEth;
+        tokensOut = (VIRTUAL_TOKEN + state.realTokenReserve) - (INVARIANT_K / newEth);
+        if (tokensOut > state.realTokenReserve) revert InsufficientReserve();
+
+        // Take the buyer's ETH from the PoolManager (settled in by the router).
+        _takeNative(grossEth);
+
+        state.realEthReserve += netEth;
+        state.realTokenReserve -= tokensOut;
+
+        if (creatorFee > 0) creatorBalances[state.creator] += creatorFee;
+        if (lossPoolFee > 0) ILossRewardPool(lossRewardPool).depositReward{value: lossPoolFee}(state.token);
+
+        // Settle the token output to the PoolManager so the router can take() it for
+        // the buyer. Measures our own balance delta around the transfer — real
+        // fee-on-transfer safety on the outbound leg too, not just trusted on the
+        // strength of V4's own sync/settle for the inbound leg.
+        _settleToken(state.token, tokensOut);
+
+        emit Bought(poolId, tx.origin, grossEth, tokensOut, creatorFee, lossPoolFee);
+
+        if (state.realEthReserve >= GRADUATION_ETH_TARGET && !state.graduated) {
+            _graduate(state, poolId, key);
+        }
+    }
+
+    /// @dev Mirrors IncentifiBondingCurve.sell() exactly.
+    function _executeSell(TokenCurveState storage state, PoolId poolId, uint256 tokensIn) internal returns (uint256 netEthOut) {
+        // Take the seller's tokens from the PoolManager (settled in by the router),
+        // measuring the actual amount received rather than trusting `tokensIn` —
+        // fee-on-transfer safety on the inbound leg, matching the v3 fix's pattern.
+        uint256 actualTokensIn = _takeToken(state.token, tokensIn);
+        if (actualTokensIn == 0) revert ZeroAmount();
+
+        uint256 currentEth = VIRTUAL_ETH + state.realEthReserve;
+        uint256 currentToken = VIRTUAL_TOKEN + state.realTokenReserve;
+        uint256 newToken = currentToken + actualTokensIn;
+        uint256 newEth = INVARIANT_K / newToken;
+        uint256 grossEthOut = currentEth - newEth;
+        if (grossEthOut > state.realEthReserve) revert InsufficientReserve();
+
+        uint256 creatorFee = grossEthOut / 100;
+        uint256 lossPoolFee = grossEthOut / 100;
+        netEthOut = grossEthOut - creatorFee - lossPoolFee;
+
+        state.realEthReserve -= grossEthOut;
+        state.realTokenReserve += actualTokensIn;
+
+        if (creatorFee > 0) creatorBalances[state.creator] += creatorFee;
+        if (lossPoolFee > 0) ILossRewardPool(lossRewardPool).depositReward{value: lossPoolFee}(state.token);
+
+        _settleNative(netEthOut);
+
+        emit Sold(poolId, tx.origin, actualTokensIn, netEthOut, creatorFee, lossPoolFee);
+    }
+
+    // ------------------------------------------------------------------------
+    // Pull-payment creator claims — same accounting shape as
+    // IncentifiBondingCurve.claimCreatorFees(), just global across pools instead
+    // of scoped to one curve's fixed creator.
+    // ------------------------------------------------------------------------
+    function claimCreatorFees() external {
+        uint256 amount = creatorBalances[msg.sender];
+        if (amount == 0) revert NoBalanceToClaim();
+
+        creatorBalances[msg.sender] = 0;
+        (bool success,) = msg.sender.call{value: amount}("");
+        if (!success) revert EthTransferFailed();
+
+        emit CreatorFeesClaimed(msg.sender, amount);
+    }
+
+    // ------------------------------------------------------------------------
+    // Graduation — real V4 liquidity deposit. Identical to IncentifiV4Hook.sol's
+    // _graduate() — this part of the logic is unaffected by the afterSwap
+    // question, since it runs exactly once, at the graduation boundary, before
+    // any post-graduation trade (fee-bearing or not) ever occurs.
+    //
+    // THE PROBLEM THIS SOLVES (genuinely V4-specific — there is no v3 equivalent
+    // to copy): v3's _graduate() creates its Uniswap V3 pool for the FIRST TIME
+    // at graduation, computing that pool's initial sqrtPriceX96 directly FROM the
+    // exact real reserve amounts being deposited — so there is no pre-existing
+    // on-chain price to reconcile, by construction. This V4 hook's pool, by
+    // contrast, was already initialized and tradeable at PoolManager.initialize()
+    // time. So by the time graduation is reached, PoolManager's slot0 for this
+    // pool is STILL sitting at the original $5,000-market-cap launch price,
+    // while the curve's real economics have moved the fair price far below that.
+    // Mint a real liquidity position at that stale price with no correction, and
+    // the very first post-graduation swapper gets a massive, structural
+    // arbitrage against the newly seeded liquidity — a real solvency bug.
+    //
+    // THE FIX: mint a small bootstrap position at the stale price (just enough
+    // real liquidity to trade against), execute one real, hook-bypassed
+    // corrective swap that walks the core pool's tracked price down to the
+    // curve's true final marginal price (bounded exactly by sqrtPriceLimitX96,
+    // so it cannot overshoot), then mint the bulk of the remaining reserves as a
+    // second position at the now-correct price. Both positions are full-range
+    // and use the same salt, so they merge into a single combined position.
+    // ------------------------------------------------------------------------
+    function _graduate(TokenCurveState storage state, PoolId poolId, PoolKey calldata key) internal {
+        state.graduated = true;
+
+        uint256 ethAvailable = state.realEthReserve;
+        uint256 tokensAvailable = state.realTokenReserve;
+
+        emit Graduated(poolId, state.token, ethAvailable, tokensAvailable);
+
+        if (ethAvailable == 0 || tokensAvailable == 0) {
+            // Nothing real to seed as liquidity. Not expected to trigger given
+            // GRADUATION_ETH_TARGET > 0 and the curve's invariant guaranteeing
+            // some unsold supply remains at that target — but the state flip
+            // above still stands regardless; explicitly not treated as an error.
+            return;
+        }
+
+        int24 tickSpacing = key.tickSpacing;
+        int24 tickLower = TickMath.minUsableTick(tickSpacing);
+        int24 tickUpper = TickMath.maxUsableTick(tickSpacing);
+        uint160 sqrtPriceLowerX96 = TickMath.getSqrtPriceAtTick(tickLower);
+        uint160 sqrtPriceUpperX96 = TickMath.getSqrtPriceAtTick(tickUpper);
+        bytes32 salt = bytes32(0);
+
+        // --- Step 1: small bootstrap position at the pool's current (stale)
+        // tracked price, purely so the corrective swap below has real liquidity
+        // to trade against. Sized as 0.1% of the real reserves.
+        uint256 bootstrapEth = ethAvailable / 1000;
+        uint256 bootstrapTokens = tokensAvailable / 1000;
+        uint160 stalePriceX96 = launchSqrtPriceX96(); // == this pool's actual current slot0, by construction
+
+        uint128 bootstrapLiquidity = LiquidityAmounts.getLiquidityForAmounts(
+            stalePriceX96, sqrtPriceLowerX96, sqrtPriceUpperX96, bootstrapEth, bootstrapTokens
+        );
+        (BalanceDelta bootstrapDelta,) = poolManager.modifyLiquidity(
+            key,
+            ModifyLiquidityParams({
+                tickLower: tickLower,
+                tickUpper: tickUpper,
+                liquidityDelta: int256(uint256(bootstrapLiquidity)),
+                salt: salt
+            }),
+            ""
+        );
+        // Capture what the bootstrap mint ACTUALLY cost, not the nominal
+        // allocation — LiquidityAmounts.getLiquidityForAmounts conservatively
+        // rounds down, so any rounding "savings" flow into the final mint's
+        // available balance instead of becoming untracked residue.
+        (uint256 bootstrapEthPaid, uint256 bootstrapTokensPaid) = _settleMintDelta(state.token, bootstrapDelta);
+
+        // --- Step 2: corrective swap. zeroForOne = true (pay ETH, receive
+        // token) moves price DOWN, which is the correct direction here — this
+        // curve's price (tokens per ETH) only ever falls as more ETH comes in.
+        // Bounded by sqrtPriceLimitX96 = the curve's actual final marginal price.
+        uint160 targetSqrtPriceX96 = _computeSqrtPriceX96(VIRTUAL_ETH + ethAvailable, VIRTUAL_TOKEN + tokensAvailable);
+
+        BalanceDelta correctiveDelta = poolManager.swap(
+            key,
+            SwapParams({zeroForOne: true, amountSpecified: -_GRADUATION_SWAP_SENTINEL, sqrtPriceLimitX96: targetSqrtPriceX96}),
+            ""
+        );
+        int128 correctiveEthDelta = correctiveDelta.amount0();
+        int128 correctiveTokenDelta = correctiveDelta.amount1();
+
+        // Sanity: this self-swap must cost us ETH and pay us tokens, matching
+        // the zeroForOne=true direction requested — never the reverse.
+        if (correctiveEthDelta > 0 || correctiveTokenDelta < 0) revert GraduationSwapDirectionInvalid();
+
+        uint256 ethSpentOnCorrection = uint256(uint128(-correctiveEthDelta));
+        uint256 tokensReceivedFromCorrection = uint256(uint128(correctiveTokenDelta));
+        _settleNative(ethSpentOnCorrection);
+        uint256 actualTokensReceived = _takeToken(state.token, tokensReceivedFromCorrection);
+
+        // --- Step 3: final position, using everything not already committed to
+        // the bootstrap mint or spent/received in the corrective swap, minted at
+        // the now-corrected price.
+        uint256 ethRemaining = ethAvailable - bootstrapEthPaid - ethSpentOnCorrection;
+        uint256 tokensRemaining = tokensAvailable - bootstrapTokensPaid + actualTokensReceived;
+
+        uint128 finalLiquidity = LiquidityAmounts.getLiquidityForAmounts(
+            targetSqrtPriceX96, sqrtPriceLowerX96, sqrtPriceUpperX96, ethRemaining, tokensRemaining
+        );
+        (BalanceDelta finalDelta,) = poolManager.modifyLiquidity(
+            key,
+            ModifyLiquidityParams({
+                tickLower: tickLower,
+                tickUpper: tickUpper,
+                liquidityDelta: int256(uint256(finalLiquidity)),
+                salt: salt
+            }),
+            ""
+        );
+        (uint256 ethDeployed, uint256 tokensDeployed) = _settleMintDelta(state.token, finalDelta);
+
+        // Whatever's left in the hook's own balance after both mints is honest,
+        // reported dust — not deposited anywhere.
+        uint256 ethDust = ethRemaining - ethDeployed;
+        uint256 tokenDust = tokensRemaining - tokensDeployed;
+        ethDustBalances[poolId] = ethDust;
+        tokenDustBalances[poolId] = tokenDust;
+
+        emit GraduationLiquidityDeployed(poolId, bootstrapLiquidity, finalLiquidity, targetSqrtPriceX96, ethDust, tokenDust);
+    }
+
+    /// @dev Settles a modifyLiquidity() mint's negative (owed-to-pool) deltas. A
+    /// plain mint should never return a positive delta (that would mean the pool
+    /// owes US on a pure add) — a positive value here reverts loudly rather than
+    /// being silently take()n. Returns the exact (ETH, token) amounts actually paid in.
+    function _settleMintDelta(address token, BalanceDelta delta) internal returns (uint256 ethPaid, uint256 tokensPaid) {
+        int128 ethDelta = delta.amount0();
+        int128 tokenDelta = delta.amount1();
+        if (ethDelta > 0 || tokenDelta > 0) revert GraduationMintUnexpectedCredit();
+        ethPaid = uint256(uint128(-ethDelta));
+        tokensPaid = uint256(uint128(-tokenDelta));
+        if (ethPaid > 0) _settleNative(ethPaid);
+        if (tokensPaid > 0) _settleToken(token, tokensPaid);
+    }
+
+    // ------------------------------------------------------------------------
+    // Settlement helpers — reimplemented directly against IPoolManager (the
+    // reference pattern in v4-core's test/utils/CurrencySettler.sol is
+    // test-only and not meant to be imported into production contracts; this is
+    // an independent implementation of the same publicly-documented
+    // sync/transfer/settle and take mechanics, not a copy).
+    // ------------------------------------------------------------------------
+    function _takeNative(uint256 amount) internal {
+        poolManager.take(Currency.wrap(address(0)), address(this), amount);
+    }
+
+    function _settleNative(uint256 amount) internal {
+        poolManager.settle{value: amount}();
+    }
+
+    /// @return actualReceived The measured balance delta on the PoolManager, not
+    /// the nominal `amount` — fee-on-transfer safe by construction.
+    function _takeToken(address token, uint256 amount) internal returns (uint256 actualReceived) {
+        uint256 balanceBefore = IERC20(token).balanceOf(address(this));
+        poolManager.take(Currency.wrap(token), address(this), amount);
+        actualReceived = IERC20(token).balanceOf(address(this)) - balanceBefore;
+    }
+
+    function _settleToken(address token, uint256 amount) internal {
+        poolManager.sync(Currency.wrap(token));
+        bool success = IERC20(token).transfer(address(poolManager), amount);
+        if (!success) revert TokenTransferFailed();
+        poolManager.settle();
+    }
+
+    // ------------------------------------------------------------------------
+    // Math helpers
+    // ------------------------------------------------------------------------
+
+    /// @dev sqrtPriceX96 for a pool where amount0 = amount of currency0 (native ETH)
+    ///      and amount1 = amount of currency1 (the Incentifi token) at the target
+    ///      price. Computed as sqrt(amount1) * 2^96 / sqrt(amount0) rather than the
+    ///      more direct sqrt(amount1 * 2^192 / amount0), to avoid the 512-bit
+    ///      intermediate multiplication that direct form would need.
+    /// @notice The single source of truth for the correct $5,000-market-cap starting
+    ///         price, exposed publicly so IncentifiV4Factory calls this directly
+    ///         instead of recomputing the same math independently.
+    function launchSqrtPriceX96() public pure returns (uint160) {
+        return _computeSqrtPriceX96(VIRTUAL_ETH, VIRTUAL_TOKEN + TOTAL_SUPPLY);
+    }
+
+    function _computeSqrtPriceX96(uint256 amount0, uint256 amount1) internal pure returns (uint160) {
+        uint256 sqrtAmount0 = _sqrt(amount0);
+        uint256 sqrtAmount1 = _sqrt(amount1);
+        return uint160((sqrtAmount1 << 96) / sqrtAmount0);
+    }
+
+    function _sqrt(uint256 x) internal pure returns (uint256 y) {
+        if (x == 0) return 0;
+        uint256 z = (x + 1) / 2;
+        y = x;
+        while (z < y) {
+            y = z;
+            z = (x / z + z) / 2;
+        }
+    }
+
+    function _toInt128(uint256 x) internal pure returns (int128) {
+        require(x <= uint256(uint128(type(int128).max)), "overflow");
+        return int128(uint128(x));
+    }
+
+    receive() external payable {}
+}

--- a/contracts/v4/IncentifiV4Router.sol
+++ b/contracts/v4/IncentifiV4Router.sol
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {IPoolManager} from "@uniswap/v4-periphery/lib/v4-core/src/interfaces/IPoolManager.sol";
+import {IUnlockCallback} from "@uniswap/v4-periphery/lib/v4-core/src/interfaces/callback/IUnlockCallback.sol";
+import {PoolKey} from "@uniswap/v4-periphery/lib/v4-core/src/types/PoolKey.sol";
+import {PoolId} from "@uniswap/v4-periphery/lib/v4-core/src/types/PoolId.sol";
+import {Currency} from "@uniswap/v4-periphery/lib/v4-core/src/types/Currency.sol";
+import {BalanceDelta} from "@uniswap/v4-periphery/lib/v4-core/src/types/BalanceDelta.sol";
+import {SwapParams} from "@uniswap/v4-periphery/lib/v4-core/src/types/PoolOperation.sol";
+
+import {IncentifiV4Hook} from "./IncentifiV4Hook.sol";
+import {IncentifiV4Factory} from "./IncentifiV4Factory.sol";
+
+interface IERC20 {
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address recipient, uint256 amount) external returns (bool);
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+}
+
+/**
+ * @title IncentifiV4Router
+ * @notice Purpose-built buy()/sell() entrypoint, mirroring IncentifiSwapRouter.sol's
+ *         (v3) ABI shape. Resolves the router-vs-Universal-Router question this
+ *         session left open, WITHOUT closing off Universal Router / any generic V4
+ *         router as an alternative path — see reasoning below.
+ *
+ * @dev STATUS: UNTESTED, same standard as the other two v4 contracts. Compiles;
+ *      has never called PoolManager.unlock()/swap() for real.
+ *
+ * @dev ROUTER DECISION (resolved, with reasoning, not silently picked):
+ *      Built this rather than relying solely on the real Universal Router, for two
+ *      concrete reasons surfaced while writing IncentifiV4Hook.sol:
+ *      (1) The graduation-boundary clamp+refund IncentifiBondingCurve.buy() does
+ *          (capping an oversized buy exactly at GRADUATION_ETH_TARGET and refunding
+ *          the excess) cannot live inside the hook's beforeSwap — V4's full-
+ *          absorption custom accounting means partially processing amountSpecified
+ *          would leave a remainder for the core pool to handle against liquidity
+ *          that doesn't exist pre-graduation, which reverts. It has to happen BEFORE
+ *          the swap is ever submitted to PoolManager, which requires a router that
+ *          knows Incentifi-specific business logic. Universal Router has no hook for
+ *          this — it would need the exact clamped amount already computed by the
+ *          time it receives the swap command.
+ *      (2) "No fallback to the old bonding curve" (an explicit hard requirement) is
+ *          trivially, structurally verifiable by reading this file — there is no
+ *          reference to IncentifiBondingCurve anywhere in it. That guarantee is
+ *          harder to state with confidence about Universal Router, a large generic
+ *          contract capable of executing arbitrary command sequences — not because
+ *          it's untrustworthy, but because "no fallback" would then be a property of
+ *          which calldata we happen to send it, not a property of the contract we
+ *          wrote and can fully audit.
+ *
+ *      This does NOT make the pool exclusively tradeable through this router. The
+ *      pool itself is a real, permissionless V4 pool — the fork test's "generic bot"
+ *      check should confirm a raw PoolManager.unlock()/swap() call (or a real
+ *      Universal Router V4_SWAP command) works with zero knowledge of this contract,
+ *      the same way the v3 fork test proved a raw SwapRouter02 call worked without
+ *      going through IncentifiSwapRouter.sol. This router exists for OUR frontend's
+ *      UX and the graduation-clamp logic, not as a gatekeeper.
+ */
+contract IncentifiV4Router is IUnlockCallback {
+    IPoolManager public immutable poolManager;
+    IncentifiV4Hook public immutable hook;
+    IncentifiV4Factory public immutable factory;
+
+    error Expired();
+    error ZeroAmount();
+    error ZeroAddress();
+    error PoolGraduated();
+    error SlippageExceeded();
+    error OnlyPoolManager();
+    error EthTransferFailed();
+    error TokenTransferFailed();
+    error UnknownAction();
+
+    enum Action {
+        Buy,
+        Sell
+    }
+
+    struct CallbackData {
+        Action action;
+        address token;
+        address trader;
+        uint256 amountIn; // clamped ETH (buy) or actual tokens received (sell)
+        uint256 minOut;
+    }
+
+    constructor(IPoolManager _poolManager, IncentifiV4Hook _hook, IncentifiV4Factory _factory) {
+        if (address(_poolManager) == address(0) || address(_hook) == address(0) || address(_factory) == address(0)) {
+            revert ZeroAddress();
+        }
+        poolManager = _poolManager;
+        hook = _hook;
+        factory = _factory;
+    }
+
+    /**
+     * @notice Buy `token` with native ETH.
+     * @dev Clamps `msg.value` to the graduation boundary and refunds any excess
+     *      BEFORE ever calling PoolManager.unlock() — see the ROUTER DECISION note
+     *      above for why this can't happen inside the hook. Reproduces
+     *      IncentifiBondingCurve.buy()'s exact clamp formula.
+     */
+    function buyToken(address token, uint256 minTokensOut, uint256 deadline) external payable returns (uint256 tokensOut) {
+        if (block.timestamp > deadline) revert Expired();
+        if (msg.value == 0) revert ZeroAmount();
+
+        PoolId poolId = factory.getPoolKey(token).toId();
+        (, , , bool graduated, uint256 realEthReserve,) = hook.curveStates(poolId);
+        if (graduated) revert PoolGraduated();
+
+        uint256 grossEth = msg.value;
+        uint256 maxNetEth = hook.GRADUATION_ETH_TARGET() - realEthReserve;
+        uint256 maxGrossEth = 100 * (maxNetEth / 98) + (maxNetEth % 98);
+        if (grossEth > maxGrossEth) {
+            uint256 refund = grossEth - maxGrossEth;
+            grossEth = maxGrossEth;
+            (bool success,) = msg.sender.call{value: refund}("");
+            if (!success) revert EthTransferFailed();
+        }
+
+        bytes memory result = poolManager.unlock(
+            abi.encode(CallbackData({action: Action.Buy, token: token, trader: msg.sender, amountIn: grossEth, minOut: minTokensOut}))
+        );
+        tokensOut = abi.decode(result, (uint256));
+    }
+
+    /**
+     * @notice Sell `token` for native ETH. Requires a prior approve() of this router
+     *         for at least `tokenAmountIn`, same as IncentifiSwapRouter.sol (v3).
+     * @dev Pulls tokens from the seller and measures the actual balance delta before
+     *      forwarding into the swap — fee-on-transfer safety, same convention already
+     *      established and fixed on the v3 router.
+     */
+    function sellToken(address token, uint256 tokenAmountIn, uint256 minEthOut, uint256 deadline) external returns (uint256 netEthOut) {
+        if (block.timestamp > deadline) revert Expired();
+        if (tokenAmountIn == 0) revert ZeroAmount();
+
+        uint256 balanceBefore = IERC20(token).balanceOf(address(this));
+        if (!IERC20(token).transferFrom(msg.sender, address(this), tokenAmountIn)) revert TokenTransferFailed();
+        uint256 actualAmountIn = IERC20(token).balanceOf(address(this)) - balanceBefore;
+        if (actualAmountIn == 0) revert ZeroAmount();
+
+        bytes memory result = poolManager.unlock(
+            abi.encode(CallbackData({action: Action.Sell, token: token, trader: msg.sender, amountIn: actualAmountIn, minOut: minEthOut}))
+        );
+        netEthOut = abi.decode(result, (uint256));
+    }
+
+    function unlockCallback(bytes calldata data) external override returns (bytes memory) {
+        if (msg.sender != address(poolManager)) revert OnlyPoolManager();
+
+        CallbackData memory cb = abi.decode(data, (CallbackData));
+        PoolKey memory key = factory.getPoolKey(cb.token);
+
+        if (cb.action == Action.Buy) {
+            return abi.encode(_executeBuy(key, cb));
+        } else if (cb.action == Action.Sell) {
+            return abi.encode(_executeSell(key, cb));
+        }
+        revert UnknownAction();
+    }
+
+    /// @dev zeroForOne = true: swapping currency0 (native ETH) for currency1 (token).
+    ///      Router's own final delta (after the hook fully absorbs the trade, per the
+    ///      sign derivation documented in IncentifiV4Hook._beforeSwap) is negative on
+    ///      amount0 (router owes ETH — settle) and positive on amount1 (router is
+    ///      owed token — take).
+    function _executeBuy(PoolKey memory key, CallbackData memory cb) internal returns (uint256 tokensOut) {
+        BalanceDelta delta = poolManager.swap(
+            key,
+            SwapParams({zeroForOne: true, amountSpecified: -int256(cb.amountIn), sqrtPriceLimitX96: 0}),
+            ""
+        );
+
+        int128 ethDelta = delta.amount0();
+        int128 tokenDelta = delta.amount1();
+        if (ethDelta > 0 || tokenDelta < 0) revert UnknownAction(); // sanity: buy must owe ETH, be owed token
+
+        tokensOut = uint256(uint128(tokenDelta));
+        if (tokensOut < cb.minOut) revert SlippageExceeded();
+
+        poolManager.settle{value: uint256(uint128(-ethDelta))}();
+        poolManager.take(key.currency1, cb.trader, tokensOut);
+    }
+
+    /// @dev zeroForOne = false: swapping currency1 (token) for currency0 (native ETH).
+    ///
+    /// @dev ORDERING BUG FIXED (found via real fork test, not by inspection): unlike
+    ///      _executeBuy, this cannot settle the token leg AFTER calling swap(). On a
+    ///      buy, the hook's mid-swap take() of native ETH succeeds even before the
+    ///      router's later settle{value}() call physically arrives, because
+    ///      PoolManager already holds a real ETH balance from all its OTHER pools'
+    ///      liquidity — the hook is effectively borrowing against that shared
+    ///      reserve for the instant before the router repays it. A freshly-launched
+    ///      Incentifi token has no such shared reserve: PoolManager has never held a
+    ///      single unit of it. So when the hook's beforeSwap (running synchronously
+    ///      inside this contract's poolManager.swap() call, below) tries to
+    ///      take() the seller's tokens out of PoolManager before this router has
+    ///      ever deposited them, the underlying ERC20 transfer reverts for real
+    ///      insufficient balance — confirmed by the actual revert trace the first
+    ///      time this was run against the fork (PoolManager -> hook.beforeSwap ->
+    ///      hook._takeToken -> a real "balance" revert from the token contract).
+    ///      Fix: settle the tokens INTO PoolManager BEFORE calling swap(), so real
+    ///      backing already exists when the hook's take() executes. The router's own
+    ///      pre-paid token credit and the swap's resulting token debit then net to
+    ///      exactly zero automatically (see the tokenDelta == 0 assertion below) —
+    ///      no post-swap token settlement is needed or correct anymore.
+    function _executeSell(PoolKey memory key, CallbackData memory cb) internal returns (uint256 netEthOut) {
+        poolManager.sync(key.currency1);
+        bool success = _tokenAt(key).transfer(address(poolManager), cb.amountIn);
+        if (!success) revert TokenTransferFailed();
+        poolManager.settle();
+
+        BalanceDelta delta = poolManager.swap(
+            key,
+            SwapParams({zeroForOne: false, amountSpecified: -int256(cb.amountIn), sqrtPriceLimitX96: 0}),
+            ""
+        );
+
+        int128 tokenDelta = delta.amount1();
+        int128 ethDelta = delta.amount0();
+        // CORRECTED (found via the same real fork test, by logging the actual
+        // returned delta): swap()'s returned delta is only THIS call's own
+        // contribution to the router's ledger, not a running cumulative total — the
+        // pre-funding settle() above already posted its own separate +cb.amountIn
+        // credit to the router's token delta a moment earlier. So this swap's own
+        // token delta should read exactly -cb.amountIn (the hook fully absorbing
+        // what was just paid in); added together, the router's cumulative token
+        // delta lands on exactly zero by the time unlock() finishes, which
+        // PoolManager itself enforces independently of this check. A mismatch here
+        // means the hook received a different amount of tokens than this router
+        // paid in — a real accounting bug, not something to silently tolerate.
+        if (tokenDelta != -int128(int256(cb.amountIn))) revert UnknownAction();
+        if (ethDelta < 0) revert UnknownAction(); // sanity: sell must be owed ETH, never owe it
+
+        netEthOut = uint256(uint128(ethDelta));
+        if (netEthOut < cb.minOut) revert SlippageExceeded();
+
+        poolManager.take(key.currency0, cb.trader, netEthOut);
+    }
+
+    function _tokenAt(PoolKey memory key) internal pure returns (IERC20) {
+        return IERC20(Currency.unwrap(key.currency1));
+    }
+
+    receive() external payable {}
+}

--- a/contracts/v4/test-deployment/IncentifiV4HookProductionLogicTest.sol
+++ b/contracts/v4/test-deployment/IncentifiV4HookProductionLogicTest.sol
@@ -1,0 +1,944 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+// NOTE: imported via @uniswap/v4-periphery's OWN nested v4-core copy
+// (node_modules/@uniswap/v4-periphery/lib/v4-core/), not the top-level
+// @uniswap/v4-core package, even though both are byte-for-byte identical
+// (confirmed via diff) and the same version (1.0.2). Uniswap/v4-periphery's
+// BaseHook.sol resolves ITS @uniswap/v4-core/... imports through its own
+// bundled lib/v4-core/ via that package's remappings.txt, so importing the
+// top-level copy here produced two structurally-identical but type-DISTINCT
+// copies of IPoolManager/Currency/Hooks.Permissions/etc. — real compiler
+// errors ("Invalid implicit conversion from contract IPoolManager to contract
+// IPoolManager", "Overriding function return types differ") the first time
+// this was compiled. Importing through the same nested path BaseHook.sol uses
+// makes every type identity match.
+import {BaseHook} from "@uniswap/v4-periphery/src/utils/BaseHook.sol";
+import {Hooks} from "@uniswap/v4-periphery/lib/v4-core/src/libraries/Hooks.sol";
+import {IPoolManager} from "@uniswap/v4-periphery/lib/v4-core/src/interfaces/IPoolManager.sol";
+import {PoolKey} from "@uniswap/v4-periphery/lib/v4-core/src/types/PoolKey.sol";
+import {PoolId, PoolIdLibrary} from "@uniswap/v4-periphery/lib/v4-core/src/types/PoolId.sol";
+import {Currency} from "@uniswap/v4-periphery/lib/v4-core/src/types/Currency.sol";
+import {BalanceDelta} from "@uniswap/v4-periphery/lib/v4-core/src/types/BalanceDelta.sol";
+import {BeforeSwapDelta, BeforeSwapDeltaLibrary, toBeforeSwapDelta} from "@uniswap/v4-periphery/lib/v4-core/src/types/BeforeSwapDelta.sol";
+import {SwapParams, ModifyLiquidityParams} from "@uniswap/v4-periphery/lib/v4-core/src/types/PoolOperation.sol";
+import {TickMath} from "@uniswap/v4-periphery/lib/v4-core/src/libraries/TickMath.sol";
+// LiquidityAmounts is imported from periphery's TOP-LEVEL path (not the nested
+// lib/v4-core one everything else here uses) deliberately: it only operates on
+// primitive uint160/uint256 values, never on a PoolKey/Currency/IPoolManager
+// struct or contract instance, so the type-identity problem documented above
+// (why every other import here goes through the nested path) does not apply to
+// it — there is no struct/contract type for the two copies to disagree about.
+import {LiquidityAmounts} from "@uniswap/v4-periphery/src/libraries/LiquidityAmounts.sol";
+
+interface IERC20 {
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address recipient, uint256 amount) external returns (bool);
+}
+
+interface ILossRewardPool {
+    function depositReward(address token) external payable;
+}
+
+/**
+ * @title IncentifiV4HookProductionLogicTest
+ * @notice TEST-PARAMETER DEPLOYMENT — NOT FOR PRODUCTION USE. Byte-for-byte the
+ *         same logic as contracts/v4/IncentifiV4Hook.sol (the production hook,
+ *         SIX permission flags including the post-graduation afterSwap fee
+ *         mechanism), with ONLY the economic constants below scaled down —
+ *         same 1/50 scaling already used and proven on real mainnet by
+ *         contracts/v4/test-deployment/IncentifiV4HookTestnet.sol, applied here
+ *         to the full production logic (that earlier contract predates the
+ *         afterSwap/post-graduation fee mechanism and only carries the original
+ *         four permission flags — it cannot exercise that code path at all).
+ *         Exists so the SIX-flag production logic, including the mechanism
+ *         that has never touched real mainnet, can be exercised end-to-end
+ *         against real gas, a real mempool, and real PoolManager/StateView
+ *         behavior — at ~1/50th the ETH cost of a full production-scale
+ *         graduation — without putting the real $5,000 launch / $69,000
+ *         graduation parameters, or the real production LossRewardPool,
+ *         anywhere near it. Wire this to a FRESH, THROWAWAY LossRewardPool at
+ *         deploy time — never the real production one
+ *         (0x697BDA9db5a297a9Cd9ED969BBF2549d0527DcdF).
+ *
+ *         This file must be kept logic-identical to IncentifiV4Hook.sol going
+ *         forward except for the constants block immediately below — any other
+ *         divergence defeats the point of using it as a real-world proving
+ *         ground for the production logic.
+ *
+ *         A SHARED Uniswap V4 hook: one deployed instance serves every token's
+ *         pool launched against it, holding per-pool state in `curveStates`
+ *         keyed by PoolId. Reproduces contracts/IncentifiBondingCurve.sol's
+ *         economics (virtual-reserve x*y=k pricing, 2%/1%/1% fee split,
+ *         pull-payment creator fees) as V4 custom accounting inside beforeSwap.
+ *
+ * @dev PAIRING CURRENCY: native ETH (Currency.wrap(address(0))), not WETH. Two reasons:
+ *      (1) V4 supports native ETH as a first-class currency, avoiding a wrap/unwrap
+ *          round-trip on every trade that the v3 architecture needed.
+ *      (2) address(0) is numerically the smallest possible address, so currency0 is
+ *          *always* ETH and currency1 is *always* the Incentifi token, for every pool,
+ *          unconditionally. This structurally eliminates the "token address < WETH
+ *          address" ordering bug class that required a dedicated fix
+ *          (_computeSqrtPriceX96 in IncentifiBondingCurve.sol) on the v3 side. There is
+ *          no equivalent bug surface here because there is no ordering ambiguity to get
+ *          wrong in the first place.
+ *      If WETH parity with the v3 pools is wanted instead, this assumption needs
+ *      revisiting throughout — flagging now rather than silently deciding it forever.
+ */
+contract IncentifiV4HookProductionLogicTest is BaseHook {
+    using PoolIdLibrary for PoolKey;
+
+    // ------------------------------------------------------------------------
+    // Economic constants — TEST SCALE, deliberately different from
+    // IncentifiV4Hook.sol's production values. TOTAL_SUPPLY and VIRTUAL_TOKEN
+    // are left unchanged (token count is a tokenomics choice, not a launch-cost
+    // one); VIRTUAL_ETH and GRADUATION_ETH_TARGET are both scaled down by the
+    // SAME 1/50 factor IncentifiV4HookTestnet.sol already used and proved on
+    // real mainnet, so the curve's shape (and therefore its math, its
+    // clamp/refund behavior, and its graduation mechanics) is identical in kind
+    // to production, just ~50x cheaper to fully exercise. INVARIANT_K is
+    // recomputed from the SAME relationship the production contract actually
+    // satisfies — INVARIANT_K == VIRTUAL_ETH * (VIRTUAL_TOKEN + TOTAL_SUPPLY) —
+    // and matches production's INVARIANT_K / 50 exactly (verified: both scale
+    // linearly with VIRTUAL_ETH when VIRTUAL_TOKEN + TOTAL_SUPPLY is held fixed).
+    //   implied launch market cap  ~= 0.04 ETH   (~$100 at a nominal $2,500/ETH)
+    //   implied graduation target  ~= 0.117 ETH  (~$293 at a nominal $2,500/ETH)
+    // ------------------------------------------------------------------------
+    uint256 public constant TOTAL_SUPPLY = 1_000_000_000 * 1e18;
+    uint256 public constant VIRTUAL_ETH = 43_125_000_000_000_000; // 0.043125 ETH (production / 50)
+    uint256 public constant VIRTUAL_TOKEN = 78_125_000_000_000_000_000_000_000; // 78,125,000 tokens (unchanged)
+    uint256 public constant INVARIANT_K = 46_494_140_625_000_000_000_000_000_000_000_000_000_000_000; // VIRTUAL_ETH * (VIRTUAL_TOKEN + TOTAL_SUPPLY)
+    uint256 public constant GRADUATION_ETH_TARGET = 117_077_264_687_500_000; // 0.1170772646875 ETH (production / 50)
+
+    uint256 public constant PROTOCOL_FEE_BPS = 200; // 2.00% total
+    uint256 public constant CREATOR_FEE_BPS = 100; // 1.00%
+    uint256 public constant LOSS_REWARD_FEE_BPS = 100; // 1.00%
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+
+    /// @dev Deliberately oversized exact-input magnitude for _graduate()'s
+    /// corrective swap, so the swap is always bounded by its sqrtPriceLimitX96
+    /// (the actual target price) rather than by this nominal amount — the
+    /// standard "swap up to a price limit" pattern. Never actually paid in full;
+    /// the real, much smaller amount that PoolManager actually consumes is read
+    /// back from the swap's returned delta and settled exactly.
+    int256 private constant _GRADUATION_SWAP_SENTINEL = type(int128).max;
+
+    // ------------------------------------------------------------------------
+    // Immutables
+    // ------------------------------------------------------------------------
+
+    /// @notice The only address permitted to call registerToken() — validation of
+    /// creator identity / total-supply / etc. lives in the factory, mirroring how
+    /// IncentifiBondingCurveFactory.sol validates before deploying a v3 curve.
+    /// @dev NOT immutable, and deliberately not a constructor param — a genuine
+    /// circular dependency, not a test convenience: this hook's own deployment
+    /// address must be mined via CREATE2 to satisfy the permission-bit requirement
+    /// BEFORE IncentifiV4Factory (which takes this hook's address as its own
+    /// constructor arg) can be deployed. If `factory` were a constructor param here,
+    /// neither contract could be deployed first. Resolved with the standard pattern
+    /// for this exact problem: deploy the hook, deploy the factory (now that the
+    /// hook exists to reference), then wire them together with one one-time call —
+    /// not a per-launch admin step, a one-time system bootstrap step.
+    address public factory;
+    address public immutable lossRewardPool;
+    /// @dev The only address allowed to call setFactory() once. Not an ongoing admin
+    /// role: setFactory() is one-time-only (reverts if `factory` is already set), so
+    /// this has no power after bootstrap.
+    /// @dev Passed explicitly as a constructor arg rather than recorded from
+    /// `msg.sender` — this hook is deployed via CREATE2 through the standard
+    /// singleton deployer factory (0x4e59b44847b379578588920cA78FbF26c0B4956C,
+    /// confirmed deployed on Robinhood Chain), which means `msg.sender` during this
+    /// constructor's execution would be that FACTORY PROXY, not the actual deployer's
+    /// EOA. Recording `msg.sender` here would make setFactory() permanently
+    /// uncallable by anyone with a private key. Caught by reasoning through the
+    /// deployment path before attempting it, not from a failed deployment.
+    address public immutable deployer;
+
+    // ------------------------------------------------------------------------
+    // Per-pool state (shared-hook model)
+    // ------------------------------------------------------------------------
+    struct TokenCurveState {
+        address token;
+        address creator;
+        bool initialized;
+        bool graduated;
+        uint256 realEthReserve;
+        uint256 realTokenReserve;
+    }
+
+    mapping(PoolId => TokenCurveState) public curveStates;
+
+    /// @notice Pull-payment creator balances, GLOBAL across every token this hook
+    /// serves (keyed by creator address, not by pool) — a single creator who
+    /// launches multiple tokens accrues into one claimable balance, and claims once
+    /// via claimCreatorFees() regardless of which of their tokens earned the fee.
+    mapping(address => uint256) public creatorBalances;
+
+    /// @notice token => creator, set by the factory via registerToken() before it
+    /// calls PoolManager.initialize(). Consumed and cleared by _beforeInitialize().
+    mapping(address => address) public pendingCreator;
+
+    /// @notice Leftover ETH/token from _graduate()'s reserve-ratio-vs-marginal-
+    /// price mismatch (see _graduate()'s doc comment), keyed by PoolId so it is
+    /// never confused with any other pool's dust or claim. Written once, at
+    /// graduation, alongside the GraduationLiquidityDeployed event — the event is
+    /// history; these mappings are the live, queryable record.
+    ///
+    /// @dev Deliberately kept SEPARATE from creatorBalances, even though both are
+    /// "real ETH sitting in this contract, not yet spent anywhere": creatorBalances
+    /// is a claimable entitlement (someone can withdraw it via claimCreatorFees()),
+    /// while ethDustBalances/tokenDustBalances are only a bookkeeping record of
+    /// value that has NO withdrawal path today (see the token-dust question this
+    /// was raised over) — merging them into one ledger would make an unclaimed
+    /// creator fee and an unspendable dust remainder indistinguishable from a
+    /// single mapping read, which is exactly the "hard to account for" risk this
+    /// pair of mappings exists to close off. tokenDustBalances is close to
+    /// redundant with IERC20(token).balanceOf(address(this)) post-graduation
+    /// (nothing else touches that balance once graduated — see the _beforeSwap
+    /// pass-through), but is recorded anyway for parity with ethDustBalances,
+    /// which has no such convenient equivalent (native ETH is one pooled balance
+    /// shared across every token this hook serves, unlike each token's own
+    /// self-isolating ERC20 balance).
+    mapping(PoolId => uint256) public ethDustBalances;
+    mapping(PoolId => uint256) public tokenDustBalances;
+
+    // ------------------------------------------------------------------------
+    // Events
+    // ------------------------------------------------------------------------
+    event TokenRegistered(address indexed token, address indexed creator);
+    event CurveInitialized(address indexed token, address indexed creator, PoolId poolId);
+    event Bought(PoolId indexed poolId, address indexed trader, uint256 ethIn, uint256 tokensOut, uint256 creatorFee, uint256 lossPoolFee);
+    event Sold(PoolId indexed poolId, address indexed trader, uint256 tokensIn, uint256 ethOut, uint256 creatorFee, uint256 lossPoolFee);
+    event CreatorFeesClaimed(address indexed creator, uint256 amount);
+    event Graduated(PoolId indexed poolId, address indexed token, uint256 finalEthReserve, uint256 finalTokenReserve);
+    /// @param ethDust,tokenDust Real, honestly-reported leftover from the reserve-
+    /// ratio-vs-marginal-price mismatch inherent to migrating a virtual-offset
+    /// bonding curve into a real concentrated-liquidity position — see the long
+    /// comment on _graduate() for why this isn't (and can't cheaply be) zero.
+    event GraduationLiquidityDeployed(
+        PoolId indexed poolId,
+        uint128 bootstrapLiquidity,
+        uint128 finalLiquidity,
+        uint160 correctedSqrtPriceX96,
+        uint256 ethDust,
+        uint256 tokenDust
+    );
+    /// @notice Emitted once per post-graduation swap, buy or sell, whenever the
+    /// 2% fee is actually collected — the graduated-pool equivalent of Bought/Sold,
+    /// deliberately a separate event rather than overloading those two: this fee
+    /// is computed from real AMM-priced amounts, not virtual-curve math, and
+    /// intentionally does not carry a token amount (buys only know the ETH side
+    /// at fee-collection time; see _beforeSwap's graduated branch).
+    event GraduatedFeeCollected(PoolId indexed poolId, bool zeroForOne, uint256 creatorFee, uint256 lossPoolFee);
+
+    // ------------------------------------------------------------------------
+    // Errors
+    // ------------------------------------------------------------------------
+    error OnlyFactory();
+    error ZeroAddress();
+    error ZeroAmount();
+    error AlreadyPending();
+    error TokenNotRegistered();
+    error AlreadyInitialized();
+    error InsufficientSupply();
+    error MustPairWithNativeEth();
+    error WrongStartingPrice();
+    error PoolNotInitialized();
+    error OnlyExactInputSupported();
+    error InsufficientReserve();
+    error SlippageExceeded();
+    error NoBalanceToClaim();
+    error CannotAddLiquidity();
+    error EthTransferFailed();
+    error TokenTransferFailed();
+    error OnlyDeployer();
+    error FactoryAlreadySet();
+    // Graduation-liquidity-specific — see _graduate()'s doc comment. Both would
+    // indicate a real accounting bug in the corrective-swap/mint math, not a
+    // condition expected to ever actually trigger.
+    error GraduationSwapDirectionInvalid();
+    error GraduationMintUnexpectedCredit();
+    /// @dev A real sell against a graduated pool must always leave the core pool
+    /// owing the trader ETH (delta.amount0() > 0) — this would only fire if the
+    /// real AMM math itself is somehow inverted, not a condition expected to
+    /// ever actually trigger.
+    error GraduatedFeeUnexpectedDirection();
+
+    constructor(IPoolManager _poolManager, address _lossRewardPool, address _deployer) BaseHook(_poolManager) {
+        if (_lossRewardPool == address(0) || _deployer == address(0)) revert ZeroAddress();
+        lossRewardPool = _lossRewardPool;
+        deployer = _deployer;
+    }
+
+    /// @notice One-time wiring of the factory address, called once immediately after
+    /// both this hook and IncentifiV4Factory are deployed. Not callable again once
+    /// set, and not callable by anyone other than whoever deployed this specific
+    /// hook instance — see the `factory` field's doc comment for why this exists.
+    function setFactory(address _factory) external {
+        if (msg.sender != deployer) revert OnlyDeployer();
+        if (factory != address(0)) revert FactoryAlreadySet();
+        if (_factory == address(0)) revert ZeroAddress();
+        factory = _factory;
+    }
+
+    // ------------------------------------------------------------------------
+    // Hook permissions
+    // ------------------------------------------------------------------------
+    /**
+     * @dev SIX flags — identical to IncentifiV4Hook.sol's production
+     *      getHookPermissions(). Originally four (see git history for the
+     *      earlier reasoning: "afterSwap unneeded, every swap is fully
+     *      absorbed pre-graduation"). That reasoning still holds for the
+     *      PRE-graduation path; it stopped holding once graduated pools
+     *      needed to keep charging a fee while letting the REAL AMM price the
+     *      trade, because a sell's ETH output isn't known until the core pool has
+     *      actually run — see _afterSwap's own doc comment for why that specific
+     *      case is what forced this hook to finally need afterSwap for real.
+     *      - BEFORE_INITIALIZE: validate + finalize a pending token registration at
+     *        the correct starting price before the pool exists.
+     *      - BEFORE_ADD_LIQUIDITY: revert unless caller == address(this) (pre-
+     *        graduation only) — blocks every external LP, protecting the internal
+     *        reserve accounting exactly the way Doppler's own beforeAddLiquidity
+     *        does (pattern studied, not copied — Doppler is BUSL-1.1, this is an
+     *        independent ~3-line reimplementation of an obvious idea).
+     *      - BEFORE_SWAP + BEFORE_SWAP_RETURNS_DELTA: pre-graduation, the full
+     *        custom-accounting override (pricing, fee split, settlement, reserve
+     *        updates, graduation trigger). Post-graduation, BEFORE_SWAP now ALSO
+     *        does the buy-side fee skim (see _beforeSwap's graduated branch).
+     *      - AFTER_SWAP + AFTER_SWAP_RETURNS_DELTA: needed exclusively for
+     *        the post-graduation SELL-side fee — the only case in this whole
+     *        contract where a fee has to be computed from a real, core-pool-priced
+     *        output rather than from an input amount or virtual-curve math known
+     *        in advance. THIS is the mechanism this test-parameter contract exists
+     *        to exercise cheaply.
+     */
+    function getHookPermissions() public pure override returns (Hooks.Permissions memory) {
+        return Hooks.Permissions({
+            beforeInitialize: true,
+            afterInitialize: false,
+            beforeAddLiquidity: true,
+            afterAddLiquidity: false,
+            beforeRemoveLiquidity: false,
+            afterRemoveLiquidity: false,
+            beforeSwap: true,
+            afterSwap: true,
+            beforeDonate: false,
+            afterDonate: false,
+            beforeSwapReturnDelta: true,
+            afterSwapReturnDelta: true,
+            afterAddLiquidityReturnDelta: false,
+            afterRemoveLiquidityReturnDelta: false
+        });
+    }
+
+    // ------------------------------------------------------------------------
+    // Permissionless launch registration (called by IncentifiV4Factory)
+    // ------------------------------------------------------------------------
+    /**
+     * @notice Records `creator` as the pending creator for `token`, ahead of the
+     *         factory calling PoolManager.initialize() for that token's pool.
+     * @dev Gated to `factory` only — this contract trusts the factory to have
+     *      already validated token.creator() / total supply / etc., mirroring
+     *      IncentifiBondingCurveFactory.registerExistingToken()'s validation.
+     *      The factory must transfer the token's full TOTAL_SUPPLY to this hook
+     *      BEFORE calling PoolManager.initialize() — _beforeInitialize checks for
+     *      that balance and reverts if it isn't there yet.
+     */
+    function registerToken(address token, address creator) external {
+        if (msg.sender != factory) revert OnlyFactory();
+        if (token == address(0) || creator == address(0)) revert ZeroAddress();
+        if (pendingCreator[token] != address(0)) revert AlreadyPending();
+
+        pendingCreator[token] = creator;
+        emit TokenRegistered(token, creator);
+    }
+
+    function _beforeInitialize(address, PoolKey calldata key, uint160 sqrtPriceX96)
+        internal
+        override
+        returns (bytes4)
+    {
+        if (!key.currency0.isAddressZero()) revert MustPairWithNativeEth();
+
+        address token = Currency.unwrap(key.currency1);
+        address creator = pendingCreator[token];
+        if (creator == address(0)) revert TokenNotRegistered();
+
+        PoolId poolId = key.toId();
+        TokenCurveState storage state = curveStates[poolId];
+        if (state.initialized) revert AlreadyInitialized();
+
+        uint256 balance = IERC20(token).balanceOf(address(this));
+        if (balance < TOTAL_SUPPLY) revert InsufficientSupply();
+
+        // Defend against anyone initializing at a wrong price: PoolManager.initialize()
+        // is permissionless at the PoolManager level, so without this check a
+        // front-runner could initialize this exact PoolKey at an arbitrary price before
+        // the factory's own initialize() call lands. Only the one correct
+        // starting price (VIRTUAL_TOKEN / VIRTUAL_ETH ratio) is accepted.
+        if (sqrtPriceX96 != launchSqrtPriceX96()) revert WrongStartingPrice();
+
+        state.token = token;
+        state.creator = creator;
+        state.initialized = true;
+        state.realEthReserve = 0;
+        state.realTokenReserve = TOTAL_SUPPLY;
+
+        delete pendingCreator[token];
+
+        emit CurveInitialized(token, creator, poolId);
+        return BaseHook.beforeInitialize.selector;
+    }
+
+    /// @dev Pre-graduation, liquidity may ONLY come from this hook itself (the
+    ///      _graduate() mint below) — an external LP adding liquidity while the
+    ///      curve is still active would corrupt the full-absorption invariant this
+    ///      hook depends on (a real, non-zero-liquidity core pool would start
+    ///      partially filling swaps itself, which _beforeSwap's OnlyExactInputSupported
+    ///      / full-absorption math does not account for). Once graduated, this
+    ///      pool is a genuine, permanently-real AMM pool with no more curve
+    ///      invariant to protect — so, unlike the permanently-hook-only v3 LP
+    ///      position (minted once, then burned/locked forever), this DOES open up
+    ///      to any external LP after graduation, same as a completely standard,
+    ///      permissionless V4 pool. Flagging this as a deliberate departure from
+    ///      v3's parity, not an oversight.
+    function _beforeAddLiquidity(address caller, PoolKey calldata key, ModifyLiquidityParams calldata, bytes calldata)
+        internal
+        view
+        override
+        returns (bytes4)
+    {
+        if (caller != address(this) && !curveStates[key.toId()].graduated) revert CannotAddLiquidity();
+        return BaseHook.beforeAddLiquidity.selector;
+    }
+
+    // ------------------------------------------------------------------------
+    // Core custom-accounting swap logic
+    // ------------------------------------------------------------------------
+    /**
+     * @dev Delta-application semantics below are transcribed from the ACTUAL
+     *      Hooks.sol I read (v4-core 1.0.2), not assumed:
+     *
+     *        amountToSwap = params.amountSpecified;
+     *        amountToSwap += hookReturn.getSpecifiedDelta();
+     *        revert if (exactInput && amountToSwap > 0)   // exactInput = original amountSpecified < 0
+     *
+     *      We only support exact-input swaps (amountSpecified < 0) — this hook has
+     *      no real liquidity backing it, so any amount left for the "core" pool to
+     *      process after our delta would hit a liquidity-less pool and revert
+     *      anyway; full absorption is the only valid mode, and OnlyExactInputSupported
+     *      documents that as a deliberate constraint, not an oversight.
+     *
+     *      Setting hookDeltaSpecified = -params.amountSpecified makes amountToSwap
+     *      land at exactly 0 — the core pool does nothing, all economics are ours.
+     *
+     *      Router's own final delta (from Hooks.afterSwap: swapDelta = coreDelta -
+     *      hookDelta, and coreDelta is (0,0) here since amountToSwap is 0) works out
+     *      to -hookDelta. Confirmed sign convention from Hooks.sol/CurrencySettler.sol
+     *      (test-path reference, read but not imported): positive hook delta = hook
+     *      take()s that amount FROM the PoolManager; negative = hook settle()s
+     *      (pays) that amount INTO the PoolManager.
+     *
+     *      BUY (zeroForOne, ETH -> TOKEN): specified = currency0 (ETH). We take() the
+     *      buyer's incoming ETH (hookDeltaSpecified > 0), and settle() the token
+     *      output (hookDeltaUnspecified < 0) so the router can take() it out for the
+     *      buyer. SELL is the mirror image with the specified/unspecified currencies
+     *      swapped and native-ETH settle() replacing ERC20 settle().
+     *
+     * @dev KNOWN GAP vs. IncentifiBondingCurve.buy(): the v3 contract clamps grossEth
+     *      to the graduation boundary and refunds any excess directly from within
+     *      buy() itself, because it holds msg.value directly. That refund mechanism
+     *      does not translate here: a hook that only partially absorbs
+     *      amountSpecified leaves the remainder for the core (liquidity-less) pool to
+     *      process, which would revert. This version does NOT clamp/refund — an
+     *      overshooting buy is accepted in full, and any excess beyond the exact
+     *      graduation target is carried into the reserve that gets migrated at
+     *      graduation rather than refunded to the buyer. If exact-target clamping
+     *      with a refund is required, it has to happen one layer up, in whichever
+     *      router originates the swap (compute the clamped amount via a view call
+     *      before ever submitting the swap, refund any excess before calling
+     *      PoolManager.unlock()) — flagging this now since it's a real, unresolved
+     *      difference from the v3 UX, and it's a concrete data point for the still-
+     *      open router-vs-Universal-Router decision: Universal Router has no way to
+     *      run our pre-swap clamping logic, which argues toward a custom router.
+     */
+    function _beforeSwap(address, PoolKey calldata key, SwapParams calldata params, bytes calldata)
+        internal
+        override
+        returns (bytes4, BeforeSwapDelta, uint24)
+    {
+        PoolId poolId = key.toId();
+        TokenCurveState storage state = curveStates[poolId];
+        if (!state.initialized) revert PoolNotInitialized();
+
+        // Both the pre- and post-graduation paths require exact input, for two
+        // different reasons: pre-graduation, there's no real liquidity for the
+        // core pool to partially fill against (full absorption is the only valid
+        // mode). Post-graduation, an exact-output swap would mean the fee itself
+        // (computed as a percentage of an input or a real AMM output) is not
+        // well-defined before the core pool runs — exact input keeps the fee
+        // math identical in shape to the pre-graduation curve's own convention.
+        if (params.amountSpecified >= 0) revert OnlyExactInputSupported();
+        uint256 amountIn = uint256(-params.amountSpecified);
+        if (amountIn == 0) revert ZeroAmount();
+
+        // POST-GRADUATION: real AMM execution, hook now skims a 2% fee instead of
+        // fully absorbing the trade. Two genuinely different mechanisms depending
+        // on direction — see the doc comment on _afterSwap for why the sell side
+        // can't be handled here.
+        if (state.graduated) {
+            if (params.zeroForOne) {
+                // BUY: fee is a cut of the ETH being paid IN — known right now,
+                // before the core pool even runs, so it can come straight off
+                // amountToSwap via the specified-delta mechanism (Hooks.sol:
+                // amountToSwap += hookDeltaSpecified). The core pool then only
+                // ever sees amountIn - fee, and prices real AMM output on that
+                // net amount — mirrors _executeBuy's grossEth-based fee exactly,
+                // just paid out of a smaller pool of ETH than the trader's full
+                // amountIn (the fee never reaches the AMM at all).
+                uint256 creatorFee = amountIn / 100;
+                uint256 lossPoolFee = amountIn / 100;
+                uint256 totalFee = creatorFee + lossPoolFee;
+                _collectGraduatedFee(state, poolId, true, creatorFee, lossPoolFee);
+                return (BaseHook.beforeSwap.selector, toBeforeSwapDelta(_toInt128(totalFee), 0), 0);
+            } else {
+                // SELL: the fee has to be a cut of the ETH coming OUT, which the
+                // real AMM hasn't computed yet at this point in execution — no
+                // adjustment here at all (full amountIn reaches the core pool
+                // unmodified); _afterSwap collects the fee once the real output
+                // is known.
+                return (BaseHook.beforeSwap.selector, BeforeSwapDeltaLibrary.ZERO_DELTA, 0);
+            }
+        }
+
+        int128 hookDeltaSpecified = int128(-params.amountSpecified);
+        int128 hookDeltaUnspecified;
+
+        if (params.zeroForOne) {
+            // BUY: ETH in (specified, currency0), TOKEN out (unspecified, currency1)
+            uint256 tokensOut = _executeBuy(state, poolId, key, amountIn);
+            hookDeltaUnspecified = -_toInt128(tokensOut);
+        } else {
+            // SELL: TOKEN in (specified, currency1), ETH out (unspecified, currency0)
+            uint256 netEthOut = _executeSell(state, poolId, amountIn);
+            hookDeltaUnspecified = -_toInt128(netEthOut);
+        }
+
+        BeforeSwapDelta delta = toBeforeSwapDelta(hookDeltaSpecified, hookDeltaUnspecified);
+        return (BaseHook.beforeSwap.selector, delta, 0);
+    }
+
+    /**
+     * @dev The ONLY reason this hook implements a real afterSwap at all. A
+     *      post-graduation SELL's ETH output is priced by the real core pool's
+     *      own concentrated-liquidity math, which does not run until AFTER
+     *      beforeSwap has already returned — so "2% of the real output" cannot
+     *      be computed inside beforeSwap the way the buy-side fee can. afterSwap
+     *      receives `delta`, the core pool's own genuine computed swap result
+     *      (confirmed from the actual installed Hooks.sol: this is the RAW
+     *      per-swap delta passed into afterSwap, before this hook's own
+     *      beforeSwap adjustment is subtracted out — i.e. real, unmodified AMM
+     *      output, not something this hook already touched).
+     *
+     *      Sign/assignment confirmed the same way every other delta in this file
+     *      was: for a sell (zeroForOne = false, exact input), Hooks.afterSwap's
+     *      hookDelta assembly uses (unspecified, specified) order for the
+     *      (amount0, amount1) pair, so returning a positive hookDeltaUnspecified
+     *      here becomes hookDelta.amount0 = +fee, and swapDelta.amount0 =
+     *      coreDelta.amount0 - fee — i.e. the trader's final receivable amount is
+     *      reduced by exactly `fee`, and this hook's own currency0 ledger is
+     *      credited by exactly `fee`, ready to take().
+     *
+     *      BUY needs no afterSwap handling at all — the fee was already fully
+     *      resolved in beforeSwap — so this returns 0 unconditionally whenever
+     *      zeroForOne is true, or the pool hasn't graduated.
+     */
+    function _afterSwap(address, PoolKey calldata key, SwapParams calldata params, BalanceDelta delta, bytes calldata)
+        internal
+        override
+        returns (bytes4, int128)
+    {
+        PoolId poolId = key.toId();
+        TokenCurveState storage state = curveStates[poolId];
+        if (!state.graduated || params.zeroForOne) {
+            return (BaseHook.afterSwap.selector, 0);
+        }
+
+        int128 grossEthOutSigned = delta.amount0();
+        if (grossEthOutSigned <= 0) revert GraduatedFeeUnexpectedDirection();
+        uint256 grossEthOut = uint256(uint128(grossEthOutSigned));
+
+        uint256 creatorFee = grossEthOut / 100;
+        uint256 lossPoolFee = grossEthOut / 100;
+        _collectGraduatedFee(state, poolId, false, creatorFee, lossPoolFee);
+
+        return (BaseHook.afterSwap.selector, _toInt128(creatorFee + lossPoolFee));
+    }
+
+    /// @dev Shared by both post-graduation fee paths. The specified/unspecified
+    /// delta mechanism only ever CREDITS this hook's own currency ledger for the
+    /// fee amount — it does not move real ETH. This take()s that real ETH out of
+    /// PoolManager (always native currency0, matching the pre-graduation
+    /// convention that fees are always ETH-denominated regardless of buy/sell
+    /// direction) and immediately splits it exactly like _executeBuy/_executeSell
+    /// already do: half to the creator's pull-payment balance, half deposited
+    /// into LossRewardPool for real.
+    function _collectGraduatedFee(TokenCurveState storage state, PoolId poolId, bool zeroForOne, uint256 creatorFee, uint256 lossPoolFee)
+        internal
+    {
+        uint256 totalFee = creatorFee + lossPoolFee;
+        if (totalFee == 0) return;
+        _takeNative(totalFee);
+        if (creatorFee > 0) creatorBalances[state.creator] += creatorFee;
+        if (lossPoolFee > 0) ILossRewardPool(lossRewardPool).depositReward{value: lossPoolFee}(state.token);
+        emit GraduatedFeeCollected(poolId, zeroForOne, creatorFee, lossPoolFee);
+    }
+
+    /// @dev Mirrors IncentifiBondingCurve.buy() exactly (minus the clamp/refund — see
+    ///      the KNOWN GAP note above), executed as V4 settlement instead of a direct
+    ///      payable call. Fee-on-transfer safety for the token leg comes from V4's
+    ///      own sync()/settle() semantics (balance measured before/after, not a
+    ///      trusted nominal amount) — the same principle as the v3 fix, provided by
+    ///      the platform this time instead of hand-rolled.
+    function _executeBuy(TokenCurveState storage state, PoolId poolId, PoolKey calldata key, uint256 grossEth) internal returns (uint256 tokensOut) {
+        uint256 creatorFee = grossEth / 100;
+        uint256 lossPoolFee = grossEth / 100;
+        uint256 netEth = grossEth - creatorFee - lossPoolFee;
+
+        uint256 newEth = VIRTUAL_ETH + state.realEthReserve + netEth;
+        tokensOut = (VIRTUAL_TOKEN + state.realTokenReserve) - (INVARIANT_K / newEth);
+        if (tokensOut > state.realTokenReserve) revert InsufficientReserve();
+
+        // Take the buyer's ETH from the PoolManager (settled in by the router).
+        _takeNative(grossEth);
+
+        state.realEthReserve += netEth;
+        state.realTokenReserve -= tokensOut;
+
+        if (creatorFee > 0) creatorBalances[state.creator] += creatorFee;
+        if (lossPoolFee > 0) ILossRewardPool(lossRewardPool).depositReward{value: lossPoolFee}(state.token);
+
+        // Settle the token output to the PoolManager so the router can take() it for
+        // the buyer. Measures our own balance delta around the transfer — real
+        // fee-on-transfer safety on the outbound leg too, not just trusted on the
+        // strength of V4's own sync/settle for the inbound leg.
+        _settleToken(state.token, tokensOut);
+
+        emit Bought(poolId, tx.origin, grossEth, tokensOut, creatorFee, lossPoolFee);
+
+        if (state.realEthReserve >= GRADUATION_ETH_TARGET && !state.graduated) {
+            _graduate(state, poolId, key);
+        }
+    }
+
+    /// @dev Mirrors IncentifiBondingCurve.sell() exactly.
+    function _executeSell(TokenCurveState storage state, PoolId poolId, uint256 tokensIn) internal returns (uint256 netEthOut) {
+        // Take the seller's tokens from the PoolManager (settled in by the router),
+        // measuring the actual amount received rather than trusting `tokensIn` —
+        // fee-on-transfer safety on the inbound leg, matching the v3 fix's pattern.
+        uint256 actualTokensIn = _takeToken(state.token, tokensIn);
+        if (actualTokensIn == 0) revert ZeroAmount();
+
+        uint256 currentEth = VIRTUAL_ETH + state.realEthReserve;
+        uint256 currentToken = VIRTUAL_TOKEN + state.realTokenReserve;
+        uint256 newToken = currentToken + actualTokensIn;
+        uint256 newEth = INVARIANT_K / newToken;
+        uint256 grossEthOut = currentEth - newEth;
+        if (grossEthOut > state.realEthReserve) revert InsufficientReserve();
+
+        uint256 creatorFee = grossEthOut / 100;
+        uint256 lossPoolFee = grossEthOut / 100;
+        netEthOut = grossEthOut - creatorFee - lossPoolFee;
+
+        state.realEthReserve -= grossEthOut;
+        state.realTokenReserve += actualTokensIn;
+
+        if (creatorFee > 0) creatorBalances[state.creator] += creatorFee;
+        if (lossPoolFee > 0) ILossRewardPool(lossRewardPool).depositReward{value: lossPoolFee}(state.token);
+
+        _settleNative(netEthOut);
+
+        emit Sold(poolId, tx.origin, actualTokensIn, netEthOut, creatorFee, lossPoolFee);
+    }
+
+    // ------------------------------------------------------------------------
+    // Pull-payment creator claims — same accounting shape as
+    // IncentifiBondingCurve.claimCreatorFees(), just global across pools instead
+    // of scoped to one curve's fixed creator.
+    // ------------------------------------------------------------------------
+    function claimCreatorFees() external {
+        uint256 amount = creatorBalances[msg.sender];
+        if (amount == 0) revert NoBalanceToClaim();
+
+        creatorBalances[msg.sender] = 0;
+        (bool success,) = msg.sender.call{value: amount}("");
+        if (!success) revert EthTransferFailed();
+
+        emit CreatorFeesClaimed(msg.sender, amount);
+    }
+
+    // ------------------------------------------------------------------------
+    // Graduation — real V4 liquidity deposit.
+    //
+    // THE PROBLEM THIS SOLVES (genuinely V4-specific — there is no v3 equivalent
+    // to copy): v3's _graduate() creates its Uniswap V3 pool for the FIRST TIME
+    // at graduation, computing that pool's initial sqrtPriceX96 directly FROM the
+    // exact real reserve amounts being deposited
+    // (_computeSqrtPriceX96(amount0Desired, amount1Desired)) — so there is no
+    // pre-existing on-chain price to reconcile, by construction. This V4 hook's
+    // pool, by contrast, was already initialized and tradeable at
+    // PoolManager.initialize() time — that instant on-chain discoverability from
+    // launch, proven in the Stage 2 fork test, was an explicit design goal — and
+    // Stage 3's fork test independently confirmed (via StateView, before/after a
+    // real swap) that full-absorption swaps never move the core pool's own
+    // tracked price. So by the time graduation is reached, PoolManager's slot0
+    // for this pool is STILL sitting at the original launch price, while the
+    // curve's real economics have moved the fair price far below that (this
+    // curve's price only ever falls as more ETH comes in). Mint a real liquidity
+    // position at that stale price with no correction, and the very first
+    // post-graduation swapper gets a massive, structural arbitrage against the
+    // newly seeded liquidity — a real solvency bug, not a cosmetic one.
+    //
+    // THE FIX: mint a small bootstrap position at the stale price (just enough
+    // real liquidity to trade against), execute one real, hook-bypassed
+    // corrective swap that walks the core pool's tracked price down to the
+    // curve's true final marginal price (bounded exactly by sqrtPriceLimitX96,
+    // so it cannot overshoot), then mint the bulk of the remaining reserves as a
+    // second position at the now-correct price. Both positions are full-range
+    // (TickMath.minUsableTick/maxUsableTick for this pool's tickSpacing) and use
+    // the same salt, so they merge into a single combined position.
+    //
+    // WHY THE CORRECTIVE SWAP DOESN'T RE-TRIGGER THIS HOOK'S OWN ABSORPTION
+    // LOGIC: confirmed by reading the actual installed Hooks.sol — both
+    // `Hooks.beforeSwap` and `Hooks.afterSwap` short-circuit to a pure no-op
+    // (hook not called at all, core pool processes the full amount) whenever
+    // `msg.sender == address(self)`, i.e. whenever the pool's OWN hook contract
+    // is the one calling PoolManager.swap() directly. Since this function IS the
+    // hook contract calling poolManager.swap() on itself, the corrective swap
+    // runs against pure core-pool AMM math with zero hook interference — no
+    // separate "migrating" flag needed, this is a built-in V4 safety mechanism.
+    //
+    // HONEST LIMITATION, not hidden: a bonding curve with virtual-reserve offsets
+    // has a real accumulated reserve ratio (ETH raised : tokens unsold) that
+    // generally does NOT equal its own marginal-price ratio at that same point —
+    // they are different quantities by construction. That means neither mint
+    // below is guaranteed to consume both real assets down to zero
+    // (LiquidityAmounts.getLiquidityForAmounts always picks whichever asset is
+    // limiting at the given price and sizes liquidity to fully use only that
+    // one). Any leftover of the non-limiting asset after the final mint stays in
+    // this contract's own balance, unused — a small, bounded, and reported (via
+    // GraduationLiquidityDeployed) imperfection, not swept under the rug. A
+    // future iteration could mint a second, narrower range to deploy it, or
+    // donate it to the pool; deliberately left unimplemented rather than faked.
+    // ------------------------------------------------------------------------
+    function _graduate(TokenCurveState storage state, PoolId poolId, PoolKey calldata key) internal {
+        state.graduated = true;
+
+        uint256 ethAvailable = state.realEthReserve;
+        uint256 tokensAvailable = state.realTokenReserve;
+
+        emit Graduated(poolId, state.token, ethAvailable, tokensAvailable);
+
+        if (ethAvailable == 0 || tokensAvailable == 0) {
+            // Nothing real to seed as liquidity. Not expected to trigger given
+            // GRADUATION_ETH_TARGET > 0 and the curve's invariant guaranteeing
+            // some unsold supply remains at that target — but the state flip
+            // above still stands regardless; explicitly not treated as an error.
+            return;
+        }
+
+        int24 tickSpacing = key.tickSpacing;
+        int24 tickLower = TickMath.minUsableTick(tickSpacing);
+        int24 tickUpper = TickMath.maxUsableTick(tickSpacing);
+        uint160 sqrtPriceLowerX96 = TickMath.getSqrtPriceAtTick(tickLower);
+        uint160 sqrtPriceUpperX96 = TickMath.getSqrtPriceAtTick(tickUpper);
+        bytes32 salt = bytes32(0);
+
+        // --- Step 1: small bootstrap position at the pool's current (stale)
+        // tracked price, purely so the corrective swap below has real liquidity
+        // to trade against. Sized as 0.1% of the real reserves — small enough
+        // that its own stale-price mispricing is immaterial, since the very next
+        // step corrects the price it trades at.
+        uint256 bootstrapEth = ethAvailable / 1000;
+        uint256 bootstrapTokens = tokensAvailable / 1000;
+        uint160 stalePriceX96 = launchSqrtPriceX96(); // == this pool's actual current slot0, by construction
+
+        uint128 bootstrapLiquidity = LiquidityAmounts.getLiquidityForAmounts(
+            stalePriceX96, sqrtPriceLowerX96, sqrtPriceUpperX96, bootstrapEth, bootstrapTokens
+        );
+        (BalanceDelta bootstrapDelta,) = poolManager.modifyLiquidity(
+            key,
+            ModifyLiquidityParams({
+                tickLower: tickLower,
+                tickUpper: tickUpper,
+                liquidityDelta: int256(uint256(bootstrapLiquidity)),
+                salt: salt
+            }),
+            ""
+        );
+        // Capture what the bootstrap mint ACTUALLY cost, not the nominal
+        // bootstrapEth/bootstrapTokens allocation — LiquidityAmounts.getLiquidityForAmounts
+        // conservatively rounds its liquidity estimate so as never to exceed the
+        // desired amounts, meaning the real amount modifyLiquidity() ends up
+        // requiring can be slightly LESS than what was budgeted. Discarding that
+        // difference (as an earlier version of this function did) doesn't lose
+        // the funds — they're still sitting safely in this contract — but it does
+        // make ethDust/tokenDust under-report the true leftover, which defeats
+        // the whole point of tracking it. Threading the actual paid amounts
+        // through means any such rounding "savings" flow into the final mint's
+        // available balance instead (getting genuinely deployed as liquidity)
+        // rather than becoming untracked residue.
+        (uint256 bootstrapEthPaid, uint256 bootstrapTokensPaid) = _settleMintDelta(state.token, bootstrapDelta);
+
+        // --- Step 2: corrective swap. zeroForOne = true (pay ETH, receive
+        // token) moves price DOWN, which is the correct direction here — this
+        // curve's price (tokens per ETH) only ever falls as more ETH comes in,
+        // so the true final marginal price is always <= the stale launch price.
+        // Bounded by sqrtPriceLimitX96 = the curve's actual final marginal
+        // price, computed the same way launchSqrtPriceX96() computes the launch
+        // price — just fed the FINAL virtual-adjusted reserves instead of the
+        // initial ones.
+        uint160 targetSqrtPriceX96 = _computeSqrtPriceX96(VIRTUAL_ETH + ethAvailable, VIRTUAL_TOKEN + tokensAvailable);
+
+        BalanceDelta correctiveDelta = poolManager.swap(
+            key,
+            SwapParams({zeroForOne: true, amountSpecified: -_GRADUATION_SWAP_SENTINEL, sqrtPriceLimitX96: targetSqrtPriceX96}),
+            ""
+        );
+        int128 correctiveEthDelta = correctiveDelta.amount0();
+        int128 correctiveTokenDelta = correctiveDelta.amount1();
+
+        // Sanity: this self-swap must cost us ETH and pay us tokens, matching
+        // the zeroForOne=true direction requested — never the reverse.
+        if (correctiveEthDelta > 0 || correctiveTokenDelta < 0) revert GraduationSwapDirectionInvalid();
+
+        uint256 ethSpentOnCorrection = uint256(uint128(-correctiveEthDelta));
+        uint256 tokensReceivedFromCorrection = uint256(uint128(correctiveTokenDelta));
+        _settleNative(ethSpentOnCorrection);
+        uint256 actualTokensReceived = _takeToken(state.token, tokensReceivedFromCorrection);
+
+        // --- Step 3: final position, using everything not already committed to
+        // the bootstrap mint or spent/received in the corrective swap, minted at
+        // the now-corrected price.
+        uint256 ethRemaining = ethAvailable - bootstrapEthPaid - ethSpentOnCorrection;
+        uint256 tokensRemaining = tokensAvailable - bootstrapTokensPaid + actualTokensReceived;
+
+        uint128 finalLiquidity = LiquidityAmounts.getLiquidityForAmounts(
+            targetSqrtPriceX96, sqrtPriceLowerX96, sqrtPriceUpperX96, ethRemaining, tokensRemaining
+        );
+        (BalanceDelta finalDelta,) = poolManager.modifyLiquidity(
+            key,
+            ModifyLiquidityParams({
+                tickLower: tickLower,
+                tickUpper: tickUpper,
+                liquidityDelta: int256(uint256(finalLiquidity)),
+                salt: salt
+            }),
+            ""
+        );
+        (uint256 ethDeployed, uint256 tokensDeployed) = _settleMintDelta(state.token, finalDelta);
+
+        // Whatever's left in the hook's own balance after both mints is the
+        // honest, reported dust described above — not deposited anywhere.
+        // Written to storage (not just emitted) so it is a live, queryable,
+        // per-pool record rather than something only recoverable by scanning
+        // event logs — see the mappings' own doc comment for why this is kept
+        // separate from creatorBalances.
+        uint256 ethDust = ethRemaining - ethDeployed;
+        uint256 tokenDust = tokensRemaining - tokensDeployed;
+        ethDustBalances[poolId] = ethDust;
+        tokenDustBalances[poolId] = tokenDust;
+
+        emit GraduationLiquidityDeployed(poolId, bootstrapLiquidity, finalLiquidity, targetSqrtPriceX96, ethDust, tokenDust);
+    }
+
+    /// @dev Settles a modifyLiquidity() mint's negative (owed-to-pool) deltas. A
+    /// plain mint should never return a positive delta (that would mean the pool
+    /// owes US on a pure add) — a positive value here reverts loudly rather than
+    /// being silently take()n, matching this file's no-silent-failures
+    /// convention. Returns the exact (ETH, token) amounts actually paid in.
+    function _settleMintDelta(address token, BalanceDelta delta) internal returns (uint256 ethPaid, uint256 tokensPaid) {
+        int128 ethDelta = delta.amount0();
+        int128 tokenDelta = delta.amount1();
+        if (ethDelta > 0 || tokenDelta > 0) revert GraduationMintUnexpectedCredit();
+        ethPaid = uint256(uint128(-ethDelta));
+        tokensPaid = uint256(uint128(-tokenDelta));
+        if (ethPaid > 0) _settleNative(ethPaid);
+        if (tokensPaid > 0) _settleToken(token, tokensPaid);
+    }
+
+    // ------------------------------------------------------------------------
+    // Settlement helpers — reimplemented directly against IPoolManager (the
+    // reference pattern in v4-core's test/utils/CurrencySettler.sol is
+    // test-only and not meant to be imported into production contracts; this is
+    // an independent implementation of the same publicly-documented
+    // sync/transfer/settle and take mechanics, not a copy).
+    // ------------------------------------------------------------------------
+    function _takeNative(uint256 amount) internal {
+        poolManager.take(Currency.wrap(address(0)), address(this), amount);
+    }
+
+    function _settleNative(uint256 amount) internal {
+        poolManager.settle{value: amount}();
+    }
+
+    /// @return actualReceived The measured balance delta on the PoolManager, not
+    /// the nominal `amount` — fee-on-transfer safe by construction.
+    function _takeToken(address token, uint256 amount) internal returns (uint256 actualReceived) {
+        uint256 balanceBefore = IERC20(token).balanceOf(address(this));
+        poolManager.take(Currency.wrap(token), address(this), amount);
+        actualReceived = IERC20(token).balanceOf(address(this)) - balanceBefore;
+    }
+
+    function _settleToken(address token, uint256 amount) internal {
+        poolManager.sync(Currency.wrap(token));
+        bool success = IERC20(token).transfer(address(poolManager), amount);
+        if (!success) revert TokenTransferFailed();
+        poolManager.settle();
+    }
+
+    // ------------------------------------------------------------------------
+    // Math helpers
+    // ------------------------------------------------------------------------
+
+    /// @dev sqrtPriceX96 for a pool where amount0 = amount of currency0 (native ETH)
+    ///      and amount1 = amount of currency1 (the Incentifi token) at the target
+    ///      price. Computed as sqrt(amount1) * 2^96 / sqrt(amount0) rather than the
+    ///      more direct sqrt(amount1 * 2^192 / amount0), to avoid the 512-bit
+    ///      intermediate multiplication that direct form would need — same technique
+    ///      already used and fork-test-verified (0 ppm error) in
+    ///      IncentifiBondingCurve._computeSqrtPriceX96, reused here for the launch
+    ///      price instead of the graduation price.
+    /// @notice The single source of truth for the correct starting price at this
+    ///         contract's (test-scale) constants, exposed publicly so
+    ///         IncentifiV4Factory calls this directly instead of recomputing the
+    ///         same math independently — duplicating security-critical price math
+    ///         in two contracts is exactly how it silently drifts apart later.
+    function launchSqrtPriceX96() public pure returns (uint160) {
+        return _computeSqrtPriceX96(VIRTUAL_ETH, VIRTUAL_TOKEN + TOTAL_SUPPLY);
+    }
+
+    function _computeSqrtPriceX96(uint256 amount0, uint256 amount1) internal pure returns (uint160) {
+        uint256 sqrtAmount0 = _sqrt(amount0);
+        uint256 sqrtAmount1 = _sqrt(amount1);
+        return uint160((sqrtAmount1 << 96) / sqrtAmount0);
+    }
+
+    function _sqrt(uint256 x) internal pure returns (uint256 y) {
+        if (x == 0) return 0;
+        uint256 z = (x + 1) / 2;
+        y = x;
+        while (z < y) {
+            y = z;
+            z = (x / z + z) / 2;
+        }
+    }
+
+    function _toInt128(uint256 x) internal pure returns (int128) {
+        require(x <= uint256(uint128(type(int128).max)), "overflow");
+        return int128(uint128(x));
+    }
+
+    receive() external payable {}
+}

--- a/contracts/v4/test-helpers/GenericV4Bot.sol
+++ b/contracts/v4/test-helpers/GenericV4Bot.sol
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {IPoolManager} from "@uniswap/v4-periphery/lib/v4-core/src/interfaces/IPoolManager.sol";
+import {IUnlockCallback} from "@uniswap/v4-periphery/lib/v4-core/src/interfaces/callback/IUnlockCallback.sol";
+import {PoolKey} from "@uniswap/v4-periphery/lib/v4-core/src/types/PoolKey.sol";
+import {BalanceDelta} from "@uniswap/v4-periphery/lib/v4-core/src/types/BalanceDelta.sol";
+import {Currency} from "@uniswap/v4-periphery/lib/v4-core/src/types/Currency.sol";
+import {SwapParams, ModifyLiquidityParams} from "@uniswap/v4-periphery/lib/v4-core/src/types/PoolOperation.sol";
+import {TickMath} from "@uniswap/v4-periphery/lib/v4-core/src/libraries/TickMath.sol";
+
+interface IERC20Min {
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+}
+
+/**
+ * @title GenericV4Bot
+ * @notice TEST-ONLY. A minimal, standalone caller written against nothing but
+ *         the PUBLIC Uniswap V4 core interfaces (IPoolManager, IUnlockCallback,
+ *         PoolKey, SwapParams, ModifyLiquidityParams, Currency) — no import of,
+ *         and no reference to, IncentifiV4Hook, IncentifiV4Factory, or
+ *         IncentifiV4Router anywhere in this file. Stands in for "any generic
+ *         V4-aware bot, router, or LP, with zero Incentifi-specific knowledge,
+ *         that discovers this pool via its PoolKey/PoolId alone" — proving the
+ *         pool is genuinely permissionless, both for trading (swap()) and,
+ *         once graduated, for providing liquidity (addLiquidity()).
+ *
+ *         Also the ONLY way to exercise a POST-graduation trade at all:
+ *         IncentifiV4Router.buyToken()/sellToken() both revert once a pool has
+ *         graduated (PoolGraduated()) — that router is deliberately
+ *         pre-graduation-only. Post-graduation trading is meant to happen via
+ *         a raw PoolManager caller exactly like this one (or a real generic V4
+ *         router/UniversalRouter), which is also the only way to genuinely
+ *         exercise IncentifiV4Hook's afterSwap sell-side fee mechanism.
+ *
+ * @dev HONEST LIMITATION vs. the v3 fork test's equivalent check: the v3 suite's
+ *      "generic bot" call went through SwapRouter02 — a real, already-deployed
+ *      Uniswap periphery contract nobody at Incentifi wrote. No equivalent real,
+ *      pre-deployed generic V4 router/UniversalRouter/PositionManager address
+ *      was found on this chain/fork to call the same way, so this is a
+ *      from-scratch reference implementation of the same "generic caller"
+ *      property, built only from Uniswap's published V4 interfaces, rather than
+ *      a call against a real pre-existing generic contract. Flagged rather than
+ *      overstated.
+ */
+contract GenericV4Bot is IUnlockCallback {
+    IPoolManager public immutable poolManager;
+
+    error OnlyPoolManager();
+    error SlippageExceeded();
+    error UnknownCall();
+
+    enum CallKind {
+        Swap,
+        AddLiquidity
+    }
+
+    struct SwapCall {
+        PoolKey key;
+        SwapParams params;
+        uint256 minAmountOut;
+        address trader;
+    }
+
+    struct LPCall {
+        PoolKey key;
+        int24 tickLower;
+        int24 tickUpper;
+        int256 liquidityDelta;
+        bytes32 salt;
+        address trader;
+        uint256 ethProvided;
+    }
+
+    constructor(IPoolManager _poolManager) {
+        poolManager = _poolManager;
+    }
+
+    /// @notice Exact-input swap against `key`, with zero knowledge of what hook
+    /// (if any) is attached — exactly what a generic bot would do armed with
+    /// nothing but a PoolKey and the standard V4 ABI. For a currency0 (native
+    /// ETH) input, send exactly `amountIn` as msg.value.
+    function swap(PoolKey calldata key, bool zeroForOne, uint256 amountIn, uint256 minAmountOut)
+        external
+        payable
+        returns (uint256 amountOut)
+    {
+        // A real swap against real liquidity (as opposed to one a full-absorption
+        // hook reduces to a zero-amount no-op for the core pool, which never
+        // reaches this validation at all) requires a genuinely bounded price
+        // limit — Pool.sol rejects 0 outright (PriceLimitOutOfBounds, since 0 is
+        // always <= TickMath.MIN_SQRT_PRICE). Use the widest valid limit in each
+        // direction, i.e. "no meaningful limit", matching ordinary router
+        // behavior for an exact-input trade with no explicit price bound.
+        uint160 sqrtPriceLimitX96 = zeroForOne ? TickMath.MIN_SQRT_PRICE + 1 : TickMath.MAX_SQRT_PRICE - 1;
+        bytes memory result = poolManager.unlock(
+            abi.encode(
+                CallKind.Swap,
+                abi.encode(
+                    SwapCall({
+                        key: key,
+                        params: SwapParams({zeroForOne: zeroForOne, amountSpecified: -int256(amountIn), sqrtPriceLimitX96: sqrtPriceLimitX96}),
+                        minAmountOut: minAmountOut,
+                        trader: msg.sender
+                    })
+                )
+            )
+        );
+        amountOut = abi.decode(result, (uint256));
+    }
+
+    /// @notice Adds real liquidity to `key` at [tickLower, tickUpper], with zero
+    /// Incentifi-specific knowledge — proving a genuine third party, not just
+    /// the hook itself, can provide liquidity once a pool allows it (which
+    /// IncentifiV4Hook only ever does post-graduation; pre-graduation this will
+    /// revert inside the hook's own beforeAddLiquidity, exactly as intended).
+    /// Caller must send generous ETH (refunded if unused) and have approved
+    /// this contract for a generous token amount beforehand — the exact amount
+    /// actually required is computed by the real pool math inside the callback,
+    /// not predicted here.
+    function addLiquidity(PoolKey calldata key, int24 tickLower, int24 tickUpper, int256 liquidityDelta, bytes32 salt)
+        external
+        payable
+        returns (uint256 ethUsed, uint256 tokenUsed)
+    {
+        bytes memory result = poolManager.unlock(
+            abi.encode(
+                CallKind.AddLiquidity,
+                abi.encode(
+                    LPCall({
+                        key: key,
+                        tickLower: tickLower,
+                        tickUpper: tickUpper,
+                        liquidityDelta: liquidityDelta,
+                        salt: salt,
+                        trader: msg.sender,
+                        ethProvided: msg.value
+                    })
+                )
+            )
+        );
+        (ethUsed, tokenUsed) = abi.decode(result, (uint256, uint256));
+    }
+
+    function unlockCallback(bytes calldata data) external override returns (bytes memory) {
+        if (msg.sender != address(poolManager)) revert OnlyPoolManager();
+        (CallKind kind, bytes memory payload) = abi.decode(data, (CallKind, bytes));
+        if (kind == CallKind.Swap) {
+            return abi.encode(_executeSwap(abi.decode(payload, (SwapCall))));
+        } else if (kind == CallKind.AddLiquidity) {
+            (uint256 ethUsed, uint256 tokenUsed) = _executeAddLiquidity(abi.decode(payload, (LPCall)));
+            return abi.encode(ethUsed, tokenUsed);
+        }
+        revert UnknownCall();
+    }
+
+    function _executeSwap(SwapCall memory call) internal returns (uint256 amountOut) {
+        BalanceDelta delta = poolManager.swap(call.key, call.params, "");
+
+        (Currency inCurrency, Currency outCurrency, int128 inDelta, int128 outDelta) = call.params.zeroForOne
+            ? (call.key.currency0, call.key.currency1, delta.amount0(), delta.amount1())
+            : (call.key.currency1, call.key.currency0, delta.amount1(), delta.amount0());
+
+        amountOut = uint256(uint128(outDelta));
+        if (amountOut < call.minAmountOut) revert SlippageExceeded();
+
+        uint256 amountIn = uint256(uint128(-inDelta));
+        if (inCurrency.isAddressZero()) {
+            poolManager.settle{value: amountIn}();
+        } else {
+            poolManager.sync(inCurrency);
+            IERC20Min(Currency.unwrap(inCurrency)).transferFrom(call.trader, address(poolManager), amountIn);
+            poolManager.settle();
+        }
+
+        poolManager.take(outCurrency, call.trader, amountOut);
+    }
+
+    /// @dev Mint-only (liquidityDelta expected positive). Settles whatever the
+    /// real pool math says is owed for each currency, pulling ETH from the
+    /// generous msg.value already forwarded into this contract and tokens via
+    /// transferFrom on the trader (who must have approved this contract). Any
+    /// leftover ETH beyond what was actually owed is refunded to the trader.
+    function _executeAddLiquidity(LPCall memory call) internal returns (uint256 ethUsed, uint256 tokenUsed) {
+        (BalanceDelta delta,) = poolManager.modifyLiquidity(
+            call.key,
+            ModifyLiquidityParams({
+                tickLower: call.tickLower,
+                tickUpper: call.tickUpper,
+                liquidityDelta: call.liquidityDelta,
+                salt: call.salt
+            }),
+            ""
+        );
+
+        ethUsed = _settleOrTake(call.key.currency0, delta.amount0(), call.trader, true);
+        tokenUsed = _settleOrTake(call.key.currency1, delta.amount1(), call.trader, false);
+
+        if (call.ethProvided > ethUsed) {
+            (bool ok,) = call.trader.call{value: call.ethProvided - ethUsed}("");
+            require(ok, "refund failed");
+        }
+    }
+
+    /// @dev amount < 0: the mint owes this currency to the pool — settle it,
+    /// pulling from the trader (tokens) or from this contract's own balance
+    /// (ETH, already forwarded via msg.value). amount > 0: pool owes it back
+    /// (rare for a plain mint, but handled rather than assumed away) — take()
+    /// it and forward to the trader directly.
+    function _settleOrTake(Currency currency, int128 amount, address trader, bool isNative) internal returns (uint256 used) {
+        if (amount < 0) {
+            used = uint256(uint128(-amount));
+            if (isNative) {
+                poolManager.settle{value: used}();
+            } else {
+                poolManager.sync(currency);
+                IERC20Min(Currency.unwrap(currency)).transferFrom(trader, address(poolManager), used);
+                poolManager.settle();
+            }
+        } else if (amount > 0) {
+            uint256 owed = uint256(uint128(amount));
+            poolManager.take(currency, trader, owed);
+            used = 0;
+        }
+    }
+
+    receive() external payable {}
+}

--- a/contracts/v4/test-helpers/HookMinerCheck.sol
+++ b/contracts/v4/test-helpers/HookMinerCheck.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {HookMiner} from "@uniswap/v4-periphery/src/utils/HookMiner.sol";
+
+/**
+ * @title HookMinerCheck
+ * @notice TEST-ONLY. Exposes HookMiner.computeAddress() (a single pair of keccak256
+ *         calls — cheap, not the brute-force find() loop) so an off-chain salt search
+ *         can be cross-checked against the REAL, actual HookMiner library this repo
+ *         depends on, instead of trusting a from-scratch JS reimplementation of the
+ *         same formula on its own say-so. Not part of contracts/v4/'s production set;
+ *         lives under test-helpers/ deliberately.
+ */
+contract HookMinerCheck {
+    function computeAddress(address deployer, uint256 salt, bytes memory creationCodeWithArgs)
+        external
+        pure
+        returns (address)
+    {
+        return HookMiner.computeAddress(deployer, salt, creationCodeWithArgs);
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@stripe/react-stripe-js": "4.0.2",
         "@supabase/supabase-js": "^2.57.4",
+        "@uniswap/v4-core": "^1.0.2",
+        "@uniswap/v4-periphery": "^1.0.3",
         "buffer": "^6.0.3",
         "firebase": "^12.7.0",
         "i18next": "^25.3.2",
@@ -2105,9 +2107,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2125,9 +2124,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2145,9 +2141,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2165,9 +2158,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3968,6 +3958,18 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@uniswap/v4-core": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/v4-core/-/v4-core-1.0.2.tgz",
+      "integrity": "sha512-X15Tm2wWd+USAzEExMbo+g9naA6QN6mPgWm0MzDwRNlOfaNlepfUpSyt9RSrUfEODspwbyWbcLg6t5nwc/e7lg==",
+      "license": "BUSL-1.1"
+    },
+    "node_modules/@uniswap/v4-periphery": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@uniswap/v4-periphery/-/v4-periphery-1.0.3.tgz",
+      "integrity": "sha512-JxLL0Djv9XcMvI2PatEnWrCrxuEaYNVhHxstndBOP+aJfh1XLg5ec8SDZ0xyoVfg2ElJTvuKpBgnu90bNValsg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react-swc": {
       "version": "3.11.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "dependencies": {
     "@stripe/react-stripe-js": "4.0.2",
     "@supabase/supabase-js": "^2.57.4",
+    "@uniswap/v4-core": "^1.0.2",
+    "@uniswap/v4-periphery": "^1.0.3",
     "buffer": "^6.0.3",
     "firebase": "^12.7.0",
     "i18next": "^25.3.2",

--- a/scripts/deploy-v4-hook-generic-sell-mainnet.ts
+++ b/scripts/deploy-v4-hook-generic-sell-mainnet.ts
@@ -1,0 +1,395 @@
+/**
+ * Deploys IncentifiV4HookGenericSell — IncentifiV4HookNoPostGradFee's exact
+ * logic (four permission flags, no afterSwap, ZERO_DELTA pass-through once
+ * graduated, FULL production economics: $5,000 launch / $69,000 graduation,
+ * unscaled) with ONE change: a pre-graduation SELL receives the seller's tokens
+ * as ERC-6909 claims (PoolManager.mint) instead of a physical PoolManager.take()
+ * — to REAL Robinhood Chain mainnet, wired to the REAL production LossRewardPool
+ * (0x697BDA9db5a297a9Cd9ED969BBF2549d0527DcdF).
+ *
+ * ============================================================================
+ * WHY A NEW HOOK:
+ * ============================================================================
+ * A real, root-caused production incident. Third-party trading bots could BUY
+ * every token launched through the NoPostGradFee hook (real mainnet txs, real
+ * PoolManager routing, the real 1% LossRewardPool fee paid) but could never SELL
+ * one pre-graduation — every attempt died in the bot's own pre-broadcast
+ * simulation, no tx hash. Chased first as an approval problem; it was not (the
+ * bot already held an unlimited direct allowance on every token). The cause is
+ * settlement ORDER: NoPostGradFee's _executeSell take()s the seller's tokens out
+ * of PoolManager inside beforeSwap, which only works if the caller settled them
+ * INTO PoolManager BEFORE swap() — which only IncentifiV4Router does. Every
+ * generic V4 router (UniversalRouter, bots, GenericV4Bot) uses the standard
+ * swap-then-settle order, so that take() fires against a PoolManager holding
+ * none of a fresh token and reverts. Buys are unaffected: the hook take()s native
+ * ETH there, borrowing momentarily against PoolManager's real ETH from other
+ * pools. The full argument — and why the claims-based fix is safe, verified
+ * against the installed PoolManager.sol — is in
+ * contracts/v4/IncentifiV4HookGenericSell.sol's header.
+ *
+ * PROVEN, at the same evidence standard as every other deploy in this batch:
+ *   - test/hardhat/v4-generic-sell-proof.test.ts (PASSED): on a mainnet fork,
+ *     against the REAL deployed production hook and the REAL TESTING pool, with
+ *     the REAL creator wallet's real balance — the generic sell reverts, the
+ *     same sell via IncentifiV4Router succeeds, and the same generic caller's
+ *     BUY succeeds. Root cause confirmed; approvals ruled out.
+ *   - test/hardhat/v4-generic-sell-hook.test.ts: deploys THIS contract via the
+ *     same CREATE2 factory and 0x2888 flag mask this script uses, then proves a
+ *     generic swap-then-settle sell SUCCEEDS, claims flow through subsequent
+ *     buys (the burn path), and a full graduation consumes every claim to zero.
+ *     THIS SCRIPT MUST NOT BE RUN UNTIL THAT TEST PASSES.
+ *
+ * Tokens already launched on the old hook (0x5bBcf2CDAAA00c285eEc903AA1E2aB9142782888)
+ * are permanently bound to it — a pool's hook address is immutable — and stay
+ * sellable only through IncentifiV4Router pre-graduation. This deployment only
+ * helps launches made through the NEW factory it deploys; the website must be
+ * re-pointed at the new factory/router/hook for that to happen.
+ *
+ * Mines a CREATE2 salt for the 4-flag permission set (IDENTICAL to the
+ * NoPostGradFee deploy — same four flags, so the same REQUIRED_FLAGS; still a
+ * different value than the six-flag production hook), deploys
+ * IncentifiV4HookGenericSell, then the SAME, unmodified IncentifiV4Factory.sol
+ * and IncentifiV4Router.sol (they just call through to whatever hook address
+ * they're given — no code change was needed for this fix, and the router's own
+ * settle-before-swap order remains compatible with the new hook), with
+ * setFactory() wiring in between.
+ *
+ * Every transaction goes through the plain viem WalletClient
+ * (deployContract/sendTransaction/writeContract) — never Hardhat's own
+ * viem.sendDeploymentTransaction() helper, for the same reason documented in
+ * every other deploy script in this batch (a real incident during the v3
+ * mainnet redeploy proved that helper's extra post-broadcast lookup can throw
+ * even after the underlying transaction already succeeded, defeating any
+ * resume logic built on top of it).
+ *
+ * SAFETY GATES:
+ *   - DEPLOYER_PRIVATE_KEY (or PRIVATE_KEY) — a funded Robinhood Chain mainnet key
+ *   - DEPLOY_CONFIRM=I_UNDERSTAND_THIS_IS_MAINNET
+ *
+ * Usage:
+ *   DEPLOYER_PRIVATE_KEY=0x... DEPLOY_CONFIRM=I_UNDERSTAND_THIS_IS_MAINNET \
+ *     npx hardhat run scripts/deploy-v4-hook-generic-sell-mainnet.ts --network robinhoodMainnet
+ *
+ * Does NOT launch a token, buy, sell, or drive graduation — scope here is
+ * exactly "deploy hook + factory + router, verify every constructor argument
+ * on-chain", matching deploy-v4-hook-production-mainnet.ts's scope. Note that
+ * driving a real graduation on THIS hook still costs the same ~5.9 ETH
+ * production graduation target as the six-flag hook — dropping afterSwap
+ * changes what happens AFTER graduation, not the cost of reaching it.
+ *
+ * CRASH / RPC-HICCUP SAFETY (automatic — no flag needed): every step's tx hash
+ * is written to scripts/.v4-generic-sell-deployment-state.json BEFORE this
+ * script ever waits on its receipt. Re-running the exact same command resumes
+ * rather than resends.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { network, artifacts } from 'hardhat';
+import { keccak256, encodeAbiParameters, parseAbiParameters, concat, pad, toHex, getAddress, getContractAddress, formatEther } from 'viem';
+
+const CHAIN_ID = 4663;
+const CREATE2_FACTORY = getAddress('0x4e59b44847b379578588920cA78FbF26c0B4956C');
+const POOL_MANAGER = getAddress('0x8366a39cc670b4001a1121b8f6a443a643e40951');
+const REAL_PRODUCTION_LOSS_REWARD_POOL = getAddress('0x697bda9db5a297a9cd9ed969bbf2549d0527dcdf');
+
+// getHookPermissions() for IncentifiV4HookGenericSell: beforeInitialize(1<<13) |
+// beforeAddLiquidity(1<<11) | beforeSwap(1<<7) | beforeSwapReturnDelta(1<<3) only —
+// NO afterSwap/afterSwapReturnDelta. IDENTICAL to IncentifiV4HookNoPostGradFee's
+// (the claims-based sell fix changes settlement inside beforeSwap, not which hooks
+// fire), so this is the exact value already proven correct by the real mainnet
+// deploy at 0x5bBcf2CDAAA00c285eEc903AA1E2aB9142782888. Cross-checked below against
+// the real on-chain HookMiner.computeAddress() before any deploy transaction is sent.
+const REQUIRED_FLAGS = (1n << 13n) | (1n << 11n) | (1n << 7n) | (1n << 3n); // 10376 (0x2888)
+const FLAG_MASK = (1n << 14n) - 1n;
+const MAX_SALT_SEARCH = 160_444;
+
+const STATE_PATH = path.resolve('scripts', '.v4-generic-sell-deployment-state.json');
+const RESULT_PATH = path.resolve('scripts', '.v4-generic-sell-deployment-result.json');
+const RECEIPT_RETRY_ATTEMPTS = Number(process.env.RECEIPT_RETRY_ATTEMPTS || 6);
+const RECEIPT_RETRY_BASE_DELAY_MS = Number(process.env.RECEIPT_RETRY_DELAY_MS || 5000);
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function computeCreate2Address(deployer: `0x${string}`, salt: bigint, initCodeHash: `0x${string}`): `0x${string}` {
+  const packed = concat(['0xff', deployer, pad(toHex(salt), { size: 32 }), initCodeHash]);
+  return getAddress(`0x${keccak256(packed).slice(-40)}`);
+}
+
+function requireConfirmation() {
+  if (process.env.DEPLOY_CONFIRM !== 'I_UNDERSTAND_THIS_IS_MAINNET') {
+    throw new Error(
+      '\nRefusing to run: this deploys NEW, IMMUTABLE contracts to REAL Robinhood Chain mainnet, wired to the ' +
+      'REAL production LossRewardPool, at real production economics.\n' +
+      'Set DEPLOY_CONFIRM=I_UNDERSTAND_THIS_IS_MAINNET to proceed.\n'
+    );
+  }
+  const key = (process.env.DEPLOYER_PRIVATE_KEY || process.env.PRIVATE_KEY || '').trim();
+  if (!key) {
+    throw new Error('DEPLOYER_PRIVATE_KEY (or PRIVATE_KEY) env var is required to deploy.');
+  }
+}
+
+type StepRecord = { hash?: `0x${string}`; confirmed?: boolean; blockNumber?: string; gasUsed?: string; effectiveGasPrice?: string; [key: string]: unknown };
+type DeployState = { wallet: `0x${string}`; steps: Record<string, StepRecord> };
+
+function loadState(walletRaw: `0x${string}`): DeployState {
+  const wallet = getAddress(walletRaw);
+  if (!fs.existsSync(STATE_PATH)) return { wallet, steps: {} };
+  const raw = JSON.parse(fs.readFileSync(STATE_PATH, 'utf8'));
+  if (!raw.wallet || getAddress(raw.wallet) !== wallet) {
+    throw new Error(
+      `${STATE_PATH} exists but is for a different wallet than this run (state: ${raw.wallet}, this run: ${wallet}).\n` +
+      `Move or delete ${STATE_PATH} by hand before re-running with a different wallet.`
+    );
+  }
+  const steps = raw.steps || {};
+  if (Object.keys(steps).length > 0) {
+    console.log(`[STATE] Found ${STATE_PATH} — resuming. Steps already recorded: ${Object.keys(steps).join(', ')}\n`);
+  }
+  return { wallet, steps };
+}
+
+function persistState(state: DeployState) {
+  fs.mkdirSync(path.dirname(STATE_PATH), { recursive: true });
+  fs.writeFileSync(STATE_PATH, JSON.stringify({ ...state, updatedAt: new Date().toISOString() }, null, 2));
+}
+
+async function main() {
+  requireConfirmation();
+
+  const { viem } = await network.create('robinhoodMainnet');
+  const publicClient = await viem.getPublicClient();
+
+  const chainId = await publicClient.getChainId();
+  if (chainId !== CHAIN_ID) throw new Error(`Chain ID mismatch! Expected ${CHAIN_ID}, got ${chainId}.`);
+
+  const [wallet] = await viem.getWalletClients();
+  const account = getAddress(wallet.account.address);
+  const balanceBefore = await publicClient.getBalance({ address: account });
+
+  console.log('\n============================================================');
+  console.log('[DEPLOY V4 HOOK — NO POST-GRAD FEE, PRODUCTION ECONOMICS] Robinhood Chain MAINNET');
+  console.log('============================================================');
+  console.log(`Deployer:                       ${account}`);
+  console.log(`Balance:                        ${formatEther(balanceBefore)} ETH`);
+  console.log(`CREATE2 singleton factory:      ${CREATE2_FACTORY}`);
+  console.log(`PoolManager:                    ${POOL_MANAGER}`);
+  console.log(`REAL production LossRewardPool: ${REAL_PRODUCTION_LOSS_REWARD_POOL}`);
+  console.log(`Required permission flags:      ${REQUIRED_FLAGS} (0x${REQUIRED_FLAGS.toString(16)}) — FOUR flags, identical to the NoPostGradFee deploy (the sell fix is claims-based settlement inside beforeSwap, not a permission change)`);
+  console.log('============================================================\n');
+
+  if (balanceBefore === 0n) throw new Error(`Deployer ${account} has zero ETH balance on mainnet. Fund it before deploying.`);
+
+  const prodPoolBalanceBefore = await publicClient.getBalance({ address: REAL_PRODUCTION_LOSS_REWARD_POOL });
+
+  const state = loadState(account);
+
+  async function waitForReceiptWithRetry(hash: `0x${string}`, label: string) {
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= RECEIPT_RETRY_ATTEMPTS; attempt++) {
+      try {
+        return await publicClient.waitForTransactionReceipt({ hash, confirmations: 1, timeout: 90_000 });
+      } catch (err) {
+        lastErr = err;
+        const delay = RECEIPT_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+        console.warn(`  [${label}] receipt wait attempt ${attempt}/${RECEIPT_RETRY_ATTEMPTS} failed (${err instanceof Error ? err.message : String(err)})` + (attempt < RECEIPT_RETRY_ATTEMPTS ? `; retrying in ${Math.round(delay / 1000)}s...` : ''));
+        if (attempt < RECEIPT_RETRY_ATTEMPTS) await sleep(delay);
+      }
+    }
+    throw new Error(`[${label}] Could not confirm receipt for tx ${hash} after ${RECEIPT_RETRY_ATTEMPTS} attempts. Its hash is already in ${STATE_PATH}; re-running resumes rather than resends.\nLast error: ${lastErr instanceof Error ? lastErr.message : String(lastErr)}`);
+  }
+
+  async function runStep(name: string, sendFn: () => Promise<{ hash: `0x${string}`; [key: string]: unknown }>, precomputedExtra: Record<string, unknown> = {}): Promise<StepRecord> {
+    let record = state.steps[name];
+    if (!record) {
+      console.log(`[${name}] sending transaction...`);
+      const sent = await sendFn();
+      record = { confirmed: false, ...precomputedExtra, ...sent };
+      state.steps[name] = record;
+      persistState(state);
+      console.log(`  Tx sent: ${record.hash}`);
+    } else {
+      console.log(`[${name}] resuming — tx already on record: ${record.hash} (confirmed: ${Boolean(record.confirmed)})`);
+    }
+    if (!record.confirmed) {
+      const receipt = await waitForReceiptWithRetry(record.hash as `0x${string}`, name);
+      if (receipt.status !== 'success') throw new Error(`[${name}] transaction reverted (status: ${receipt.status}). Tx: ${record.hash}`);
+      record.confirmed = true;
+      record.blockNumber = receipt.blockNumber.toString();
+      record.gasUsed = receipt.gasUsed.toString();
+      record.effectiveGasPrice = receipt.effectiveGasPrice.toString();
+      state.steps[name] = record;
+      persistState(state);
+      console.log(`  Confirmed in block #${receipt.blockNumber} (gas used ${receipt.gasUsed})\n`);
+    }
+    return record;
+  }
+
+  // ==========================================================================
+  // Step 1: mine the CREATE2 salt for IncentifiV4HookGenericSell
+  // ==========================================================================
+  console.log('[1/5] Mining CREATE2 salt for IncentifiV4HookGenericSell...');
+  const hookArtifact = await artifacts.readArtifact('IncentifiV4HookGenericSell');
+  const hookConstructorArgs = encodeAbiParameters(parseAbiParameters('address, address, address'), [POOL_MANAGER, REAL_PRODUCTION_LOSS_REWARD_POOL, account]);
+  const hookInitCode = concat([hookArtifact.bytecode as `0x${string}`, hookConstructorArgs]);
+  const hookInitCodeHash = keccak256(hookInitCode);
+
+  let foundSalt: bigint | null = null;
+  let foundHookAddress: `0x${string}` | null = null;
+  const searchStart = Date.now();
+  for (let salt = 0n; salt < BigInt(MAX_SALT_SEARCH); salt++) {
+    const candidate = computeCreate2Address(CREATE2_FACTORY, salt, hookInitCodeHash);
+    if ((BigInt(candidate) & FLAG_MASK) === REQUIRED_FLAGS) {
+      foundSalt = salt;
+      foundHookAddress = candidate;
+      break;
+    }
+  }
+  if (foundSalt === null || foundHookAddress === null) throw new Error(`No valid CREATE2 salt found within ${MAX_SALT_SEARCH} attempts.`);
+  console.log(`  Found salt ${foundSalt} after ${Date.now() - searchStart}ms (off-chain, zero gas)`);
+  console.log(`  Predicted hook address: ${foundHookAddress}`);
+
+  const hookMinerCheckArtifact = await artifacts.readArtifact('HookMinerCheck');
+  const hmcRecord = await runStep('hookMinerCheckDeploy', async () => {
+    const nonce = await publicClient.getTransactionCount({ address: account, blockTag: 'pending' });
+    const address = getContractAddress({ from: account, nonce: BigInt(nonce) });
+    const hash = await wallet.deployContract({ abi: hookMinerCheckArtifact.abi, bytecode: hookMinerCheckArtifact.bytecode as `0x${string}`, nonce });
+    return { hash, address };
+  });
+  const hookMinerCheck = await viem.getContractAt('HookMinerCheck', getAddress(hmcRecord.address as string));
+  const onChainComputed = getAddress(await hookMinerCheck.read.computeAddress([CREATE2_FACTORY, foundSalt, hookInitCode]));
+  if (onChainComputed !== foundHookAddress) throw new Error('JS-computed hook address does not match the REAL on-chain HookMiner library. Stopping.');
+  console.log(`  Cross-checked against real HookMiner.computeAddress(): MATCH\n`);
+
+  // Only meaningful before hookDeploy has ever been sent — on a resume where
+  // state.steps.hookDeploy is already on record, code at this address is the
+  // EXPECTED, successful outcome of that prior run, not a collision to abort
+  // on. Checking unconditionally here previously broke every resume: the
+  // legitimate "already deployed" case looked identical to the genuinely
+  // impossible "salt collision" case this check exists to catch.
+  if (!state.steps.hookDeploy) {
+    const codeAtPredicted = await publicClient.getCode({ address: foundHookAddress });
+    if (codeAtPredicted && codeAtPredicted !== '0x') throw new Error(`Predicted hook address ${foundHookAddress} already has code. Stopping.`);
+  }
+
+  // ==========================================================================
+  // Step 2: deploy the hook via CREATE2
+  // ==========================================================================
+  console.log('[2/5] Deploying IncentifiV4HookGenericSell via CREATE2...');
+  const hookDeployData = concat([pad(toHex(foundSalt), { size: 32 }), hookInitCode]);
+  await runStep('hookDeploy', async () => ({ hash: await wallet.sendTransaction({ to: CREATE2_FACTORY, data: hookDeployData }) }));
+
+  const hookCode = await publicClient.getCode({ address: foundHookAddress });
+  if (!hookCode || hookCode === '0x') throw new Error(`Hook deployment succeeded but no code landed at ${foundHookAddress}.`);
+  const deployedFlags = BigInt(foundHookAddress) & FLAG_MASK;
+  if (deployedFlags !== REQUIRED_FLAGS) throw new Error(`Deployed hook permission bits (${deployedFlags}) != required (${REQUIRED_FLAGS}).`);
+  console.log(`  eth_getCode: NON-EMPTY (${(hookCode.length - 2) / 2} bytes). Permission bits confirmed.`);
+
+  const hookContract = await viem.getContractAt('IncentifiV4HookGenericSell', foundHookAddress);
+  const hookDeployerOnChain = getAddress(await hookContract.read.deployer());
+  const hookLossRewardPoolOnChain = getAddress(await hookContract.read.lossRewardPool());
+  if (hookDeployerOnChain !== account) throw new Error(`hook.deployer() mismatch: got ${hookDeployerOnChain}.`);
+  if (hookLossRewardPoolOnChain !== REAL_PRODUCTION_LOSS_REWARD_POOL) {
+    throw new Error(`hook.lossRewardPool() mismatch: got ${hookLossRewardPoolOnChain}, expected the REAL production pool ${REAL_PRODUCTION_LOSS_REWARD_POOL}.`);
+  }
+  const hookGraduationTarget = await hookContract.read.GRADUATION_ETH_TARGET();
+  if (hookGraduationTarget !== 5_853_863_234_375_000_000n) throw new Error(`hook.GRADUATION_ETH_TARGET() (${hookGraduationTarget}) is not the full production value.`);
+  console.log(`  hook.deployer() == ${hookDeployerOnChain} (confirmed)`);
+  console.log(`  hook.lossRewardPool() == ${hookLossRewardPoolOnChain} (confirmed == REAL production pool)`);
+  console.log(`  hook.GRADUATION_ETH_TARGET() == ${formatEther(hookGraduationTarget)} ETH (confirmed == full production target)\n`);
+
+  // ==========================================================================
+  // Step 3: IncentifiV4Factory (same, unmodified production contract)
+  // ==========================================================================
+  console.log('[3/5] Deploying IncentifiV4Factory...');
+  const factoryArtifact = await artifacts.readArtifact('IncentifiV4Factory');
+  const factoryRecord = await runStep('factoryDeploy', async () => {
+    const nonce = await publicClient.getTransactionCount({ address: account, blockTag: 'pending' });
+    const address = getContractAddress({ from: account, nonce: BigInt(nonce) });
+    const hash = await wallet.deployContract({ abi: factoryArtifact.abi, bytecode: factoryArtifact.bytecode as `0x${string}`, args: [POOL_MANAGER, foundHookAddress], nonce });
+    return { hash, address };
+  });
+  const factoryAddress = getAddress(factoryRecord.address as string);
+  const factoryContract = await viem.getContractAt('IncentifiV4Factory', factoryAddress);
+  if (getAddress(await factoryContract.read.poolManager()) !== POOL_MANAGER) throw new Error('factory.poolManager() mismatch.');
+  if (getAddress(await factoryContract.read.hook()) !== foundHookAddress) throw new Error('factory.hook() mismatch.');
+  console.log(`  Factory: ${factoryAddress} (confirmed)\n`);
+
+  // ==========================================================================
+  // Step 4: setFactory()
+  // ==========================================================================
+  console.log('[4/5] setFactory() (one-time wiring)...');
+  const factoryBeforeWiring = getAddress(await hookContract.read.factory());
+  if (factoryBeforeWiring === '0x0000000000000000000000000000000000000000') {
+    await runStep('setFactory', async () => ({ hash: await wallet.writeContract({ address: foundHookAddress, abi: hookArtifact.abi, functionName: 'setFactory', args: [factoryAddress] }) }));
+  } else {
+    console.log(`  hook.factory() already set to ${factoryBeforeWiring} — skipping.`);
+  }
+  if (getAddress(await hookContract.read.factory()) !== factoryAddress) throw new Error('hook.factory() does not match the deployed Factory after wiring.');
+  console.log('  hook.factory() confirmed.\n');
+
+  // ==========================================================================
+  // Step 5: IncentifiV4Router (same, unmodified production contract)
+  // ==========================================================================
+  console.log('[5/5] Deploying IncentifiV4Router...');
+  const routerArtifact = await artifacts.readArtifact('IncentifiV4Router');
+  const routerRecord = await runStep('routerDeploy', async () => {
+    const nonce = await publicClient.getTransactionCount({ address: account, blockTag: 'pending' });
+    const address = getContractAddress({ from: account, nonce: BigInt(nonce) });
+    const hash = await wallet.deployContract({ abi: routerArtifact.abi, bytecode: routerArtifact.bytecode as `0x${string}`, args: [POOL_MANAGER, foundHookAddress, factoryAddress], nonce });
+    return { hash, address };
+  });
+  const routerAddress = getAddress(routerRecord.address as string);
+  const routerContract = await viem.getContractAt('IncentifiV4Router', routerAddress);
+  if (getAddress(await routerContract.read.poolManager()) !== POOL_MANAGER) throw new Error('router.poolManager() mismatch.');
+  if (getAddress(await routerContract.read.hook()) !== foundHookAddress) throw new Error('router.hook() mismatch.');
+  if (getAddress(await routerContract.read.factory()) !== factoryAddress) throw new Error('router.factory() mismatch.');
+  console.log(`  Router: ${routerAddress} (confirmed)\n`);
+
+  // Deployment itself should never touch the real production LossRewardPool's balance.
+  const prodPoolBalanceAfter = await publicClient.getBalance({ address: REAL_PRODUCTION_LOSS_REWARD_POOL });
+  if (prodPoolBalanceAfter !== prodPoolBalanceBefore) {
+    throw new Error(`Real production LossRewardPool balance CHANGED during deployment (${formatEther(prodPoolBalanceBefore)} -> ${formatEther(prodPoolBalanceAfter)} ETH). Investigate before trusting anything above.`);
+  }
+  console.log(`Confirmed: real production LossRewardPool balance unchanged (${formatEther(prodPoolBalanceAfter)} ETH).\n`);
+
+  const balanceAfter = await publicClient.getBalance({ address: account });
+  const result = {
+    chainId,
+    deployer: account,
+    hook: {
+      address: foundHookAddress,
+      salt: foundSalt.toString(),
+      permissionFlags: REQUIRED_FLAGS.toString(),
+      hasPostGraduationFee: false,
+      // Pre-graduation sells settle via ERC-6909 claims, so generic swap-then-settle
+      // routers (UniversalRouter, third-party bots) can sell — the reason this hook exists.
+      genericSellCompatible: true,
+      constructorArgs: { poolManager: POOL_MANAGER, lossRewardPool: REAL_PRODUCTION_LOSS_REWARD_POOL, deployer: account },
+    },
+    factory: { address: factoryAddress, constructorArgs: { poolManager: POOL_MANAGER, hook: foundHookAddress } },
+    router: { address: routerAddress, constructorArgs: { poolManager: POOL_MANAGER, hook: foundHookAddress, factory: factoryAddress } },
+    gasSpentWei: (balanceBefore - balanceAfter).toString(),
+    gasSpentEth: formatEther(balanceBefore - balanceAfter),
+    deployedAt: new Date().toISOString(),
+  };
+  fs.writeFileSync(RESULT_PATH, JSON.stringify(result, null, 2));
+
+  console.log('============================================================');
+  console.log('[DEPLOY V4 HOOK — NO POST-GRAD FEE] COMPLETE');
+  console.log('============================================================');
+  console.log(JSON.stringify(result, null, 2));
+  console.log(`\nSaved to ${RESULT_PATH}`);
+  console.log(`Total gas spent: ${formatEther(balanceBefore - balanceAfter)} ETH`);
+  console.log('\nReminder: this hook takes NO fee of any kind on post-graduation trades. Driving a real');
+  console.log('graduation on it still costs the full ~5.9 ETH production target — that cost is unchanged.');
+}
+
+main().catch((err) => {
+  console.error('\n[DEPLOY ERROR]', err instanceof Error ? err.message : err);
+  console.error(`Progress so far is saved in ${STATE_PATH}. Re-running the exact same command resumes, not resends.`);
+  process.exitCode = 1;
+});

--- a/scripts/deploy-v4-hook-no-postgrad-fee-mainnet.ts
+++ b/scripts/deploy-v4-hook-no-postgrad-fee-mainnet.ts
@@ -1,0 +1,376 @@
+/**
+ * Deploys IncentifiV4HookNoPostGradFee — the CORE IncentifiV4Hook bonding-curve
+ * + graduation logic, WITHOUT the afterSwap post-graduation fee mechanism (four
+ * permission flags, not six) — to REAL Robinhood Chain mainnet, at FULL
+ * production economics ($5,000 launch / $69,000 graduation, unscaled), wired to
+ * the REAL production LossRewardPool (0x697BDA9db5a297a9Cd9ED969BBF2549d0527DcdF).
+ *
+ * ============================================================================
+ * WHAT THIS IS AND ISN'T:
+ * ============================================================================
+ * contracts/v4/IncentifiV4HookNoPostGradFee.sol is NOT a from-scratch strip-down
+ * of IncentifiV4Hook.sol. There is no separate git commit for "the hook before
+ * afterSwap was added" — the whole V4 system landed in one commit. Instead, this
+ * is contracts/v4/test-deployment/IncentifiV4HookTestnet.sol's logic verbatim
+ * (that file already IS this exact pre-afterSwap shape: 4 permission flags, a
+ * plain ZERO_DELTA pass-through once graduated, no fee of any kind on
+ * post-graduation trades) — already proven on a fork AND on real Robinhood
+ * Chain mainnet this morning via scripts/deploy-testnet-mainnet.ts — with ONLY
+ * its economic constants restored to full production scale and wired to the
+ * real production LossRewardPool instead of a throwaway one.
+ *
+ * Once graduated, a pool deployed against this hook becomes a completely
+ * standard, fee-free-from-Incentifi permissionless V4 pool — no 2% protocol
+ * fee, no creator fee, no LossRewardPool deposit on ANY post-graduation trade.
+ * That is the deliberate trade-off for dropping afterSwap: real post-graduation
+ * revenue, in exchange for only ever running logic already proven end-to-end on
+ * real mainnet (at smaller scale).
+ *
+ * This IS the first time production economics + the real production
+ * LossRewardPool have been combined with this specific logic anywhere (fork or
+ * mainnet) — the graduation/liquidity-deposit mechanics themselves are
+ * unchanged from what already ran on real mainnet this morning, so the risk is
+ * materially lower than deploying the six-flag hook untested, but this exact
+ * combination has not itself been exercised end-to-end before this deployment.
+ *
+ * Mines a CREATE2 salt for the 4-flag permission set (a DIFFERENT REQUIRED_FLAGS
+ * value than the six-flag production hook), deploys IncentifiV4HookNoPostGradFee,
+ * then the SAME, unmodified IncentifiV4Factory.sol and IncentifiV4Router.sol
+ * contracts already used everywhere else in this V4 batch (their logic has no
+ * dependency on the hook's economics or permission set — they just call through
+ * to whatever hook address they're given), with setFactory() wiring in between.
+ *
+ * Every transaction goes through the plain viem WalletClient
+ * (deployContract/sendTransaction/writeContract) — never Hardhat's own
+ * viem.sendDeploymentTransaction() helper, for the same reason documented in
+ * every other deploy script in this batch (a real incident during the v3
+ * mainnet redeploy proved that helper's extra post-broadcast lookup can throw
+ * even after the underlying transaction already succeeded, defeating any
+ * resume logic built on top of it).
+ *
+ * SAFETY GATES:
+ *   - DEPLOYER_PRIVATE_KEY (or PRIVATE_KEY) — a funded Robinhood Chain mainnet key
+ *   - DEPLOY_CONFIRM=I_UNDERSTAND_THIS_IS_MAINNET
+ *
+ * Usage:
+ *   DEPLOYER_PRIVATE_KEY=0x... DEPLOY_CONFIRM=I_UNDERSTAND_THIS_IS_MAINNET \
+ *     npx hardhat run scripts/deploy-v4-hook-no-postgrad-fee-mainnet.ts --network robinhoodMainnet
+ *
+ * Does NOT launch a token, buy, sell, or drive graduation — scope here is
+ * exactly "deploy hook + factory + router, verify every constructor argument
+ * on-chain", matching deploy-v4-hook-production-mainnet.ts's scope. Note that
+ * driving a real graduation on THIS hook still costs the same ~5.9 ETH
+ * production graduation target as the six-flag hook — dropping afterSwap
+ * changes what happens AFTER graduation, not the cost of reaching it.
+ *
+ * CRASH / RPC-HICCUP SAFETY (automatic — no flag needed): every step's tx hash
+ * is written to scripts/.v4-no-postgrad-fee-deployment-state.json BEFORE this
+ * script ever waits on its receipt. Re-running the exact same command resumes
+ * rather than resends.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { network, artifacts } from 'hardhat';
+import { keccak256, encodeAbiParameters, parseAbiParameters, concat, pad, toHex, getAddress, getContractAddress, formatEther } from 'viem';
+
+const CHAIN_ID = 4663;
+const CREATE2_FACTORY = getAddress('0x4e59b44847b379578588920cA78FbF26c0B4956C');
+const POOL_MANAGER = getAddress('0x8366a39cc670b4001a1121b8f6a443a643e40951');
+const REAL_PRODUCTION_LOSS_REWARD_POOL = getAddress('0x697bda9db5a297a9cd9ed969bbf2549d0527dcdf');
+
+// getHookPermissions() for IncentifiV4HookNoPostGradFee: beforeInitialize(1<<13) |
+// beforeAddLiquidity(1<<11) | beforeSwap(1<<7) | beforeSwapReturnDelta(1<<3) only —
+// NO afterSwap/afterSwapReturnDelta. Same value scripts/deploy-testnet-mainnet.ts
+// already used and proved correct on real mainnet this morning (same 4-flag shape,
+// different economics/pool).
+const REQUIRED_FLAGS = (1n << 13n) | (1n << 11n) | (1n << 7n) | (1n << 3n); // 10376 (0x2888)
+const FLAG_MASK = (1n << 14n) - 1n;
+const MAX_SALT_SEARCH = 160_444;
+
+const STATE_PATH = path.resolve('scripts', '.v4-no-postgrad-fee-deployment-state.json');
+const RESULT_PATH = path.resolve('scripts', '.v4-no-postgrad-fee-deployment-result.json');
+const RECEIPT_RETRY_ATTEMPTS = Number(process.env.RECEIPT_RETRY_ATTEMPTS || 6);
+const RECEIPT_RETRY_BASE_DELAY_MS = Number(process.env.RECEIPT_RETRY_DELAY_MS || 5000);
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function computeCreate2Address(deployer: `0x${string}`, salt: bigint, initCodeHash: `0x${string}`): `0x${string}` {
+  const packed = concat(['0xff', deployer, pad(toHex(salt), { size: 32 }), initCodeHash]);
+  return getAddress(`0x${keccak256(packed).slice(-40)}`);
+}
+
+function requireConfirmation() {
+  if (process.env.DEPLOY_CONFIRM !== 'I_UNDERSTAND_THIS_IS_MAINNET') {
+    throw new Error(
+      '\nRefusing to run: this deploys NEW, IMMUTABLE contracts to REAL Robinhood Chain mainnet, wired to the ' +
+      'REAL production LossRewardPool, at real production economics.\n' +
+      'Set DEPLOY_CONFIRM=I_UNDERSTAND_THIS_IS_MAINNET to proceed.\n'
+    );
+  }
+  const key = (process.env.DEPLOYER_PRIVATE_KEY || process.env.PRIVATE_KEY || '').trim();
+  if (!key) {
+    throw new Error('DEPLOYER_PRIVATE_KEY (or PRIVATE_KEY) env var is required to deploy.');
+  }
+}
+
+type StepRecord = { hash?: `0x${string}`; confirmed?: boolean; blockNumber?: string; gasUsed?: string; effectiveGasPrice?: string; [key: string]: unknown };
+type DeployState = { wallet: `0x${string}`; steps: Record<string, StepRecord> };
+
+function loadState(walletRaw: `0x${string}`): DeployState {
+  const wallet = getAddress(walletRaw);
+  if (!fs.existsSync(STATE_PATH)) return { wallet, steps: {} };
+  const raw = JSON.parse(fs.readFileSync(STATE_PATH, 'utf8'));
+  if (!raw.wallet || getAddress(raw.wallet) !== wallet) {
+    throw new Error(
+      `${STATE_PATH} exists but is for a different wallet than this run (state: ${raw.wallet}, this run: ${wallet}).\n` +
+      `Move or delete ${STATE_PATH} by hand before re-running with a different wallet.`
+    );
+  }
+  const steps = raw.steps || {};
+  if (Object.keys(steps).length > 0) {
+    console.log(`[STATE] Found ${STATE_PATH} — resuming. Steps already recorded: ${Object.keys(steps).join(', ')}\n`);
+  }
+  return { wallet, steps };
+}
+
+function persistState(state: DeployState) {
+  fs.mkdirSync(path.dirname(STATE_PATH), { recursive: true });
+  fs.writeFileSync(STATE_PATH, JSON.stringify({ ...state, updatedAt: new Date().toISOString() }, null, 2));
+}
+
+async function main() {
+  requireConfirmation();
+
+  const { viem } = await network.create('robinhoodMainnet');
+  const publicClient = await viem.getPublicClient();
+
+  const chainId = await publicClient.getChainId();
+  if (chainId !== CHAIN_ID) throw new Error(`Chain ID mismatch! Expected ${CHAIN_ID}, got ${chainId}.`);
+
+  const [wallet] = await viem.getWalletClients();
+  const account = getAddress(wallet.account.address);
+  const balanceBefore = await publicClient.getBalance({ address: account });
+
+  console.log('\n============================================================');
+  console.log('[DEPLOY V4 HOOK — NO POST-GRAD FEE, PRODUCTION ECONOMICS] Robinhood Chain MAINNET');
+  console.log('============================================================');
+  console.log(`Deployer:                       ${account}`);
+  console.log(`Balance:                        ${formatEther(balanceBefore)} ETH`);
+  console.log(`CREATE2 singleton factory:      ${CREATE2_FACTORY}`);
+  console.log(`PoolManager:                    ${POOL_MANAGER}`);
+  console.log(`REAL production LossRewardPool: ${REAL_PRODUCTION_LOSS_REWARD_POOL}`);
+  console.log(`Required permission flags:      ${REQUIRED_FLAGS} (0x${REQUIRED_FLAGS.toString(16)}) — FOUR flags, no afterSwap`);
+  console.log('============================================================\n');
+
+  if (balanceBefore === 0n) throw new Error(`Deployer ${account} has zero ETH balance on mainnet. Fund it before deploying.`);
+
+  const prodPoolBalanceBefore = await publicClient.getBalance({ address: REAL_PRODUCTION_LOSS_REWARD_POOL });
+
+  const state = loadState(account);
+
+  async function waitForReceiptWithRetry(hash: `0x${string}`, label: string) {
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= RECEIPT_RETRY_ATTEMPTS; attempt++) {
+      try {
+        return await publicClient.waitForTransactionReceipt({ hash, confirmations: 1, timeout: 90_000 });
+      } catch (err) {
+        lastErr = err;
+        const delay = RECEIPT_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+        console.warn(`  [${label}] receipt wait attempt ${attempt}/${RECEIPT_RETRY_ATTEMPTS} failed (${err instanceof Error ? err.message : String(err)})` + (attempt < RECEIPT_RETRY_ATTEMPTS ? `; retrying in ${Math.round(delay / 1000)}s...` : ''));
+        if (attempt < RECEIPT_RETRY_ATTEMPTS) await sleep(delay);
+      }
+    }
+    throw new Error(`[${label}] Could not confirm receipt for tx ${hash} after ${RECEIPT_RETRY_ATTEMPTS} attempts. Its hash is already in ${STATE_PATH}; re-running resumes rather than resends.\nLast error: ${lastErr instanceof Error ? lastErr.message : String(lastErr)}`);
+  }
+
+  async function runStep(name: string, sendFn: () => Promise<{ hash: `0x${string}`; [key: string]: unknown }>, precomputedExtra: Record<string, unknown> = {}): Promise<StepRecord> {
+    let record = state.steps[name];
+    if (!record) {
+      console.log(`[${name}] sending transaction...`);
+      const sent = await sendFn();
+      record = { confirmed: false, ...precomputedExtra, ...sent };
+      state.steps[name] = record;
+      persistState(state);
+      console.log(`  Tx sent: ${record.hash}`);
+    } else {
+      console.log(`[${name}] resuming — tx already on record: ${record.hash} (confirmed: ${Boolean(record.confirmed)})`);
+    }
+    if (!record.confirmed) {
+      const receipt = await waitForReceiptWithRetry(record.hash as `0x${string}`, name);
+      if (receipt.status !== 'success') throw new Error(`[${name}] transaction reverted (status: ${receipt.status}). Tx: ${record.hash}`);
+      record.confirmed = true;
+      record.blockNumber = receipt.blockNumber.toString();
+      record.gasUsed = receipt.gasUsed.toString();
+      record.effectiveGasPrice = receipt.effectiveGasPrice.toString();
+      state.steps[name] = record;
+      persistState(state);
+      console.log(`  Confirmed in block #${receipt.blockNumber} (gas used ${receipt.gasUsed})\n`);
+    }
+    return record;
+  }
+
+  // ==========================================================================
+  // Step 1: mine the CREATE2 salt for IncentifiV4HookNoPostGradFee
+  // ==========================================================================
+  console.log('[1/5] Mining CREATE2 salt for IncentifiV4HookNoPostGradFee...');
+  const hookArtifact = await artifacts.readArtifact('IncentifiV4HookNoPostGradFee');
+  const hookConstructorArgs = encodeAbiParameters(parseAbiParameters('address, address, address'), [POOL_MANAGER, REAL_PRODUCTION_LOSS_REWARD_POOL, account]);
+  const hookInitCode = concat([hookArtifact.bytecode as `0x${string}`, hookConstructorArgs]);
+  const hookInitCodeHash = keccak256(hookInitCode);
+
+  let foundSalt: bigint | null = null;
+  let foundHookAddress: `0x${string}` | null = null;
+  const searchStart = Date.now();
+  for (let salt = 0n; salt < BigInt(MAX_SALT_SEARCH); salt++) {
+    const candidate = computeCreate2Address(CREATE2_FACTORY, salt, hookInitCodeHash);
+    if ((BigInt(candidate) & FLAG_MASK) === REQUIRED_FLAGS) {
+      foundSalt = salt;
+      foundHookAddress = candidate;
+      break;
+    }
+  }
+  if (foundSalt === null || foundHookAddress === null) throw new Error(`No valid CREATE2 salt found within ${MAX_SALT_SEARCH} attempts.`);
+  console.log(`  Found salt ${foundSalt} after ${Date.now() - searchStart}ms (off-chain, zero gas)`);
+  console.log(`  Predicted hook address: ${foundHookAddress}`);
+
+  const hookMinerCheckArtifact = await artifacts.readArtifact('HookMinerCheck');
+  const hmcRecord = await runStep('hookMinerCheckDeploy', async () => {
+    const nonce = await publicClient.getTransactionCount({ address: account, blockTag: 'pending' });
+    const address = getContractAddress({ from: account, nonce: BigInt(nonce) });
+    const hash = await wallet.deployContract({ abi: hookMinerCheckArtifact.abi, bytecode: hookMinerCheckArtifact.bytecode as `0x${string}`, nonce });
+    return { hash, address };
+  });
+  const hookMinerCheck = await viem.getContractAt('HookMinerCheck', getAddress(hmcRecord.address as string));
+  const onChainComputed = getAddress(await hookMinerCheck.read.computeAddress([CREATE2_FACTORY, foundSalt, hookInitCode]));
+  if (onChainComputed !== foundHookAddress) throw new Error('JS-computed hook address does not match the REAL on-chain HookMiner library. Stopping.');
+  console.log(`  Cross-checked against real HookMiner.computeAddress(): MATCH\n`);
+
+  // Only meaningful before hookDeploy has ever been sent — on a resume where
+  // state.steps.hookDeploy is already on record, code at this address is the
+  // EXPECTED, successful outcome of that prior run, not a collision to abort
+  // on. Checking unconditionally here previously broke every resume: the
+  // legitimate "already deployed" case looked identical to the genuinely
+  // impossible "salt collision" case this check exists to catch.
+  if (!state.steps.hookDeploy) {
+    const codeAtPredicted = await publicClient.getCode({ address: foundHookAddress });
+    if (codeAtPredicted && codeAtPredicted !== '0x') throw new Error(`Predicted hook address ${foundHookAddress} already has code. Stopping.`);
+  }
+
+  // ==========================================================================
+  // Step 2: deploy the hook via CREATE2
+  // ==========================================================================
+  console.log('[2/5] Deploying IncentifiV4HookNoPostGradFee via CREATE2...');
+  const hookDeployData = concat([pad(toHex(foundSalt), { size: 32 }), hookInitCode]);
+  await runStep('hookDeploy', async () => ({ hash: await wallet.sendTransaction({ to: CREATE2_FACTORY, data: hookDeployData }) }));
+
+  const hookCode = await publicClient.getCode({ address: foundHookAddress });
+  if (!hookCode || hookCode === '0x') throw new Error(`Hook deployment succeeded but no code landed at ${foundHookAddress}.`);
+  const deployedFlags = BigInt(foundHookAddress) & FLAG_MASK;
+  if (deployedFlags !== REQUIRED_FLAGS) throw new Error(`Deployed hook permission bits (${deployedFlags}) != required (${REQUIRED_FLAGS}).`);
+  console.log(`  eth_getCode: NON-EMPTY (${(hookCode.length - 2) / 2} bytes). Permission bits confirmed.`);
+
+  const hookContract = await viem.getContractAt('IncentifiV4HookNoPostGradFee', foundHookAddress);
+  const hookDeployerOnChain = getAddress(await hookContract.read.deployer());
+  const hookLossRewardPoolOnChain = getAddress(await hookContract.read.lossRewardPool());
+  if (hookDeployerOnChain !== account) throw new Error(`hook.deployer() mismatch: got ${hookDeployerOnChain}.`);
+  if (hookLossRewardPoolOnChain !== REAL_PRODUCTION_LOSS_REWARD_POOL) {
+    throw new Error(`hook.lossRewardPool() mismatch: got ${hookLossRewardPoolOnChain}, expected the REAL production pool ${REAL_PRODUCTION_LOSS_REWARD_POOL}.`);
+  }
+  const hookGraduationTarget = await hookContract.read.GRADUATION_ETH_TARGET();
+  if (hookGraduationTarget !== 5_853_863_234_375_000_000n) throw new Error(`hook.GRADUATION_ETH_TARGET() (${hookGraduationTarget}) is not the full production value.`);
+  console.log(`  hook.deployer() == ${hookDeployerOnChain} (confirmed)`);
+  console.log(`  hook.lossRewardPool() == ${hookLossRewardPoolOnChain} (confirmed == REAL production pool)`);
+  console.log(`  hook.GRADUATION_ETH_TARGET() == ${formatEther(hookGraduationTarget)} ETH (confirmed == full production target)\n`);
+
+  // ==========================================================================
+  // Step 3: IncentifiV4Factory (same, unmodified production contract)
+  // ==========================================================================
+  console.log('[3/5] Deploying IncentifiV4Factory...');
+  const factoryArtifact = await artifacts.readArtifact('IncentifiV4Factory');
+  const factoryRecord = await runStep('factoryDeploy', async () => {
+    const nonce = await publicClient.getTransactionCount({ address: account, blockTag: 'pending' });
+    const address = getContractAddress({ from: account, nonce: BigInt(nonce) });
+    const hash = await wallet.deployContract({ abi: factoryArtifact.abi, bytecode: factoryArtifact.bytecode as `0x${string}`, args: [POOL_MANAGER, foundHookAddress], nonce });
+    return { hash, address };
+  });
+  const factoryAddress = getAddress(factoryRecord.address as string);
+  const factoryContract = await viem.getContractAt('IncentifiV4Factory', factoryAddress);
+  if (getAddress(await factoryContract.read.poolManager()) !== POOL_MANAGER) throw new Error('factory.poolManager() mismatch.');
+  if (getAddress(await factoryContract.read.hook()) !== foundHookAddress) throw new Error('factory.hook() mismatch.');
+  console.log(`  Factory: ${factoryAddress} (confirmed)\n`);
+
+  // ==========================================================================
+  // Step 4: setFactory()
+  // ==========================================================================
+  console.log('[4/5] setFactory() (one-time wiring)...');
+  const factoryBeforeWiring = getAddress(await hookContract.read.factory());
+  if (factoryBeforeWiring === '0x0000000000000000000000000000000000000000') {
+    await runStep('setFactory', async () => ({ hash: await wallet.writeContract({ address: foundHookAddress, abi: hookArtifact.abi, functionName: 'setFactory', args: [factoryAddress] }) }));
+  } else {
+    console.log(`  hook.factory() already set to ${factoryBeforeWiring} — skipping.`);
+  }
+  if (getAddress(await hookContract.read.factory()) !== factoryAddress) throw new Error('hook.factory() does not match the deployed Factory after wiring.');
+  console.log('  hook.factory() confirmed.\n');
+
+  // ==========================================================================
+  // Step 5: IncentifiV4Router (same, unmodified production contract)
+  // ==========================================================================
+  console.log('[5/5] Deploying IncentifiV4Router...');
+  const routerArtifact = await artifacts.readArtifact('IncentifiV4Router');
+  const routerRecord = await runStep('routerDeploy', async () => {
+    const nonce = await publicClient.getTransactionCount({ address: account, blockTag: 'pending' });
+    const address = getContractAddress({ from: account, nonce: BigInt(nonce) });
+    const hash = await wallet.deployContract({ abi: routerArtifact.abi, bytecode: routerArtifact.bytecode as `0x${string}`, args: [POOL_MANAGER, foundHookAddress, factoryAddress], nonce });
+    return { hash, address };
+  });
+  const routerAddress = getAddress(routerRecord.address as string);
+  const routerContract = await viem.getContractAt('IncentifiV4Router', routerAddress);
+  if (getAddress(await routerContract.read.poolManager()) !== POOL_MANAGER) throw new Error('router.poolManager() mismatch.');
+  if (getAddress(await routerContract.read.hook()) !== foundHookAddress) throw new Error('router.hook() mismatch.');
+  if (getAddress(await routerContract.read.factory()) !== factoryAddress) throw new Error('router.factory() mismatch.');
+  console.log(`  Router: ${routerAddress} (confirmed)\n`);
+
+  // Deployment itself should never touch the real production LossRewardPool's balance.
+  const prodPoolBalanceAfter = await publicClient.getBalance({ address: REAL_PRODUCTION_LOSS_REWARD_POOL });
+  if (prodPoolBalanceAfter !== prodPoolBalanceBefore) {
+    throw new Error(`Real production LossRewardPool balance CHANGED during deployment (${formatEther(prodPoolBalanceBefore)} -> ${formatEther(prodPoolBalanceAfter)} ETH). Investigate before trusting anything above.`);
+  }
+  console.log(`Confirmed: real production LossRewardPool balance unchanged (${formatEther(prodPoolBalanceAfter)} ETH).\n`);
+
+  const balanceAfter = await publicClient.getBalance({ address: account });
+  const result = {
+    chainId,
+    deployer: account,
+    hook: {
+      address: foundHookAddress,
+      salt: foundSalt.toString(),
+      permissionFlags: REQUIRED_FLAGS.toString(),
+      hasPostGraduationFee: false,
+      constructorArgs: { poolManager: POOL_MANAGER, lossRewardPool: REAL_PRODUCTION_LOSS_REWARD_POOL, deployer: account },
+    },
+    factory: { address: factoryAddress, constructorArgs: { poolManager: POOL_MANAGER, hook: foundHookAddress } },
+    router: { address: routerAddress, constructorArgs: { poolManager: POOL_MANAGER, hook: foundHookAddress, factory: factoryAddress } },
+    gasSpentWei: (balanceBefore - balanceAfter).toString(),
+    gasSpentEth: formatEther(balanceBefore - balanceAfter),
+    deployedAt: new Date().toISOString(),
+  };
+  fs.writeFileSync(RESULT_PATH, JSON.stringify(result, null, 2));
+
+  console.log('============================================================');
+  console.log('[DEPLOY V4 HOOK — NO POST-GRAD FEE] COMPLETE');
+  console.log('============================================================');
+  console.log(JSON.stringify(result, null, 2));
+  console.log(`\nSaved to ${RESULT_PATH}`);
+  console.log(`Total gas spent: ${formatEther(balanceBefore - balanceAfter)} ETH`);
+  console.log('\nReminder: this hook takes NO fee of any kind on post-graduation trades. Driving a real');
+  console.log('graduation on it still costs the full ~5.9 ETH production target — that cost is unchanged.');
+}
+
+main().catch((err) => {
+  console.error('\n[DEPLOY ERROR]', err instanceof Error ? err.message : err);
+  console.error(`Progress so far is saved in ${STATE_PATH}. Re-running the exact same command resumes, not resends.`);
+  process.exitCode = 1;
+});

--- a/scripts/deploy-v4-hook-production-logic-test-mainnet.ts
+++ b/scripts/deploy-v4-hook-production-logic-test-mainnet.ts
@@ -1,0 +1,349 @@
+/**
+ * Deploys IncentifiV4HookProductionLogicTest — byte-for-byte the SAME logic as
+ * the production IncentifiV4Hook.sol (six permission flags, including the
+ * afterSwap post-graduation fee mechanism), with ONLY VIRTUAL_ETH and
+ * GRADUATION_ETH_TARGET scaled down by the same 1/50 factor already proven on
+ * real mainnet by IncentifiV4HookTestnet.sol — to REAL Robinhood Chain mainnet,
+ * at roughly 1/50th the ETH cost of a production-scale run.
+ *
+ * ============================================================================
+ * THE REAL PRODUCTION LossRewardPool IS NEVER TOUCHED BY THIS SCRIPT.
+ * ============================================================================
+ * This file never even references the real production LossRewardPool address
+ * (0x697BDA9db5a297a9Cd9ED969BBF2549d0527DcdF) as a usable value — it exists
+ * below ONLY inside one impossible-equality safety assertion (mirroring the
+ * same check scripts/deploy-testnet-mainnet.ts already used), so there is no
+ * code path in this script that could wire the hook to it. This script deploys
+ * a FRESH LossRewardPool from contracts/LossRewardPool.sol on every run and
+ * wires the hook to THAT throwaway instance, exactly like
+ * scripts/deploy-testnet-mainnet.ts already did for the 4-flag testnet hook.
+ * ============================================================================
+ *
+ * Deploys, in order: a fresh throwaway LossRewardPool, then
+ * IncentifiV4HookProductionLogicTest (mined CREATE2 salt, cross-checked
+ * on-chain via HookMinerCheck — identical process to
+ * deploy-v4-hook-production-mainnet.ts, same REQUIRED_FLAGS since the
+ * permission set is identical to production), then the SAME, unmodified
+ * IncentifiV4Factory.sol and IncentifiV4Router.sol contracts already deployed
+ * for production (their logic has no dependency on the hook's economic
+ * constants — they just call through to whatever hook address they're given).
+ *
+ * Every transaction goes through the plain viem WalletClient
+ * (deployContract/sendTransaction/writeContract) — never Hardhat's own
+ * viem.sendDeploymentTransaction() helper, for the same reason documented in
+ * deploy-v4-hook-production-mainnet.ts (a real incident during the v3 mainnet
+ * redeploy proved that helper's extra post-broadcast lookup can throw even
+ * after the underlying transaction already succeeded, defeating resume logic
+ * built on top of it).
+ *
+ * SAFETY GATES:
+ *   - DEPLOYER_PRIVATE_KEY (or PRIVATE_KEY) — a funded Robinhood Chain mainnet key
+ *   - DEPLOY_CONFIRM=I_UNDERSTAND_THIS_IS_MAINNET
+ *
+ * Usage:
+ *   DEPLOYER_PRIVATE_KEY=0x... DEPLOY_CONFIRM=I_UNDERSTAND_THIS_IS_MAINNET \
+ *     npx hardhat run scripts/deploy-v4-hook-production-logic-test-mainnet.ts --network robinhoodMainnet
+ *
+ * CRASH / RPC-HICCUP SAFETY (automatic — no flag needed): identical mechanism
+ * to every other script in this batch. Every step's tx hash is written to
+ * scripts/.v4-logic-test-deployment-state.json BEFORE this script ever waits on
+ * its receipt. Re-running the exact same command resumes rather than resends.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { network, artifacts } from 'hardhat';
+import { keccak256, encodeAbiParameters, parseAbiParameters, concat, pad, toHex, getAddress, getContractAddress, formatEther } from 'viem';
+
+const CHAIN_ID = 4663;
+const CREATE2_FACTORY = getAddress('0x4e59b44847b379578588920cA78FbF26c0B4956C');
+const POOL_MANAGER = getAddress('0x8366a39cc670b4001a1121b8f6a443a643e40951');
+// Present ONLY for the impossible-equality safety check below — never used as
+// a constructor arg or wired to anything in this script. See the header comment.
+const REAL_PRODUCTION_LOSS_REWARD_POOL = getAddress('0x697bda9db5a297a9cd9ed969bbf2549d0527dcdf');
+
+// getHookPermissions() is identical to the production hook's — same 6 flags,
+// same REQUIRED_FLAGS, independently confirmed against
+// test/hardhat/v4-hook-deployment.test.ts's own tested constant.
+const REQUIRED_FLAGS = (1n << 13n) | (1n << 11n) | (1n << 7n) | (1n << 3n) | (1n << 6n) | (1n << 2n); // 10444 (0x28cc)
+const FLAG_MASK = (1n << 14n) - 1n;
+const MAX_SALT_SEARCH = 160_444;
+
+const STATE_PATH = path.resolve('scripts', '.v4-logic-test-deployment-state.json');
+const RESULT_PATH = path.resolve('scripts', '.v4-logic-test-deployment-result.json');
+const RECEIPT_RETRY_ATTEMPTS = Number(process.env.RECEIPT_RETRY_ATTEMPTS || 6);
+const RECEIPT_RETRY_BASE_DELAY_MS = Number(process.env.RECEIPT_RETRY_DELAY_MS || 5000);
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function computeCreate2Address(deployer: `0x${string}`, salt: bigint, initCodeHash: `0x${string}`): `0x${string}` {
+  const packed = concat(['0xff', deployer, pad(toHex(salt), { size: 32 }), initCodeHash]);
+  return getAddress(`0x${keccak256(packed).slice(-40)}`);
+}
+
+function requireConfirmation() {
+  if (process.env.DEPLOY_CONFIRM !== 'I_UNDERSTAND_THIS_IS_MAINNET') {
+    throw new Error('\nSet DEPLOY_CONFIRM=I_UNDERSTAND_THIS_IS_MAINNET to proceed.\n');
+  }
+  const key = (process.env.DEPLOYER_PRIVATE_KEY || process.env.PRIVATE_KEY || '').trim();
+  if (!key) {
+    throw new Error('DEPLOYER_PRIVATE_KEY (or PRIVATE_KEY) env var is required to deploy.');
+  }
+}
+
+type StepRecord = { hash?: `0x${string}`; confirmed?: boolean; blockNumber?: string; gasUsed?: string; effectiveGasPrice?: string; [key: string]: unknown };
+type DeployState = { wallet: `0x${string}`; steps: Record<string, StepRecord> };
+
+function loadState(walletRaw: `0x${string}`): DeployState {
+  const wallet = getAddress(walletRaw);
+  if (!fs.existsSync(STATE_PATH)) return { wallet, steps: {} };
+  const raw = JSON.parse(fs.readFileSync(STATE_PATH, 'utf8'));
+  if (!raw.wallet || getAddress(raw.wallet) !== wallet) {
+    throw new Error(
+      `${STATE_PATH} exists but is for a different wallet than this run (state: ${raw.wallet}, this run: ${wallet}).\n` +
+      `Move or delete ${STATE_PATH} by hand before re-running with a different wallet.`
+    );
+  }
+  const steps = raw.steps || {};
+  if (Object.keys(steps).length > 0) {
+    console.log(`[STATE] Found ${STATE_PATH} — resuming. Steps already recorded: ${Object.keys(steps).join(', ')}\n`);
+  }
+  return { wallet, steps };
+}
+
+function persistState(state: DeployState) {
+  fs.mkdirSync(path.dirname(STATE_PATH), { recursive: true });
+  fs.writeFileSync(STATE_PATH, JSON.stringify({ ...state, updatedAt: new Date().toISOString() }, null, 2));
+}
+
+async function main() {
+  requireConfirmation();
+
+  const { viem } = await network.create('robinhoodMainnet');
+  const publicClient = await viem.getPublicClient();
+
+  const chainId = await publicClient.getChainId();
+  if (chainId !== CHAIN_ID) throw new Error(`Chain ID mismatch! Expected ${CHAIN_ID}, got ${chainId}.`);
+
+  const [wallet] = await viem.getWalletClients();
+  const account = getAddress(wallet.account.address);
+  const balanceBefore = await publicClient.getBalance({ address: account });
+
+  console.log('\n============================================================');
+  console.log('[DEPLOY V4 HOOK — PRODUCTION LOGIC, TEST SCALE] Robinhood Chain MAINNET');
+  console.log('============================================================');
+  console.log(`Deployer:                  ${account}`);
+  console.log(`Balance:                   ${formatEther(balanceBefore)} ETH`);
+  console.log(`CREATE2 singleton factory: ${CREATE2_FACTORY}`);
+  console.log(`PoolManager:               ${POOL_MANAGER}`);
+  console.log(`Required permission flags: ${REQUIRED_FLAGS} (0x${REQUIRED_FLAGS.toString(16)}) — same as production`);
+  console.log('============================================================\n');
+
+  if (balanceBefore === 0n) throw new Error(`Deployer ${account} has zero ETH balance on mainnet. Fund it before deploying.`);
+
+  const state = loadState(account);
+
+  async function waitForReceiptWithRetry(hash: `0x${string}`, label: string) {
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= RECEIPT_RETRY_ATTEMPTS; attempt++) {
+      try {
+        return await publicClient.waitForTransactionReceipt({ hash, confirmations: 1, timeout: 90_000 });
+      } catch (err) {
+        lastErr = err;
+        const delay = RECEIPT_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+        console.warn(`  [${label}] receipt wait attempt ${attempt}/${RECEIPT_RETRY_ATTEMPTS} failed (${err instanceof Error ? err.message : String(err)})` + (attempt < RECEIPT_RETRY_ATTEMPTS ? `; retrying in ${Math.round(delay / 1000)}s...` : ''));
+        if (attempt < RECEIPT_RETRY_ATTEMPTS) await sleep(delay);
+      }
+    }
+    throw new Error(`[${label}] Could not confirm receipt for tx ${hash} after ${RECEIPT_RETRY_ATTEMPTS} attempts. Its hash is already in ${STATE_PATH}; re-running resumes rather than resends.\nLast error: ${lastErr instanceof Error ? lastErr.message : String(lastErr)}`);
+  }
+
+  async function runStep(name: string, sendFn: () => Promise<{ hash: `0x${string}`; [key: string]: unknown }>, precomputedExtra: Record<string, unknown> = {}): Promise<StepRecord> {
+    let record = state.steps[name];
+    if (!record) {
+      console.log(`[${name}] sending transaction...`);
+      const sent = await sendFn();
+      record = { confirmed: false, ...precomputedExtra, ...sent };
+      state.steps[name] = record;
+      persistState(state);
+      console.log(`  Tx sent: ${record.hash}`);
+    } else {
+      console.log(`[${name}] resuming — tx already on record: ${record.hash} (confirmed: ${Boolean(record.confirmed)})`);
+    }
+    if (!record.confirmed) {
+      const receipt = await waitForReceiptWithRetry(record.hash as `0x${string}`, name);
+      if (receipt.status !== 'success') throw new Error(`[${name}] transaction reverted (status: ${receipt.status}). Tx: ${record.hash}`);
+      record.confirmed = true;
+      record.blockNumber = receipt.blockNumber.toString();
+      record.gasUsed = receipt.gasUsed.toString();
+      record.effectiveGasPrice = receipt.effectiveGasPrice.toString();
+      state.steps[name] = record;
+      persistState(state);
+      console.log(`  Confirmed in block #${receipt.blockNumber} (gas used ${receipt.gasUsed})\n`);
+    }
+    return record;
+  }
+
+  // ==========================================================================
+  // Step 1: fresh, throwaway LossRewardPool — never the real production one.
+  // ==========================================================================
+  console.log('[1/6] Deploying a FRESH, throwaway LossRewardPool (never the real production one)...');
+  const lossRewardPoolArtifact = await artifacts.readArtifact('LossRewardPool');
+  const lrpRecord = await runStep('lossRewardPoolDeploy', async () => {
+    const nonce = await publicClient.getTransactionCount({ address: account, blockTag: 'pending' });
+    const address = getContractAddress({ from: account, nonce: BigInt(nonce) });
+    const hash = await wallet.deployContract({ abi: lossRewardPoolArtifact.abi, bytecode: lossRewardPoolArtifact.bytecode as `0x${string}`, args: [account], nonce });
+    return { hash, address };
+  });
+  const lossRewardPoolAddress = getAddress(lrpRecord.address as string);
+  if (lossRewardPoolAddress === REAL_PRODUCTION_LOSS_REWARD_POOL) {
+    throw new Error('IMPOSSIBLE SAFETY CHECK FAILED: freshly deployed address matches the real production LossRewardPool. Stopping immediately.');
+  }
+  console.log(`  Throwaway LossRewardPool: ${lossRewardPoolAddress} (confirmed != real production pool)\n`);
+
+  // ==========================================================================
+  // Step 2: mine the CREATE2 salt for IncentifiV4HookProductionLogicTest
+  // ==========================================================================
+  console.log('[2/6] Mining CREATE2 salt for IncentifiV4HookProductionLogicTest...');
+  const hookArtifact = await artifacts.readArtifact('IncentifiV4HookProductionLogicTest');
+  const hookConstructorArgs = encodeAbiParameters(parseAbiParameters('address, address, address'), [POOL_MANAGER, lossRewardPoolAddress, account]);
+  const hookInitCode = concat([hookArtifact.bytecode as `0x${string}`, hookConstructorArgs]);
+  const hookInitCodeHash = keccak256(hookInitCode);
+
+  let foundSalt: bigint | null = null;
+  let foundHookAddress: `0x${string}` | null = null;
+  const searchStart = Date.now();
+  for (let salt = 0n; salt < BigInt(MAX_SALT_SEARCH); salt++) {
+    const candidate = computeCreate2Address(CREATE2_FACTORY, salt, hookInitCodeHash);
+    if ((BigInt(candidate) & FLAG_MASK) === REQUIRED_FLAGS) {
+      foundSalt = salt;
+      foundHookAddress = candidate;
+      break;
+    }
+  }
+  if (foundSalt === null || foundHookAddress === null) throw new Error(`No valid CREATE2 salt found within ${MAX_SALT_SEARCH} attempts.`);
+  console.log(`  Found salt ${foundSalt} after ${Date.now() - searchStart}ms (off-chain, zero gas)`);
+  console.log(`  Predicted hook address: ${foundHookAddress}`);
+
+  const hookMinerCheckArtifact = await artifacts.readArtifact('HookMinerCheck');
+  const hmcRecord = await runStep('hookMinerCheckDeploy', async () => {
+    const nonce = await publicClient.getTransactionCount({ address: account, blockTag: 'pending' });
+    const address = getContractAddress({ from: account, nonce: BigInt(nonce) });
+    const hash = await wallet.deployContract({ abi: hookMinerCheckArtifact.abi, bytecode: hookMinerCheckArtifact.bytecode as `0x${string}`, nonce });
+    return { hash, address };
+  });
+  const hookMinerCheck = await viem.getContractAt('HookMinerCheck', getAddress(hmcRecord.address as string));
+  const onChainComputed = getAddress(await hookMinerCheck.read.computeAddress([CREATE2_FACTORY, foundSalt, hookInitCode]));
+  if (onChainComputed !== foundHookAddress) throw new Error('JS-computed hook address does not match the REAL on-chain HookMiner library. Stopping.');
+  console.log(`  Cross-checked against real HookMiner.computeAddress(): MATCH\n`);
+
+  // Only meaningful before hookDeploy has ever been sent — on a resume where
+  // state.steps.hookDeploy is already on record, code at this address is the
+  // EXPECTED, successful outcome of that prior run, not a collision to abort
+  // on. Checking unconditionally here previously broke every resume: the
+  // legitimate "already deployed" case looked identical to the genuinely
+  // impossible "salt collision" case this check exists to catch.
+  if (!state.steps.hookDeploy) {
+    const codeAtPredicted = await publicClient.getCode({ address: foundHookAddress });
+    if (codeAtPredicted && codeAtPredicted !== '0x') throw new Error(`Predicted hook address ${foundHookAddress} already has code. Stopping.`);
+  }
+
+  // ==========================================================================
+  // Step 3: deploy the hook via CREATE2
+  // ==========================================================================
+  console.log('[3/6] Deploying IncentifiV4HookProductionLogicTest via CREATE2...');
+  const hookDeployData = concat([pad(toHex(foundSalt), { size: 32 }), hookInitCode]);
+  await runStep('hookDeploy', async () => ({ hash: await wallet.sendTransaction({ to: CREATE2_FACTORY, data: hookDeployData }) }));
+
+  const hookCode = await publicClient.getCode({ address: foundHookAddress });
+  if (!hookCode || hookCode === '0x') throw new Error(`Hook deployment succeeded but no code landed at ${foundHookAddress}.`);
+  const deployedFlags = BigInt(foundHookAddress) & FLAG_MASK;
+  if (deployedFlags !== REQUIRED_FLAGS) throw new Error(`Deployed hook permission bits (${deployedFlags}) != required (${REQUIRED_FLAGS}).`);
+  console.log(`  eth_getCode: NON-EMPTY (${(hookCode.length - 2) / 2} bytes). Permission bits confirmed.`);
+
+  const hookContract = await viem.getContractAt('IncentifiV4HookProductionLogicTest', foundHookAddress);
+  const hookDeployerOnChain = getAddress(await hookContract.read.deployer());
+  const hookLossRewardPoolOnChain = getAddress(await hookContract.read.lossRewardPool());
+  if (hookDeployerOnChain !== account) throw new Error(`hook.deployer() mismatch: got ${hookDeployerOnChain}.`);
+  if (hookLossRewardPoolOnChain !== lossRewardPoolAddress) throw new Error(`hook.lossRewardPool() mismatch: got ${hookLossRewardPoolOnChain}, expected the throwaway pool ${lossRewardPoolAddress}.`);
+  if (hookLossRewardPoolOnChain === REAL_PRODUCTION_LOSS_REWARD_POOL) throw new Error('IMPOSSIBLE SAFETY CHECK FAILED: hook.lossRewardPool() is the REAL production pool. Stopping.');
+  console.log(`  hook.deployer() == ${hookDeployerOnChain} (confirmed)`);
+  console.log(`  hook.lossRewardPool() == ${hookLossRewardPoolOnChain} (confirmed == throwaway pool, NOT production)\n`);
+
+  // ==========================================================================
+  // Step 4: IncentifiV4Factory (same, unmodified production contract)
+  // ==========================================================================
+  console.log('[4/6] Deploying IncentifiV4Factory...');
+  const factoryArtifact = await artifacts.readArtifact('IncentifiV4Factory');
+  const factoryRecord = await runStep('factoryDeploy', async () => {
+    const nonce = await publicClient.getTransactionCount({ address: account, blockTag: 'pending' });
+    const address = getContractAddress({ from: account, nonce: BigInt(nonce) });
+    const hash = await wallet.deployContract({ abi: factoryArtifact.abi, bytecode: factoryArtifact.bytecode as `0x${string}`, args: [POOL_MANAGER, foundHookAddress], nonce });
+    return { hash, address };
+  });
+  const factoryAddress = getAddress(factoryRecord.address as string);
+  const factoryContract = await viem.getContractAt('IncentifiV4Factory', factoryAddress);
+  if (getAddress(await factoryContract.read.poolManager()) !== POOL_MANAGER) throw new Error('factory.poolManager() mismatch.');
+  if (getAddress(await factoryContract.read.hook()) !== foundHookAddress) throw new Error('factory.hook() mismatch.');
+  console.log(`  Factory: ${factoryAddress} (confirmed)\n`);
+
+  // ==========================================================================
+  // Step 5: setFactory()
+  // ==========================================================================
+  console.log('[5/6] setFactory() (one-time wiring)...');
+  const factoryBeforeWiring = getAddress(await hookContract.read.factory());
+  if (factoryBeforeWiring === '0x0000000000000000000000000000000000000000') {
+    await runStep('setFactory', async () => ({ hash: await wallet.writeContract({ address: foundHookAddress, abi: hookArtifact.abi, functionName: 'setFactory', args: [factoryAddress] }) }));
+  } else {
+    console.log(`  hook.factory() already set to ${factoryBeforeWiring} — skipping.`);
+  }
+  if (getAddress(await hookContract.read.factory()) !== factoryAddress) throw new Error('hook.factory() does not match the deployed Factory after wiring.');
+  console.log('  hook.factory() confirmed.\n');
+
+  // ==========================================================================
+  // Step 6: IncentifiV4Router (same, unmodified production contract)
+  // ==========================================================================
+  console.log('[6/6] Deploying IncentifiV4Router...');
+  const routerArtifact = await artifacts.readArtifact('IncentifiV4Router');
+  const routerRecord = await runStep('routerDeploy', async () => {
+    const nonce = await publicClient.getTransactionCount({ address: account, blockTag: 'pending' });
+    const address = getContractAddress({ from: account, nonce: BigInt(nonce) });
+    const hash = await wallet.deployContract({ abi: routerArtifact.abi, bytecode: routerArtifact.bytecode as `0x${string}`, args: [POOL_MANAGER, foundHookAddress, factoryAddress], nonce });
+    return { hash, address };
+  });
+  const routerAddress = getAddress(routerRecord.address as string);
+  const routerContract = await viem.getContractAt('IncentifiV4Router', routerAddress);
+  if (getAddress(await routerContract.read.poolManager()) !== POOL_MANAGER) throw new Error('router.poolManager() mismatch.');
+  if (getAddress(await routerContract.read.hook()) !== foundHookAddress) throw new Error('router.hook() mismatch.');
+  if (getAddress(await routerContract.read.factory()) !== factoryAddress) throw new Error('router.factory() mismatch.');
+  console.log(`  Router: ${routerAddress} (confirmed)\n`);
+
+  const balanceAfter = await publicClient.getBalance({ address: account });
+  const result = {
+    chainId,
+    deployer: account,
+    lossRewardPool: { address: lossRewardPoolAddress, throwaway: true },
+    hook: { address: foundHookAddress, salt: foundSalt.toString(), constructorArgs: { poolManager: POOL_MANAGER, lossRewardPool: lossRewardPoolAddress, deployer: account } },
+    factory: { address: factoryAddress, constructorArgs: { poolManager: POOL_MANAGER, hook: foundHookAddress } },
+    router: { address: routerAddress, constructorArgs: { poolManager: POOL_MANAGER, hook: foundHookAddress, factory: factoryAddress } },
+    gasSpentWei: (balanceBefore - balanceAfter).toString(),
+    gasSpentEth: formatEther(balanceBefore - balanceAfter),
+    deployedAt: new Date().toISOString(),
+  };
+  fs.writeFileSync(RESULT_PATH, JSON.stringify(result, null, 2));
+
+  console.log('============================================================');
+  console.log('[DEPLOY V4 HOOK — PRODUCTION LOGIC, TEST SCALE] COMPLETE');
+  console.log('============================================================');
+  console.log(JSON.stringify(result, null, 2));
+  console.log(`\nSaved to ${RESULT_PATH}`);
+  console.log(`Total gas spent: ${formatEther(balanceBefore - balanceAfter)} ETH`);
+}
+
+main().catch((err) => {
+  console.error('\n[DEPLOY ERROR]', err instanceof Error ? err.message : err);
+  console.error(`Progress so far is saved in ${STATE_PATH}. Re-running the exact same command resumes, not resends.`);
+  process.exitCode = 1;
+});

--- a/scripts/deploy-v4-hook-production-mainnet.ts
+++ b/scripts/deploy-v4-hook-production-mainnet.ts
@@ -1,0 +1,537 @@
+/**
+ * Deploys the PRODUCTION IncentifiV4Hook (contracts/v4/IncentifiV4Hook.sol — NOT
+ * contracts/v4/test-deployment/IncentifiV4HookTestnet.sol) to REAL Robinhood Chain
+ * mainnet, wired to the REAL production LossRewardPool
+ * (0x697BDA9db5a297a9Cd9ED969BBF2549d0527DcdF), using the production $5,000-launch /
+ * $69,000-graduation economic constants (identical to the v3 IncentifiBondingCurve).
+ * Then deploys IncentifiV4Factory and IncentifiV4Router wired to that hook.
+ *
+ * ============================================================================
+ * READ THIS BEFORE RUNNING — risk this script cannot verify away:
+ * ============================================================================
+ * contracts/v4/IncentifiV4Hook.sol and contracts/v4/IncentifiV4Router.sol both carry
+ * their own header comment: "STATUS: UNTESTED ... has never executed against a real
+ * PoolManager." The only V4 code proven end-to-end on REAL Robinhood Chain mainnet so
+ * far is IncentifiV4HookTestnet.sol (scripts/deploy-testnet-mainnet.ts) — a DIFFERENT
+ * contract with a SMALLER permission-bit set (4 flags: beforeInitialize,
+ * beforeAddLiquidity, beforeSwap, beforeSwapReturnDelta). The PRODUCTION hook this
+ * script deploys adds TWO more flags (afterSwap, afterSwapReturnDelta) for an entirely
+ * new code path — the post-graduation sell-side fee mechanism — that has ONLY ever run
+ * on a simulated EDR fork (test/hardhat/v4-graduated-fee.test.ts), never against a
+ * real PoolManager. This deployment is also the FIRST time any V4 code touches the
+ * REAL production LossRewardPool — every prior real-mainnet V4 run deliberately used a
+ * fresh throwaway pool instead, specifically because of this same untested status.
+ * None of that makes the contract wrong — the fork tests that do exist found and fixed
+ * several real bugs already (see the "FIXED"/"CORRECTED" comments in
+ * IncentifiV4Router.sol) — but it is a materially different risk profile from "same
+ * process as the testnet deployment," and this script cannot make that determination
+ * for you. Hence V4_PRODUCTION_CONFIRM below, in addition to DEPLOY_CONFIRM.
+ * ============================================================================
+ *
+ * Mirrors the mining/verification process already proven in
+ * test/hardhat/v4-hook-deployment.test.ts (Stage 1) and scripts/deploy-testnet-mainnet.ts,
+ * with two deliberate departures from both:
+ *   1. Uses IncentifiV4Hook (production), the real production LossRewardPool, and the
+ *      correct 6-flag REQUIRED_FLAGS for its actual getHookPermissions() — NOT the
+ *      4-flag testnet value.
+ *   2. Every transaction goes through the plain viem WalletClient (deployContract /
+ *      sendTransaction / writeContract), never Hardhat's own
+ *      viem.sendDeploymentTransaction() helper — that helper makes an extra
+ *      publicClient.getTransaction() round-trip immediately after broadcasting, purely
+ *      to recover the tx's nonce for CREATE address computation, and a real incident
+ *      during the v3 mainnet redeploy proved that follow-up call can throw on this RPC
+ *      even though the underlying transaction already succeeded — before ever handing
+ *      the hash back to the caller, defeating any retry/resume logic built on top of
+ *      it. This script computes ordinary-CREATE addresses itself from a nonce fetched
+ *      BEFORE sending (CREATE2 addresses need no such trick — they're already fully
+ *      deterministic from the salt+initcode alone), so a hash is always known and
+ *      persisted to disk the instant a transaction is actually broadcast.
+ *
+ * CRASH / RPC-HICCUP SAFETY (automatic — no flag needed): identical mechanism to
+ * verify-v3-fix-mainnet.ts. Every step's tx hash (and anything else needed to resume
+ * it, e.g. a pre-computed CREATE address) is written to
+ * scripts/.v4-hook-deployment-state.json BEFORE this script ever waits on its receipt.
+ * If a receipt wait fails (retried with backoff first — 6 attempts, 5s/10s/20s/40s/
+ * 80s/160s by default; override via RECEIPT_RETRY_ATTEMPTS / RECEIPT_RETRY_DELAY_MS)
+ * or the process dies outright, re-run the EXACT SAME command: any step already on
+ * disk is never re-sent, only re-polled for its receipt.
+ *
+ * SAFETY GATES — ALL required:
+ *   - DEPLOYER_PRIVATE_KEY (or PRIVATE_KEY) — a funded Robinhood Chain mainnet key
+ *   - DEPLOY_CONFIRM=I_UNDERSTAND_THIS_IS_MAINNET
+ *   - V4_PRODUCTION_CONFIRM=I_ACKNOWLEDGE_V4_HOOK_IS_UNTESTED_ON_REAL_POOLMANAGER
+ *     (see the risk section above — this is deliberately a separate, explicitly-named
+ *     flag from DEPLOY_CONFIRM, not reused, because the risk it acknowledges is
+ *     specific to this contract's test status and this being the real production
+ *     LossRewardPool's first-ever exposure to V4 code, not just "this is mainnet.")
+ *
+ * Usage:
+ *   DEPLOYER_PRIVATE_KEY=0x... \
+ *   DEPLOY_CONFIRM=I_UNDERSTAND_THIS_IS_MAINNET \
+ *   V4_PRODUCTION_CONFIRM=I_ACKNOWLEDGE_V4_HOOK_IS_UNTESTED_ON_REAL_POOLMANAGER \
+ *     npx hardhat run scripts/deploy-v4-hook-production-mainnet.ts --network robinhoodMainnet
+ *
+ * Does NOT launch a token, buy, sell, or drive graduation — scope here is exactly
+ * "deploy hook + factory + router, verify every constructor argument on-chain." A
+ * separate verify script (mirroring verify-v3-fix-mainnet.ts) is the natural next step
+ * once this is done, not folded into this one.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { network, artifacts } from 'hardhat';
+import {
+  keccak256,
+  encodeAbiParameters,
+  parseAbiParameters,
+  concat,
+  pad,
+  toHex,
+  getAddress,
+  getContractAddress,
+  formatEther,
+} from 'viem';
+
+const CHAIN_ID = 4663;
+const CREATE2_FACTORY = getAddress('0x4e59b44847b379578588920cA78FbF26c0B4956C');
+const POOL_MANAGER = getAddress('0x8366a39cc670b4001a1121b8f6a443a643e40951');
+// The REAL production pool — deliberately hardcoded, not an env var or CLI arg, so
+// there is no way to accidentally point this specific script at a throwaway one.
+const REAL_PRODUCTION_LOSS_REWARD_POOL = getAddress('0x697bda9db5a297a9cd9ed969bbf2549d0527dcdf');
+
+// getHookPermissions() for the PRODUCTION hook (contracts/v4/IncentifiV4Hook.sol):
+// beforeInitialize(1<<13) | beforeAddLiquidity(1<<11) | beforeSwap(1<<7) |
+// beforeSwapReturnDelta(1<<3) | afterSwap(1<<6) | afterSwapReturnDelta(1<<2).
+// Independently confirmed against test/hardhat/v4-hook-deployment.test.ts's own
+// REQUIRED_FLAGS constant (= 10444 = 0x28cc), which that fork test asserts on-chain
+// against the actually-deployed hook's address. NOT the same value as the 4-flag
+// testnet hook (IncentifiV4HookTestnet.sol) used by scripts/deploy-testnet-mainnet.ts.
+const REQUIRED_FLAGS = (1n << 13n) | (1n << 11n) | (1n << 7n) | (1n << 3n) | (1n << 6n) | (1n << 2n); // 10444 (0x28cc)
+const FLAG_MASK = (1n << 14n) - 1n; // Hooks.ALL_HOOK_MASK
+const MAX_SALT_SEARCH = 160_444; // same cap HookMiner.sol's own find() loop uses
+
+const STATE_PATH = path.resolve('scripts', '.v4-hook-deployment-state.json');
+const RESULT_PATH = path.resolve('scripts', '.v4-hook-deployment-result.json');
+const RECEIPT_RETRY_ATTEMPTS = Number(process.env.RECEIPT_RETRY_ATTEMPTS || 6);
+const RECEIPT_RETRY_BASE_DELAY_MS = Number(process.env.RECEIPT_RETRY_DELAY_MS || 5000);
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function computeCreate2Address(deployer: `0x${string}`, salt: bigint, initCodeHash: `0x${string}`): `0x${string}` {
+  const packed = concat(['0xff', deployer, pad(toHex(salt), { size: 32 }), initCodeHash]);
+  return getAddress(`0x${keccak256(packed).slice(-40)}`);
+}
+
+function requireConfirmation() {
+  if (process.env.DEPLOY_CONFIRM !== 'I_UNDERSTAND_THIS_IS_MAINNET') {
+    throw new Error(
+      '\nRefusing to run: this deploys NEW, IMMUTABLE contracts to REAL Robinhood Chain ' +
+      'mainnet using REAL ETH.\nSet DEPLOY_CONFIRM=I_UNDERSTAND_THIS_IS_MAINNET to proceed.\n'
+    );
+  }
+  if (process.env.V4_PRODUCTION_CONFIRM !== 'I_ACKNOWLEDGE_V4_HOOK_IS_UNTESTED_ON_REAL_POOLMANAGER') {
+    throw new Error(
+      '\nRefusing to run: IncentifiV4Hook.sol / IncentifiV4Router.sol are self-documented as ' +
+      '"UNTESTED ... has never executed against a real PoolManager", and this is the first time ' +
+      'any V4 code touches the REAL production LossRewardPool (every prior real-mainnet V4 run used ' +
+      'a throwaway pool instead). Read the header comment in this file for the full risk explanation.\n' +
+      'Set V4_PRODUCTION_CONFIRM=I_ACKNOWLEDGE_V4_HOOK_IS_UNTESTED_ON_REAL_POOLMANAGER to proceed.\n'
+    );
+  }
+  const key = (process.env.DEPLOYER_PRIVATE_KEY || process.env.PRIVATE_KEY || '').trim();
+  if (!key) {
+    throw new Error('DEPLOYER_PRIVATE_KEY (or PRIVATE_KEY) env var is required to deploy.');
+  }
+}
+
+type StepRecord = {
+  hash?: `0x${string}`;
+  confirmed?: boolean;
+  blockNumber?: string;
+  gasUsed?: string;
+  effectiveGasPrice?: string;
+  [key: string]: unknown;
+};
+type DeployState = { wallet: `0x${string}`; steps: Record<string, StepRecord> };
+
+function loadState(walletAddressRaw: `0x${string}`): DeployState {
+  const walletAddress = getAddress(walletAddressRaw);
+  if (!fs.existsSync(STATE_PATH)) {
+    return { wallet: walletAddress, steps: {} };
+  }
+  const raw = JSON.parse(fs.readFileSync(STATE_PATH, 'utf8'));
+  if (!raw.wallet || getAddress(raw.wallet) !== walletAddress) {
+    throw new Error(
+      `${STATE_PATH} exists but is for a different wallet than this run (state: ${raw.wallet}, this run: ${walletAddress}).\n` +
+      `If that earlier run's transactions are done with (all confirmed, or safely abandoned before anything was ` +
+      `sent), move or delete ${STATE_PATH} by hand before re-running with a different wallet.`
+    );
+  }
+  const steps = raw.steps || {};
+  if (Object.keys(steps).length > 0) {
+    console.log(`[STATE] Found ${STATE_PATH} — resuming. Steps already recorded: ${Object.keys(steps).join(', ')}\n`);
+  }
+  return { wallet: walletAddress, steps };
+}
+
+function persistState(state: DeployState) {
+  fs.mkdirSync(path.dirname(STATE_PATH), { recursive: true });
+  fs.writeFileSync(STATE_PATH, JSON.stringify({ ...state, updatedAt: new Date().toISOString() }, null, 2));
+}
+
+async function main() {
+  requireConfirmation();
+
+  const { viem } = await network.create('robinhoodMainnet');
+  const publicClient = await viem.getPublicClient();
+
+  const chainId = await publicClient.getChainId();
+  if (chainId !== CHAIN_ID) {
+    throw new Error(`Chain ID mismatch! Expected ${CHAIN_ID}, got ${chainId}.`);
+  }
+
+  const [wallet] = await viem.getWalletClients();
+  const account = getAddress(wallet.account.address);
+  const balanceBefore = await publicClient.getBalance({ address: account });
+
+  console.log('\n============================================================');
+  console.log('[DEPLOY V4 HOOK — PRODUCTION] Robinhood Chain MAINNET (Chain ID 4663)');
+  console.log('============================================================');
+  console.log(`Deployer:                    ${account}`);
+  console.log(`Balance:                     ${formatEther(balanceBefore)} ETH`);
+  console.log(`CREATE2 singleton factory:   ${CREATE2_FACTORY}`);
+  console.log(`PoolManager:                 ${POOL_MANAGER}`);
+  console.log(`REAL production LossRewardPool: ${REAL_PRODUCTION_LOSS_REWARD_POOL}`);
+  console.log(`Required permission flags:   ${REQUIRED_FLAGS} (0x${REQUIRED_FLAGS.toString(16)})`);
+  console.log('============================================================\n');
+
+  if (balanceBefore === 0n) {
+    throw new Error(`Deployer ${account} has zero ETH balance on mainnet. Fund it before deploying.`);
+  }
+
+  const prodPoolBalanceBefore = await publicClient.getBalance({ address: REAL_PRODUCTION_LOSS_REWARD_POOL });
+
+  const state = loadState(account);
+
+  async function waitForReceiptWithRetry(hash: `0x${string}`, label: string) {
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= RECEIPT_RETRY_ATTEMPTS; attempt++) {
+      try {
+        return await publicClient.waitForTransactionReceipt({ hash, confirmations: 1, timeout: 90_000 });
+      } catch (err) {
+        lastErr = err;
+        const delay = RECEIPT_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+        console.warn(
+          `  [${label}] receipt wait attempt ${attempt}/${RECEIPT_RETRY_ATTEMPTS} failed ` +
+          `(${err instanceof Error ? err.message : String(err)})` +
+          (attempt < RECEIPT_RETRY_ATTEMPTS ? `; retrying in ${Math.round(delay / 1000)}s...` : '')
+        );
+        if (attempt < RECEIPT_RETRY_ATTEMPTS) await sleep(delay);
+      }
+    }
+    throw new Error(
+      `[${label}] Could not confirm receipt for tx ${hash} after ${RECEIPT_RETRY_ATTEMPTS} attempts. The ` +
+      `transaction itself may still be pending or may already have succeeded — check a block explorer before ` +
+      `re-running. Its hash is already saved in ${STATE_PATH}; re-running this exact command resumes from here, ` +
+      `it will not resend it.\nLast error: ${lastErr instanceof Error ? lastErr.message : String(lastErr)}`
+    );
+  }
+
+  async function runStep(
+    name: string,
+    sendFn: () => Promise<{ hash: `0x${string}`; [key: string]: unknown }>,
+    precomputedExtra: Record<string, unknown> = {}
+  ): Promise<StepRecord> {
+    let record = state.steps[name];
+    if (!record) {
+      console.log(`[${name}] sending transaction...`);
+      const sent = await sendFn();
+      record = { confirmed: false, ...precomputedExtra, ...sent };
+      state.steps[name] = record;
+      persistState(state);
+      console.log(`  Tx sent: ${record.hash}`);
+    } else {
+      console.log(`[${name}] resuming — tx already on record: ${record.hash} (confirmed: ${Boolean(record.confirmed)})`);
+    }
+    if (!record.confirmed) {
+      const receipt = await waitForReceiptWithRetry(record.hash as `0x${string}`, name);
+      if (receipt.status !== 'success') {
+        throw new Error(`[${name}] transaction reverted (status: ${receipt.status}). Tx: ${record.hash}`);
+      }
+      record.confirmed = true;
+      record.blockNumber = receipt.blockNumber.toString();
+      record.gasUsed = receipt.gasUsed.toString();
+      record.effectiveGasPrice = receipt.effectiveGasPrice.toString();
+      state.steps[name] = record;
+      persistState(state);
+      console.log(`  Confirmed in block #${receipt.blockNumber} (gas used ${receipt.gasUsed})\n`);
+    }
+    return record;
+  }
+
+  // ------------------------------------------------------------------------
+  // Step 1: mine the CREATE2 salt off-chain (free, deterministic — not a
+  // transaction, so nothing here needs to be persisted/resumed).
+  // ------------------------------------------------------------------------
+  console.log('[1/6] Mining CREATE2 salt for IncentifiV4Hook...');
+  const hookArtifact = await artifacts.readArtifact('IncentifiV4Hook');
+  const hookConstructorArgs = encodeAbiParameters(
+    parseAbiParameters('address, address, address'),
+    [POOL_MANAGER, REAL_PRODUCTION_LOSS_REWARD_POOL, account]
+  );
+  const hookInitCode = concat([hookArtifact.bytecode as `0x${string}`, hookConstructorArgs]);
+  const hookInitCodeHash = keccak256(hookInitCode);
+
+  let foundSalt: bigint | null = null;
+  let foundHookAddress: `0x${string}` | null = null;
+  const searchStart = Date.now();
+  for (let salt = 0n; salt < BigInt(MAX_SALT_SEARCH); salt++) {
+    const candidate = computeCreate2Address(CREATE2_FACTORY, salt, hookInitCodeHash);
+    if ((BigInt(candidate) & FLAG_MASK) === REQUIRED_FLAGS) {
+      foundSalt = salt;
+      foundHookAddress = candidate;
+      break;
+    }
+  }
+  if (foundSalt === null || foundHookAddress === null) {
+    throw new Error(`No valid CREATE2 salt found within ${MAX_SALT_SEARCH} attempts. Stopping before spending any gas.`);
+  }
+  console.log(`  Found salt ${foundSalt} after ${Date.now() - searchStart}ms (off-chain, zero gas)`);
+  console.log(`  Predicted hook address: ${foundHookAddress}`);
+
+  // ------------------------------------------------------------------------
+  // Step 2: deploy HookMinerCheck and cross-check the mined address against the
+  // REAL, actual, installed HookMiner library — not just this script's own JS
+  // reimplementation of the CREATE2 formula.
+  // ------------------------------------------------------------------------
+  console.log('\n[2/6] Deploying HookMinerCheck (cross-check helper)...');
+  const hookMinerCheckArtifact = await artifacts.readArtifact('HookMinerCheck');
+  const hmcNonce = state.steps.hookMinerCheckDeploy?.nonce !== undefined
+    ? Number(state.steps.hookMinerCheckDeploy.nonce)
+    : await publicClient.getTransactionCount({ address: account, blockTag: 'pending' });
+  const hookMinerCheckAddress = getContractAddress({ from: account, nonce: BigInt(hmcNonce) });
+  await runStep(
+    'hookMinerCheckDeploy',
+    async () => ({
+      hash: await wallet.deployContract({ abi: hookMinerCheckArtifact.abi, bytecode: hookMinerCheckArtifact.bytecode as `0x${string}`, nonce: hmcNonce }),
+    }),
+    { nonce: hmcNonce, address: hookMinerCheckAddress }
+  );
+  const hookMinerCheck = await viem.getContractAt('HookMinerCheck', hookMinerCheckAddress);
+  const onChainComputed = getAddress(await hookMinerCheck.read.computeAddress([CREATE2_FACTORY, foundSalt, hookInitCode]));
+  console.log(`  Off-chain JS computed:  ${foundHookAddress}`);
+  console.log(`  Real on-chain computed: ${onChainComputed}`);
+  if (onChainComputed !== foundHookAddress) {
+    throw new Error('JS-computed hook address does not match the REAL on-chain HookMiner library. Stopping — do not deploy.');
+  }
+  console.log('  Cross-check: MATCH\n');
+
+  // Only meaningful before hookDeploy has ever been sent — on a resume where
+  // state.steps.hookDeploy is already on record, code at this address is the
+  // EXPECTED, successful outcome of that prior run, not a collision to abort
+  // on. Checking unconditionally here previously broke every resume: the
+  // legitimate "already deployed" case looked identical to the genuinely
+  // impossible "salt collision" case this check exists to catch.
+  if (!state.steps.hookDeploy) {
+    const codeAtPredicted = await publicClient.getCode({ address: foundHookAddress });
+    if (codeAtPredicted && codeAtPredicted !== '0x') {
+      throw new Error(`Predicted hook address ${foundHookAddress} already has code on real mainnet. Stopping — this should never happen for a freshly-mined salt.`);
+    }
+  }
+
+  // ------------------------------------------------------------------------
+  // Step 3: the REAL CREATE2 deployment, through the REAL singleton factory.
+  // CREATE2 addresses are fully deterministic from (deployer, salt, initCodeHash)
+  // alone — unlike an ordinary CREATE deploy, no nonce-based address recovery is
+  // needed here, so there is no equivalent of the v3-redeploy sendDeploymentTransaction
+  // bug to work around for this specific step.
+  // ------------------------------------------------------------------------
+  console.log('[3/6] Deploying IncentifiV4Hook via CREATE2...');
+  const hookDeployData = concat([pad(toHex(foundSalt), { size: 32 }), hookInitCode]);
+  await runStep('hookDeploy', async () => ({
+    hash: await wallet.sendTransaction({ to: CREATE2_FACTORY, data: hookDeployData }),
+  }));
+
+  const hookCode = await publicClient.getCode({ address: foundHookAddress });
+  if (!hookCode || hookCode === '0x') {
+    throw new Error(`Hook deployment transaction succeeded but no code landed at ${foundHookAddress}. Stopping.`);
+  }
+  const deployedFlags = BigInt(foundHookAddress) & FLAG_MASK;
+  if (deployedFlags !== REQUIRED_FLAGS) {
+    throw new Error(`Deployed hook address permission bits (${deployedFlags}) != required (${REQUIRED_FLAGS}). Stopping — do not wire a factory to this.`);
+  }
+  console.log(`  eth_getCode: NON-EMPTY (${(hookCode.length - 2) / 2} bytes)`);
+  console.log('  Permission bits confirmed on real deployed bytecode.');
+
+  const hookContract = await viem.getContractAt('IncentifiV4Hook', foundHookAddress);
+  const hookDeployerOnChain = getAddress(await hookContract.read.deployer());
+  const hookLossRewardPoolOnChain = getAddress(await hookContract.read.lossRewardPool());
+  if (hookDeployerOnChain !== account) throw new Error(`hook.deployer() mismatch: got ${hookDeployerOnChain}, expected ${account}.`);
+  if (hookLossRewardPoolOnChain !== REAL_PRODUCTION_LOSS_REWARD_POOL) {
+    throw new Error(`hook.lossRewardPool() mismatch: got ${hookLossRewardPoolOnChain}, expected ${REAL_PRODUCTION_LOSS_REWARD_POOL} (REAL production pool).`);
+  }
+  console.log(`  hook.deployer() == ${hookDeployerOnChain} (confirmed)`);
+  console.log(`  hook.lossRewardPool() == ${hookLossRewardPoolOnChain} (confirmed == REAL production pool)\n`);
+
+  // ------------------------------------------------------------------------
+  // Step 4: IncentifiV4Factory — ordinary CREATE, so its address depends on the
+  // deployer's nonce. Fetched BEFORE sending (never read back from the just-sent
+  // tx) so the address is known immediately, with no post-broadcast lookup that
+  // could fail independently of the underlying transaction's own success.
+  // ------------------------------------------------------------------------
+  console.log('[4/6] Deploying IncentifiV4Factory...');
+  const factoryArtifact = await artifacts.readArtifact('IncentifiV4Factory');
+  const factoryNonce = state.steps.factoryDeploy?.nonce !== undefined
+    ? Number(state.steps.factoryDeploy.nonce)
+    : await publicClient.getTransactionCount({ address: account, blockTag: 'pending' });
+  const factoryAddress = getContractAddress({ from: account, nonce: BigInt(factoryNonce) });
+  await runStep(
+    'factoryDeploy',
+    async () => ({
+      hash: await wallet.deployContract({
+        abi: factoryArtifact.abi,
+        bytecode: factoryArtifact.bytecode as `0x${string}`,
+        args: [POOL_MANAGER, foundHookAddress],
+        nonce: factoryNonce,
+      }),
+    }),
+    { nonce: factoryNonce, address: factoryAddress }
+  );
+
+  const factoryCode = await publicClient.getCode({ address: factoryAddress });
+  if (!factoryCode || factoryCode === '0x') throw new Error(`Factory has EMPTY code at ${factoryAddress}.`);
+  const factoryContract = await viem.getContractAt('IncentifiV4Factory', factoryAddress);
+  const factoryPoolManagerOnChain = getAddress(await factoryContract.read.poolManager());
+  const factoryHookOnChain = getAddress(await factoryContract.read.hook());
+  if (factoryPoolManagerOnChain !== POOL_MANAGER) throw new Error(`factory.poolManager() mismatch: got ${factoryPoolManagerOnChain}.`);
+  if (factoryHookOnChain !== foundHookAddress) throw new Error(`factory.hook() mismatch: got ${factoryHookOnChain}, expected ${foundHookAddress}.`);
+  console.log(`  Factory address: ${factoryAddress}`);
+  console.log(`  factory.poolManager() == ${factoryPoolManagerOnChain} (confirmed)`);
+  console.log(`  factory.hook() == ${factoryHookOnChain} (confirmed)\n`);
+
+  // ------------------------------------------------------------------------
+  // Step 5: setFactory() — one-time wiring, must be called by `account` (the
+  // exact address passed as `_deployer` in the hook's constructor).
+  // ------------------------------------------------------------------------
+  console.log('[5/6] setFactory() (one-time wiring)...');
+  const factoryBeforeWiring = getAddress(await hookContract.read.factory());
+  if (factoryBeforeWiring === '0x0000000000000000000000000000000000000000') {
+    await runStep('setFactory', async () => ({
+      hash: await wallet.writeContract({
+        address: foundHookAddress,
+        abi: hookArtifact.abi,
+        functionName: 'setFactory',
+        args: [factoryAddress],
+      }),
+    }));
+  } else {
+    console.log(`  hook.factory() is already set to ${factoryBeforeWiring} — skipping (already wired).`);
+  }
+  const factoryAfterWiring = getAddress(await hookContract.read.factory());
+  if (factoryAfterWiring !== factoryAddress) {
+    throw new Error(`hook.factory() (${factoryAfterWiring}) does not match the deployed Factory (${factoryAddress}) after wiring.`);
+  }
+  console.log(`  hook.factory() == ${factoryAfterWiring} (confirmed)\n`);
+
+  // ------------------------------------------------------------------------
+  // Step 6: IncentifiV4Router — same nonce-prefetch pattern as the Factory.
+  // ------------------------------------------------------------------------
+  console.log('[6/6] Deploying IncentifiV4Router...');
+  const routerArtifact = await artifacts.readArtifact('IncentifiV4Router');
+  const routerNonce = state.steps.routerDeploy?.nonce !== undefined
+    ? Number(state.steps.routerDeploy.nonce)
+    : await publicClient.getTransactionCount({ address: account, blockTag: 'pending' });
+  const routerAddress = getContractAddress({ from: account, nonce: BigInt(routerNonce) });
+  await runStep(
+    'routerDeploy',
+    async () => ({
+      hash: await wallet.deployContract({
+        abi: routerArtifact.abi,
+        bytecode: routerArtifact.bytecode as `0x${string}`,
+        args: [POOL_MANAGER, foundHookAddress, factoryAddress],
+        nonce: routerNonce,
+      }),
+    }),
+    { nonce: routerNonce, address: routerAddress }
+  );
+
+  const routerCode = await publicClient.getCode({ address: routerAddress });
+  if (!routerCode || routerCode === '0x') throw new Error(`Router has EMPTY code at ${routerAddress}.`);
+  const routerContract = await viem.getContractAt('IncentifiV4Router', routerAddress);
+  const routerPoolManagerOnChain = getAddress(await routerContract.read.poolManager());
+  const routerHookOnChain = getAddress(await routerContract.read.hook());
+  const routerFactoryOnChain = getAddress(await routerContract.read.factory());
+  if (routerPoolManagerOnChain !== POOL_MANAGER) throw new Error(`router.poolManager() mismatch: got ${routerPoolManagerOnChain}.`);
+  if (routerHookOnChain !== foundHookAddress) throw new Error(`router.hook() mismatch: got ${routerHookOnChain}, expected ${foundHookAddress}.`);
+  if (routerFactoryOnChain !== factoryAddress) throw new Error(`router.factory() mismatch: got ${routerFactoryOnChain}, expected ${factoryAddress}.`);
+  console.log(`  Router address: ${routerAddress}`);
+  console.log(`  router.poolManager() == ${routerPoolManagerOnChain} (confirmed)`);
+  console.log(`  router.hook() == ${routerHookOnChain} (confirmed)`);
+  console.log(`  router.factory() == ${routerFactoryOnChain} (confirmed)\n`);
+
+  // ------------------------------------------------------------------------
+  // Final paranoid safety check: nothing in this script should ever move the
+  // real production LossRewardPool's balance — only a real trade would.
+  // ------------------------------------------------------------------------
+  const prodPoolBalanceAfter = await publicClient.getBalance({ address: REAL_PRODUCTION_LOSS_REWARD_POOL });
+  if (prodPoolBalanceAfter !== prodPoolBalanceBefore) {
+    throw new Error(
+      `Real production LossRewardPool balance CHANGED (${formatEther(prodPoolBalanceBefore)} -> ` +
+      `${formatEther(prodPoolBalanceAfter)} ETH) during a deployment script that should never move it. ` +
+      `Investigate before trusting anything above.`
+    );
+  }
+  console.log(`Confirmed: real production LossRewardPool balance unchanged (${formatEther(prodPoolBalanceAfter)} ETH).\n`);
+
+  const balanceAfter = await publicClient.getBalance({ address: account });
+  const result = {
+    chainId,
+    deployer: account,
+    hook: {
+      address: foundHookAddress,
+      salt: foundSalt.toString(),
+      txHash: state.steps.hookDeploy.hash,
+      blockNumber: state.steps.hookDeploy.blockNumber,
+      gasUsed: state.steps.hookDeploy.gasUsed,
+      constructorArgs: { poolManager: POOL_MANAGER, lossRewardPool: REAL_PRODUCTION_LOSS_REWARD_POOL, deployer: account },
+      permissionFlags: REQUIRED_FLAGS.toString(),
+    },
+    factory: {
+      address: factoryAddress,
+      txHash: state.steps.factoryDeploy.hash,
+      blockNumber: state.steps.factoryDeploy.blockNumber,
+      gasUsed: state.steps.factoryDeploy.gasUsed,
+      constructorArgs: { poolManager: POOL_MANAGER, hook: foundHookAddress },
+    },
+    router: {
+      address: routerAddress,
+      txHash: state.steps.routerDeploy.hash,
+      blockNumber: state.steps.routerDeploy.blockNumber,
+      gasUsed: state.steps.routerDeploy.gasUsed,
+      constructorArgs: { poolManager: POOL_MANAGER, hook: foundHookAddress, factory: factoryAddress },
+    },
+    hookMinerCheck: hookMinerCheckAddress,
+    gasSpentWei: (balanceBefore - balanceAfter).toString(),
+    gasSpentEth: formatEther(balanceBefore - balanceAfter),
+    deployedAt: new Date().toISOString(),
+  };
+
+  fs.writeFileSync(RESULT_PATH, JSON.stringify(result, null, 2));
+
+  console.log('============================================================');
+  console.log('[DEPLOY V4 HOOK — PRODUCTION] COMPLETE — every constructor arg confirmed on-chain');
+  console.log('============================================================');
+  console.log(JSON.stringify(result, null, 2));
+  console.log(`\nSaved to ${RESULT_PATH}`);
+  console.log('\nThis script did NOT launch a token, buy, sell, or drive graduation — that scope was');
+  console.log('deliberately left for a separate verify script, mirroring verify-v3-fix-mainnet.ts.');
+}
+
+main().catch((err) => {
+  console.error('\n[DEPLOY V4 HOOK ERROR]', err instanceof Error ? err.message : err);
+  console.error(`Progress so far (including any tx hashes already sent) is saved in ${STATE_PATH}.`);
+  console.error('Re-running the exact same command will resume from here, not resend anything already sent.');
+  process.exitCode = 1;
+});

--- a/scripts/verify-v4-hook-production-logic-test-mainnet.ts
+++ b/scripts/verify-v4-hook-production-logic-test-mainnet.ts
@@ -1,0 +1,581 @@
+/**
+ * End-to-end REAL-money verification of IncentifiV4HookProductionLogicTest —
+ * byte-for-byte the same logic as the production IncentifiV4Hook.sol (six
+ * permission flags, including the never-before-real-mainnet-tested afterSwap
+ * post-graduation fee mechanism), at ~1/50th the ETH cost of a production-scale
+ * graduation. Same shape and rigor as verify-v4-hook-production-mainnet.ts —
+ * see that file for the full design rationale — targeting the cheap
+ * test-parameter deployment instead.
+ *
+ * The LossRewardPool this script checks balances against is whatever THROWAWAY
+ * pool deploy-v4-hook-production-logic-test-mainnet.ts deployed and recorded —
+ * this script never references the real production LossRewardPool address at
+ * all, anywhere, so there is no code path that could touch it.
+ *
+ * Steps (identical shape to the production verify script):
+ *   1. Launch a real test token through the test-scale factory.
+ *   2. Real pre-graduation BUY (0.005 ETH) through the router.
+ *   3. Real pre-graduation SELL of everything just bought.
+ *   4. Drive a REAL graduation (cheap here — GRADUATION_ETH_TARGET is ~0.117 ETH,
+ *      not ~5.85 ETH). Verifies graduation state, GraduationLiquidityDeployed,
+ *      and an independent StateView cross-check.
+ *   5. Deploy GenericV4Bot (the router is pre-graduation-only, same as production).
+ *   6. Real POST-graduation BUY via the bot — beforeSwap graduated-branch skim.
+ *   7. Real POST-graduation SELL via the bot — afterSwap fee mechanism, THE
+ *      never-before-mainnet-tested code path, exercised here cheaply first.
+ *   8. claimCreatorFees() across everything accrued in steps 2, 3, 4, 6, 7.
+ *
+ * SAFETY GATES:
+ *   - DEPLOYER_PRIVATE_KEY (or PRIVATE_KEY) — the SAME funded key used to deploy
+ *   - DEPLOY_CONFIRM=I_UNDERSTAND_THIS_IS_MAINNET
+ *   - The hook/factory/router/lossRewardPool addresses, via V4_HOOK_ADDRESS /
+ *     V4_FACTORY_ADDRESS / V4_ROUTER_ADDRESS / V4_LOSS_REWARD_POOL_ADDRESS env
+ *     vars, or scripts/.v4-logic-test-deployment-result.json (written by
+ *     deploy-v4-hook-production-logic-test-mainnet.ts) if unset.
+ *
+ * Usage:
+ *   DEPLOYER_PRIVATE_KEY=0x... DEPLOY_CONFIRM=I_UNDERSTAND_THIS_IS_MAINNET \
+ *     npx hardhat run scripts/verify-v4-hook-production-logic-test-mainnet.ts --network robinhoodMainnet
+ *
+ * CRASH / RPC-HICCUP SAFETY (automatic — no flag needed): identical mechanism
+ * to every other script in this batch — every tx hash (and any pre-send
+ * snapshot its exact-delta assertion needs) is written to
+ * scripts/.v4-logic-test-verify-state.json before this script ever waits on a
+ * receipt. Re-running the exact same command resumes rather than resends.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { network, artifacts } from 'hardhat';
+import { keccak256, encodeAbiParameters, parseAbiParameters, parseAbi, getAddress, getContractAddress, formatEther, parseEther } from 'viem';
+
+const CHAIN_ID = 4663;
+const POOL_MANAGER = getAddress('0x8366a39cc670b4001a1121b8f6a443a643e40951');
+const STATE_VIEW = getAddress('0xf3334192d15450cdd385c8b70e03f9a6bd9e673b');
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+const TOTAL_SUPPLY = 1_000_000_000n * 10n ** 18n;
+const BUY_AMOUNT_WEI = parseEther('0.005');
+
+const STATE_VIEW_ABI = parseAbi([
+  'function getSlot0(bytes32 poolId) view returns (uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)',
+  'function getLiquidity(bytes32 poolId) view returns (uint128 liquidity)',
+]);
+
+const RESULT_PATH = path.resolve('scripts', '.v4-logic-test-deployment-result.json');
+const STATE_PATH = path.resolve('scripts', '.v4-logic-test-verify-state.json');
+const RECEIPT_RETRY_ATTEMPTS = Number(process.env.RECEIPT_RETRY_ATTEMPTS || 6);
+const RECEIPT_RETRY_BASE_DELAY_MS = Number(process.env.RECEIPT_RETRY_DELAY_MS || 5000);
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function resolveAddresses(): { hook: `0x${string}`; factory: `0x${string}`; router: `0x${string}`; lossRewardPool: `0x${string}` } {
+  const envHook = process.env.V4_HOOK_ADDRESS;
+  const envFactory = process.env.V4_FACTORY_ADDRESS;
+  const envRouter = process.env.V4_ROUTER_ADDRESS;
+  const envLrp = process.env.V4_LOSS_REWARD_POOL_ADDRESS;
+  if (envHook && envFactory && envRouter && envLrp) {
+    return { hook: getAddress(envHook), factory: getAddress(envFactory), router: getAddress(envRouter), lossRewardPool: getAddress(envLrp) };
+  }
+  if (!fs.existsSync(RESULT_PATH)) {
+    throw new Error(
+      `Neither V4_HOOK_ADDRESS/V4_FACTORY_ADDRESS/V4_ROUTER_ADDRESS/V4_LOSS_REWARD_POOL_ADDRESS env vars nor ` +
+      `${RESULT_PATH} were found.\nRun deploy-v4-hook-production-logic-test-mainnet.ts first, or set all four env vars explicitly.`
+    );
+  }
+  const deployResult = JSON.parse(fs.readFileSync(RESULT_PATH, 'utf8'));
+  return {
+    hook: getAddress(deployResult.hook.address),
+    factory: getAddress(deployResult.factory.address),
+    router: getAddress(deployResult.router.address),
+    lossRewardPool: getAddress(deployResult.lossRewardPool.address),
+  };
+}
+
+function requireConfirmation() {
+  if (process.env.DEPLOY_CONFIRM !== 'I_UNDERSTAND_THIS_IS_MAINNET') {
+    throw new Error('\nSet DEPLOY_CONFIRM=I_UNDERSTAND_THIS_IS_MAINNET to proceed.\n');
+  }
+  const key = (process.env.DEPLOYER_PRIVATE_KEY || process.env.PRIVATE_KEY || '').trim();
+  if (!key) {
+    throw new Error('DEPLOYER_PRIVATE_KEY (or PRIVATE_KEY) env var is required.');
+  }
+}
+
+type StepRecord = { hash?: `0x${string}`; confirmed?: boolean; blockNumber?: string; gasUsed?: string; effectiveGasPrice?: string; [key: string]: unknown };
+type VerifyState = { hook: `0x${string}`; factory: `0x${string}`; router: `0x${string}`; lossRewardPool: `0x${string}`; wallet: `0x${string}`; steps: Record<string, StepRecord> };
+
+function loadState(hook: `0x${string}`, factory: `0x${string}`, router: `0x${string}`, lossRewardPool: `0x${string}`, walletRaw: `0x${string}`): VerifyState {
+  const wallet = getAddress(walletRaw);
+  if (!fs.existsSync(STATE_PATH)) return { hook, factory, router, lossRewardPool, wallet, steps: {} };
+  const raw = JSON.parse(fs.readFileSync(STATE_PATH, 'utf8'));
+  const sameRun =
+    raw.hook && getAddress(raw.hook) === hook &&
+    raw.factory && getAddress(raw.factory) === factory &&
+    raw.router && getAddress(raw.router) === router &&
+    raw.lossRewardPool && getAddress(raw.lossRewardPool) === lossRewardPool &&
+    raw.wallet && getAddress(raw.wallet) === wallet;
+  if (!sameRun) {
+    throw new Error(
+      `${STATE_PATH} exists but is for different addresses than this run.\n` +
+      `  state file: hook=${raw.hook}, factory=${raw.factory}, router=${raw.router}, lossRewardPool=${raw.lossRewardPool}, wallet=${raw.wallet}\n` +
+      `  this run:   hook=${hook}, factory=${factory}, router=${router}, lossRewardPool=${lossRewardPool}, wallet=${wallet}\n` +
+      `Move or delete ${STATE_PATH} by hand if that earlier run is done with.`
+    );
+  }
+  const steps = raw.steps || {};
+  if (Object.keys(steps).length > 0) {
+    console.log(`[STATE] Found ${STATE_PATH} — resuming. Steps already recorded: ${Object.keys(steps).join(', ')}\n`);
+  }
+  return { hook, factory, router, lossRewardPool, wallet, steps };
+}
+
+function persistState(state: VerifyState) {
+  fs.mkdirSync(path.dirname(STATE_PATH), { recursive: true });
+  fs.writeFileSync(STATE_PATH, JSON.stringify({ ...state, updatedAt: new Date().toISOString() }, null, 2));
+}
+
+async function main() {
+  requireConfirmation();
+  const { hook: hookAddress, factory: factoryAddress, router: routerAddress, lossRewardPool: lossRewardPoolAddress } = resolveAddresses();
+
+  const { viem } = await network.create('robinhoodMainnet');
+  const publicClient = await viem.getPublicClient();
+
+  const chainId = await publicClient.getChainId();
+  if (chainId !== CHAIN_ID) throw new Error(`Chain ID mismatch! Expected ${CHAIN_ID}, got ${chainId}.`);
+
+  const [wallet] = await viem.getWalletClients();
+  const account = getAddress(wallet.account.address);
+
+  console.log('\n============================================================');
+  console.log('[VERIFY V4 HOOK — PRODUCTION LOGIC, TEST SCALE] Robinhood Chain MAINNET');
+  console.log('============================================================');
+  console.log(`Wallet:         ${account}`);
+  console.log(`Hook:           ${hookAddress}`);
+  console.log(`Factory:        ${factoryAddress}`);
+  console.log(`Router:         ${routerAddress}`);
+  console.log(`LossRewardPool: ${lossRewardPoolAddress} (throwaway — NOT the real production pool)`);
+  console.log('============================================================\n');
+
+  const state = loadState(hookAddress, factoryAddress, routerAddress, lossRewardPoolAddress, account);
+
+  async function waitForReceiptWithRetry(hash: `0x${string}`, label: string) {
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= RECEIPT_RETRY_ATTEMPTS; attempt++) {
+      try {
+        return await publicClient.waitForTransactionReceipt({ hash, confirmations: 1, timeout: 90_000 });
+      } catch (err) {
+        lastErr = err;
+        const delay = RECEIPT_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+        console.warn(`  [${label}] receipt wait attempt ${attempt}/${RECEIPT_RETRY_ATTEMPTS} failed (${err instanceof Error ? err.message : String(err)})` + (attempt < RECEIPT_RETRY_ATTEMPTS ? `; retrying in ${Math.round(delay / 1000)}s...` : ''));
+        if (attempt < RECEIPT_RETRY_ATTEMPTS) await sleep(delay);
+      }
+    }
+    throw new Error(`[${label}] Could not confirm receipt for tx ${hash} after ${RECEIPT_RETRY_ATTEMPTS} attempts. Its hash is already in ${STATE_PATH}; re-running resumes rather than resends.\nLast error: ${lastErr instanceof Error ? lastErr.message : String(lastErr)}`);
+  }
+
+  async function runStep(name: string, sendFn: () => Promise<{ hash: `0x${string}`; [key: string]: unknown }>, precomputedExtra: Record<string, unknown> = {}): Promise<StepRecord> {
+    let record = state.steps[name];
+    if (!record) {
+      console.log(`[${name}] sending transaction...`);
+      const sent = await sendFn();
+      record = { confirmed: false, ...precomputedExtra, ...sent };
+      state.steps[name] = record;
+      persistState(state);
+      console.log(`  Tx sent: ${record.hash}`);
+    } else {
+      console.log(`[${name}] resuming — tx already on record: ${record.hash} (confirmed: ${Boolean(record.confirmed)})`);
+    }
+    if (!record.confirmed) {
+      const receipt = await waitForReceiptWithRetry(record.hash as `0x${string}`, name);
+      if (receipt.status !== 'success') throw new Error(`[${name}] transaction reverted (status: ${receipt.status}). Tx: ${record.hash}`);
+      record.confirmed = true;
+      record.blockNumber = receipt.blockNumber.toString();
+      record.gasUsed = receipt.gasUsed.toString();
+      record.effectiveGasPrice = receipt.effectiveGasPrice.toString();
+      state.steps[name] = record;
+      persistState(state);
+      console.log(`  Confirmed in block #${receipt.blockNumber} (gas used ${receipt.gasUsed})\n`);
+    }
+    return record;
+  }
+
+  function gasCost(record: StepRecord): bigint {
+    return BigInt(record.gasUsed!) * BigInt(record.effectiveGasPrice!);
+  }
+
+  const hookArtifact = await artifacts.readArtifact('IncentifiV4HookProductionLogicTest');
+  const hook = await viem.getContractAt('IncentifiV4HookProductionLogicTest', hookAddress);
+  const factory = await viem.getContractAt('IncentifiV4Factory', factoryAddress);
+  const router = await viem.getContractAt('IncentifiV4Router', routerAddress);
+  for (const [label, addr] of [['Hook', hookAddress], ['Factory', factoryAddress], ['Router', routerAddress], ['LossRewardPool', lossRewardPoolAddress]] as const) {
+    const code = await publicClient.getCode({ address: addr });
+    if (!code || code === '0x') throw new Error(`${label} ${addr} has empty code.`);
+  }
+  if (getAddress(await factory.read.hook()) !== hookAddress) throw new Error('factory.hook() does not match the given Hook.');
+  if (getAddress(await router.read.hook()) !== hookAddress) throw new Error('router.hook() does not match the given Hook.');
+  if (getAddress(await router.read.factory()) !== factoryAddress) throw new Error('router.factory() does not match the given Factory.');
+  if (getAddress(await hook.read.lossRewardPool()) !== lossRewardPoolAddress) throw new Error('hook.lossRewardPool() does not match the given (throwaway) LossRewardPool.');
+  console.log('[PRE-FLIGHT] Hook/Factory/Router/LossRewardPool all have live code and are correctly cross-wired. OK.\n');
+
+  const totalDepositedAbi = parseAbi(['function totalDeposited(address) view returns (uint256)']);
+  async function lossPoolBalance() { return publicClient.getBalance({ address: lossRewardPoolAddress }); }
+  async function lossPoolDeposited(token: `0x${string}`) {
+    return publicClient.readContract({ address: lossRewardPoolAddress, abi: totalDepositedAbi, functionName: 'totalDeposited', args: [token] });
+  }
+
+  // ==========================================================================
+  // STAGE 1: launch a real test token
+  // ==========================================================================
+  console.log('[1/8] Test token launch...');
+  const tokenDeployRecord = await runStep('tokenDeploy', async () => {
+    const launchTokenArtifact = await artifacts.readArtifact('IncentifiLaunchToken');
+    const nonce = await publicClient.getTransactionCount({ address: account, blockTag: 'pending' });
+    const address = getContractAddress({ from: account, nonce: BigInt(nonce) });
+    const tokenName = `Incentifi V4 Logic Test ${Date.now()}`;
+    const hash = await wallet.deployContract({ abi: launchTokenArtifact.abi, bytecode: launchTokenArtifact.bytecode as `0x${string}`, args: [tokenName, 'IFV4T', TOTAL_SUPPLY], nonce });
+    return { hash, address, tokenName };
+  });
+  const tokenAddress = getAddress(tokenDeployRecord.address as string);
+  const token = await viem.getContractAt('IncentifiLaunchToken', tokenAddress);
+  console.log(`  Token: ${tokenAddress} ("${tokenDeployRecord.tokenName}")`);
+
+  await runStep('approveFactory', async () => ({ hash: await token.write.approve([factoryAddress, TOTAL_SUPPLY]) }));
+  await runStep('launchToken', async () => ({ hash: await factory.write.launchToken([tokenAddress]) }));
+
+  const poolKey = await factory.read.getPoolKey([tokenAddress]);
+  const poolId = keccak256(
+    encodeAbiParameters(parseAbiParameters('address, address, uint24, int24, address'), [poolKey.currency0, poolKey.currency1, poolKey.fee, poolKey.tickSpacing, poolKey.hooks])
+  );
+  const curveAfterLaunch = await hook.read.curveStates([poolId]);
+  if (getAddress(curveAfterLaunch[0]) !== tokenAddress) throw new Error('curveStates.token mismatch after launch.');
+  if (getAddress(curveAfterLaunch[1]) !== account) throw new Error('curveStates.creator mismatch after launch.');
+  if (curveAfterLaunch[2] !== true) throw new Error('curveStates.initialized is not true after launch.');
+  if (curveAfterLaunch[5] !== TOTAL_SUPPLY) throw new Error('curveStates.realTokenReserve != TOTAL_SUPPLY after launch.');
+
+  const slot0Launch = await publicClient.readContract({ address: STATE_VIEW, abi: STATE_VIEW_ABI, functionName: 'getSlot0', args: [poolId] });
+  const expectedLaunchPrice = await hook.read.launchSqrtPriceX96();
+  if (slot0Launch[0] !== expectedLaunchPrice) throw new Error('StateView launch price does not match hook.launchSqrtPriceX96().');
+  console.log(`  PoolId: ${poolId}`);
+  console.log('  curveStates + independent StateView launch-price cross-check: MATCH\n');
+
+  // ==========================================================================
+  // STAGE 2: real pre-graduation buy
+  // ==========================================================================
+  console.log(`[2/8] Pre-graduation buy of ${formatEther(BUY_AMOUNT_WEI)} ETH...`);
+  const buy1Before = (state.steps.preGradBuy?.before as Record<string, string>) ?? {
+    ethBefore: (await publicClient.getBalance({ address: account })).toString(),
+    tokensBefore: (await token.read.balanceOf([account])).toString(),
+    curveEthReserveBefore: ((await hook.read.curveStates([poolId]))[4] as bigint).toString(),
+    lossPoolBalanceBefore: (await lossPoolBalance()).toString(),
+    lossPoolDepositedBefore: (await lossPoolDeposited(tokenAddress)).toString(),
+  };
+  const buy1Record = await runStep(
+    'preGradBuy',
+    async () => {
+      const deadline = BigInt(Math.floor(Date.now() / 1000) + 600);
+      return { hash: await router.write.buyToken([tokenAddress, 0n, deadline], { value: BUY_AMOUNT_WEI }) };
+    },
+    { before: buy1Before }
+  );
+  {
+    const b = buy1Record.before as Record<string, string>;
+    const ethAfter = await publicClient.getBalance({ address: account });
+    const tokensAfter = await token.read.balanceOf([account]);
+    const curveEthReserveAfter = (await hook.read.curveStates([poolId]))[4] as bigint;
+    const lossPoolBalanceAfter = await lossPoolBalance();
+    const lossPoolDepositedAfter = await lossPoolDeposited(tokenAddress);
+
+    const ethSpent = BigInt(b.ethBefore) - ethAfter - gasCost(buy1Record);
+    const tokensReceived = tokensAfter - BigInt(b.tokensBefore);
+    const curveDelta = curveEthReserveAfter - BigInt(b.curveEthReserveBefore);
+    const lossPoolDelta = lossPoolBalanceAfter - BigInt(b.lossPoolBalanceBefore);
+    const lossPoolDepositedDelta = lossPoolDepositedAfter - BigInt(b.lossPoolDepositedBefore);
+    const expectedNetEth = BUY_AMOUNT_WEI - BUY_AMOUNT_WEI / 100n - BUY_AMOUNT_WEI / 100n;
+    const expectedFee = BUY_AMOUNT_WEI / 100n;
+
+    if (ethSpent !== BUY_AMOUNT_WEI) throw new Error(`Pre-grad buy: wallet spent ${ethSpent}, expected exactly ${BUY_AMOUNT_WEI}.`);
+    if (tokensReceived <= 0n) throw new Error('Pre-grad buy produced zero tokens.');
+    if (curveDelta !== expectedNetEth) throw new Error(`Pre-grad buy: curve realEthReserve delta ${curveDelta} != expected ${expectedNetEth}.`);
+    if (lossPoolDelta !== expectedFee) throw new Error(`Pre-grad buy: LossRewardPool balance delta ${lossPoolDelta} != expected ${expectedFee}.`);
+    if (lossPoolDepositedDelta !== expectedFee) throw new Error(`Pre-grad buy: LossRewardPool.totalDeposited(token) delta ${lossPoolDepositedDelta} != expected ${expectedFee}.`);
+    console.log(`  Tokens received: ${tokensReceived}. Exact balance-delta assertions: PASS\n`);
+
+    if (buy1Record.tokensReceived === undefined) {
+      buy1Record.tokensReceived = tokensReceived.toString();
+      state.steps.preGradBuy = buy1Record;
+      persistState(state);
+    }
+  }
+  const preGradTokens = BigInt(buy1Record.tokensReceived as string);
+
+  // ==========================================================================
+  // STAGE 3: real pre-graduation sell
+  // ==========================================================================
+  console.log(`[3/8] Pre-graduation sell of all ${preGradTokens} tokens...`);
+  await runStep('preGradSellApprove', async () => ({ hash: await token.write.approve([routerAddress, preGradTokens]) }));
+
+  const sell1Before = (state.steps.preGradSell?.before as Record<string, string>) ?? {
+    ethBefore: (await publicClient.getBalance({ address: account })).toString(),
+    curveEthReserveBefore: ((await hook.read.curveStates([poolId]))[4] as bigint).toString(),
+    lossPoolBalanceBefore: (await lossPoolBalance()).toString(),
+  };
+  const sell1Record = await runStep(
+    'preGradSell',
+    async () => {
+      const deadline = BigInt(Math.floor(Date.now() / 1000) + 600);
+      return { hash: await router.write.sellToken([tokenAddress, preGradTokens, 0n, deadline]) };
+    },
+    { before: sell1Before }
+  );
+  {
+    const b = sell1Record.before as Record<string, string>;
+    const ethAfter = await publicClient.getBalance({ address: account });
+    const tokensAfter = await token.read.balanceOf([account]);
+    const curveEthReserveAfter = (await hook.read.curveStates([poolId]))[4] as bigint;
+    const lossPoolBalanceAfter = await lossPoolBalance();
+
+    const ethReceived = ethAfter - BigInt(b.ethBefore) + gasCost(sell1Record);
+    const curveDelta = BigInt(b.curveEthReserveBefore) - curveEthReserveAfter;
+    const expectedNet = curveDelta - curveDelta / 100n - curveDelta / 100n;
+    const lossPoolDelta = lossPoolBalanceAfter - BigInt(b.lossPoolBalanceBefore);
+
+    if (tokensAfter !== 0n) throw new Error(`Pre-grad sell: wallet still holds ${tokensAfter} tokens.`);
+    if (ethReceived !== expectedNet) throw new Error(`Pre-grad sell: wallet received ${ethReceived}, expected exactly ${expectedNet}.`);
+    if (lossPoolDelta !== curveDelta / 100n) throw new Error(`Pre-grad sell: LossRewardPool balance delta ${lossPoolDelta} != expected ${curveDelta / 100n}.`);
+    console.log('  Exact balance-delta assertions: PASS\n');
+  }
+
+  // ==========================================================================
+  // STAGE 4: drive a REAL graduation (cheap here)
+  // ==========================================================================
+  console.log('[4/8] Driving to a REAL graduation (test-scale target)...');
+  let overshootGrossEth: bigint;
+  let gradSnapshotBefore: Record<string, string>;
+  if (state.steps.graduatingBuy?.before) {
+    gradSnapshotBefore = state.steps.graduatingBuy.before as Record<string, string>;
+    overshootGrossEth = BigInt(state.steps.graduatingBuy.overshootGrossEth as string);
+  } else {
+    const graduationTarget = await hook.read.GRADUATION_ETH_TARGET();
+    const realEthReserveNow = (await hook.read.curveStates([poolId]))[4] as bigint;
+    const maxNetEth = graduationTarget - realEthReserveNow;
+    const maxGrossEth = 100n * (maxNetEth / 98n) + (maxNetEth % 98n);
+    overshootGrossEth = (maxGrossEth * 105n) / 100n;
+    const gasBuffer = parseEther('0.01');
+    const walletBalance = await publicClient.getBalance({ address: account });
+    console.log(`  realEthReserve now: ${formatEther(realEthReserveNow)} ETH`);
+    console.log(`  GRADUATION_ETH_TARGET: ${formatEther(graduationTarget)} ETH`);
+    console.log(`  Exact clamp target (gross): ${formatEther(maxGrossEth)} ETH`);
+    console.log(`  Sending (1.05x, to force the real clamp path): ${formatEther(overshootGrossEth)} ETH`);
+    if (walletBalance < overshootGrossEth + gasBuffer) {
+      throw new Error(`Wallet balance (${formatEther(walletBalance)} ETH) is insufficient for the graduating buy (${formatEther(overshootGrossEth)} ETH + ${formatEther(gasBuffer)} ETH gas buffer).`);
+    }
+    gradSnapshotBefore = {
+      ethBefore: walletBalance.toString(),
+      curveEthReserveBefore: realEthReserveNow.toString(),
+      lossPoolBalanceBefore: (await lossPoolBalance()).toString(),
+    };
+  }
+
+  const gradRecord = await runStep(
+    'graduatingBuy',
+    async () => {
+      const deadline = BigInt(Math.floor(Date.now() / 1000) + 600);
+      return { hash: await router.write.buyToken([tokenAddress, 0n, deadline], { value: overshootGrossEth }) };
+    },
+    { before: gradSnapshotBefore, overshootGrossEth: overshootGrossEth.toString() }
+  );
+  {
+    const b = gradRecord.before as Record<string, string>;
+    const ethAfter = await publicClient.getBalance({ address: account });
+    const curveEthReserveAfter = (await hook.read.curveStates([poolId]))[4] as bigint;
+    const graduated = (await hook.read.curveStates([poolId]))[3] as boolean;
+    const graduationTarget = await hook.read.GRADUATION_ETH_TARGET();
+    const lossPoolBalanceAfter = await lossPoolBalance();
+
+    const netOutflow = BigInt(b.ethBefore) - ethAfter - gasCost(gradRecord);
+    const curveDelta = curveEthReserveAfter - BigInt(b.curveEthReserveBefore);
+    const actualGrossEth = netOutflow;
+    const expectedCurveDelta = actualGrossEth - actualGrossEth / 100n - actualGrossEth / 100n;
+    const expectedFee = actualGrossEth / 100n;
+    const lossPoolDelta = lossPoolBalanceAfter - BigInt(b.lossPoolBalanceBefore);
+
+    if (!graduated) throw new Error('state.graduated is not true after the graduating buy.');
+    if (curveEthReserveAfter !== graduationTarget) throw new Error(`realEthReserve (${curveEthReserveAfter}) did not land exactly on GRADUATION_ETH_TARGET (${graduationTarget}).`);
+    if (curveDelta !== expectedCurveDelta) throw new Error(`Graduating buy: curve delta ${curveDelta} != expected ${expectedCurveDelta}.`);
+    if (lossPoolDelta !== expectedFee) throw new Error(`Graduating buy: LossRewardPool delta ${lossPoolDelta} != expected ${expectedFee}.`);
+    console.log(`  Real gross ETH processed: ${formatEther(actualGrossEth)} ETH`);
+    console.log('  state.graduated == true, realEthReserve == GRADUATION_ETH_TARGET exactly (confirmed)');
+
+    const gradLogs = await publicClient.getContractEvents({ address: hookAddress, abi: hookArtifact.abi, eventName: 'GraduationLiquidityDeployed', fromBlock: BigInt(gradRecord.blockNumber!), toBlock: BigInt(gradRecord.blockNumber!) });
+    if (gradLogs.length !== 1) throw new Error(`Expected exactly 1 GraduationLiquidityDeployed event, got ${gradLogs.length}.`);
+    const gradEvent = gradLogs[0].args as { bootstrapLiquidity: bigint; finalLiquidity: bigint; correctedSqrtPriceX96: bigint };
+    const slot0PostGrad = await publicClient.readContract({ address: STATE_VIEW, abi: STATE_VIEW_ABI, functionName: 'getSlot0', args: [poolId] });
+    const liquidityPostGrad = await publicClient.readContract({ address: STATE_VIEW, abi: STATE_VIEW_ABI, functionName: 'getLiquidity', args: [poolId] });
+    if (slot0PostGrad[0] !== gradEvent.correctedSqrtPriceX96) throw new Error('StateView post-grad price does not match the event.');
+    if (liquidityPostGrad !== gradEvent.bootstrapLiquidity + gradEvent.finalLiquidity) throw new Error('StateView post-grad liquidity does not match the event.');
+    console.log('  Independent StateView cross-check of post-graduation price/liquidity: MATCH\n');
+  }
+
+  // ==========================================================================
+  // STAGE 5: deploy GenericV4Bot
+  // ==========================================================================
+  console.log('[5/8] Deploying GenericV4Bot...');
+  const botArtifact = await artifacts.readArtifact('GenericV4Bot');
+  const botRecord = await runStep('botDeploy', async () => {
+    const nonce = await publicClient.getTransactionCount({ address: account, blockTag: 'pending' });
+    const address = getContractAddress({ from: account, nonce: BigInt(nonce) });
+    const hash = await wallet.deployContract({ abi: botArtifact.abi, bytecode: botArtifact.bytecode as `0x${string}`, args: [POOL_MANAGER], nonce });
+    return { hash, address };
+  });
+  const botAddress = getAddress(botRecord.address as string);
+  const bot = await viem.getContractAt('GenericV4Bot', botAddress);
+  console.log(`  GenericV4Bot: ${botAddress}\n`);
+
+  // ==========================================================================
+  // STAGE 6: real POST-graduation buy
+  // ==========================================================================
+  console.log(`[6/8] Post-graduation buy of ${formatEther(BUY_AMOUNT_WEI)} ETH via GenericV4Bot...`);
+  const buy2Before = (state.steps.postGradBuy?.before as Record<string, string>) ?? {
+    ethBefore: (await publicClient.getBalance({ address: account })).toString(),
+    tokensBefore: (await token.read.balanceOf([account])).toString(),
+    lossPoolBalanceBefore: (await lossPoolBalance()).toString(),
+    creatorBalanceBefore: ((await hook.read.creatorBalances([account])) as bigint).toString(),
+  };
+  let predictedBuy2Out: bigint | undefined = state.steps.postGradBuy?.predictedOut !== undefined ? BigInt(state.steps.postGradBuy.predictedOut as string) : undefined;
+  if (predictedBuy2Out === undefined) {
+    const sim = await publicClient.simulateContract({ address: botAddress, abi: botArtifact.abi, functionName: 'swap', args: [poolKey, true, BUY_AMOUNT_WEI, 0n], account, value: BUY_AMOUNT_WEI });
+    predictedBuy2Out = sim.result as bigint;
+  }
+  const buy2Record = await runStep(
+    'postGradBuy',
+    async () => ({ hash: await bot.write.swap([poolKey, true, BUY_AMOUNT_WEI, 0n], { value: BUY_AMOUNT_WEI }) }),
+    { before: buy2Before, predictedOut: predictedBuy2Out.toString() }
+  );
+  {
+    const b = buy2Record.before as Record<string, string>;
+    const predicted = BigInt(buy2Record.predictedOut as string);
+    const ethAfter = await publicClient.getBalance({ address: account });
+    const tokensAfter = await token.read.balanceOf([account]);
+    const lossPoolBalanceAfter = await lossPoolBalance();
+    const creatorBalanceAfter = (await hook.read.creatorBalances([account])) as bigint;
+
+    const ethSpent = BigInt(b.ethBefore) - ethAfter - gasCost(buy2Record);
+    const tokensReceived = tokensAfter - BigInt(b.tokensBefore);
+
+    const feeLogs = await publicClient.getContractEvents({ address: hookAddress, abi: hookArtifact.abi, eventName: 'GraduatedFeeCollected', fromBlock: BigInt(buy2Record.blockNumber!), toBlock: BigInt(buy2Record.blockNumber!) });
+    if (feeLogs.length !== 1) throw new Error(`Expected exactly 1 GraduatedFeeCollected event on post-grad buy, got ${feeLogs.length}.`);
+    const feeEvent = feeLogs[0].args as { zeroForOne: boolean; creatorFee: bigint; lossPoolFee: bigint };
+    if (feeEvent.zeroForOne !== true) throw new Error('Post-grad buy GraduatedFeeCollected.zeroForOne should be true.');
+
+    if (ethSpent !== BUY_AMOUNT_WEI) throw new Error(`Post-grad buy: wallet spent ${ethSpent}, expected exactly ${BUY_AMOUNT_WEI}.`);
+    if (tokensReceived !== predicted) throw new Error(`Post-grad buy: tokens received ${tokensReceived} != simulated prediction ${predicted}.`);
+    if (lossPoolBalanceAfter - BigInt(b.lossPoolBalanceBefore) !== feeEvent.lossPoolFee) throw new Error('Post-grad buy: LossRewardPool delta != event.lossPoolFee.');
+    if (creatorBalanceAfter - BigInt(b.creatorBalanceBefore) !== feeEvent.creatorFee) throw new Error('Post-grad buy: creatorBalances delta != event.creatorFee.');
+    console.log(`  Tokens received: ${tokensReceived} (== simulated prediction, exact)`);
+    console.log(`  GraduatedFeeCollected(zeroForOne=true): creatorFee=${feeEvent.creatorFee}, lossPoolFee=${feeEvent.lossPoolFee}`);
+    console.log('  Exact balance-delta assertions: PASS\n');
+
+    if (buy2Record.tokensReceived === undefined) {
+      buy2Record.tokensReceived = tokensReceived.toString();
+      state.steps.postGradBuy = buy2Record;
+      persistState(state);
+    }
+  }
+  const postGradTokens = BigInt(buy2Record.tokensReceived as string);
+
+  // ==========================================================================
+  // STAGE 7: real POST-graduation sell — the never-before-mainnet-tested path
+  // ==========================================================================
+  console.log(`[7/8] Post-graduation sell of ${postGradTokens} tokens via GenericV4Bot (afterSwap fee path)...`);
+  await runStep('postGradSellApprove', async () => ({ hash: await token.write.approve([botAddress, postGradTokens]) }));
+
+  const sell2Before = (state.steps.postGradSell?.before as Record<string, string>) ?? {
+    ethBefore: (await publicClient.getBalance({ address: account })).toString(),
+    lossPoolBalanceBefore: (await lossPoolBalance()).toString(),
+    creatorBalanceBefore: ((await hook.read.creatorBalances([account])) as bigint).toString(),
+  };
+  let predictedSell2Out: bigint | undefined = state.steps.postGradSell?.predictedOut !== undefined ? BigInt(state.steps.postGradSell.predictedOut as string) : undefined;
+  if (predictedSell2Out === undefined) {
+    const sim = await publicClient.simulateContract({ address: botAddress, abi: botArtifact.abi, functionName: 'swap', args: [poolKey, false, postGradTokens, 0n], account });
+    predictedSell2Out = sim.result as bigint;
+  }
+  const sell2Record = await runStep(
+    'postGradSell',
+    async () => ({ hash: await bot.write.swap([poolKey, false, postGradTokens, 0n]) }),
+    { before: sell2Before, predictedOut: predictedSell2Out.toString() }
+  );
+  {
+    const b = sell2Record.before as Record<string, string>;
+    const predicted = BigInt(sell2Record.predictedOut as string);
+    const ethAfter = await publicClient.getBalance({ address: account });
+    const tokensAfter = await token.read.balanceOf([account]);
+    const lossPoolBalanceAfter = await lossPoolBalance();
+    const creatorBalanceAfter = (await hook.read.creatorBalances([account])) as bigint;
+
+    const ethReceived = ethAfter - BigInt(b.ethBefore) + gasCost(sell2Record);
+
+    const feeLogs = await publicClient.getContractEvents({ address: hookAddress, abi: hookArtifact.abi, eventName: 'GraduatedFeeCollected', fromBlock: BigInt(sell2Record.blockNumber!), toBlock: BigInt(sell2Record.blockNumber!) });
+    if (feeLogs.length !== 1) throw new Error(`Expected exactly 1 GraduatedFeeCollected event on post-grad sell, got ${feeLogs.length}.`);
+    const feeEvent = feeLogs[0].args as { zeroForOne: boolean; creatorFee: bigint; lossPoolFee: bigint };
+    if (feeEvent.zeroForOne !== false) throw new Error('Post-grad sell GraduatedFeeCollected.zeroForOne should be false — this is THE never-before-tested code path.');
+
+    if (tokensAfter !== 0n) throw new Error(`Post-grad sell: wallet still holds ${tokensAfter} tokens.`);
+    if (ethReceived !== predicted) throw new Error(`Post-grad sell: ETH received ${ethReceived} != simulated prediction ${predicted}.`);
+    if (lossPoolBalanceAfter - BigInt(b.lossPoolBalanceBefore) !== feeEvent.lossPoolFee) throw new Error('Post-grad sell: LossRewardPool delta != event.lossPoolFee.');
+    if (creatorBalanceAfter - BigInt(b.creatorBalanceBefore) !== feeEvent.creatorFee) throw new Error('Post-grad sell: creatorBalances delta != event.creatorFee.');
+    console.log(`  ETH received: ${formatEther(ethReceived)} ETH (== simulated prediction, exact)`);
+    console.log(`  GraduatedFeeCollected(zeroForOne=false): creatorFee=${feeEvent.creatorFee}, lossPoolFee=${feeEvent.lossPoolFee}`);
+    console.log('  *** afterSwap sell-side fee mechanism confirmed working on real mainnet (test-scale, throwaway pool) ***');
+    console.log('  Exact balance-delta assertions: PASS\n');
+  }
+
+  // ==========================================================================
+  // STAGE 8: claim
+  // ==========================================================================
+  console.log('[8/8] Claiming accrued creator fees (pre- + post-graduation, one ledger)...');
+  const claimBefore = (state.steps.claim?.before as Record<string, string>) ?? {
+    ethBefore: (await publicClient.getBalance({ address: account })).toString(),
+    accruedBefore: ((await hook.read.creatorBalances([account])) as bigint).toString(),
+  };
+  const accruedBeforeClaim = BigInt(claimBefore.accruedBefore);
+  console.log(`  creatorBalances(${account}) before claim: ${formatEther(accruedBeforeClaim)} ETH`);
+  if (!state.steps.claim && accruedBeforeClaim <= 0n) throw new Error('Expected a non-zero accrued creator balance, got 0.');
+  const claimRecord = await runStep('claim', async () => ({ hash: await hook.write.claimCreatorFees() }), { before: claimBefore });
+  {
+    const b = claimRecord.before as Record<string, string>;
+    const ethAfter = await publicClient.getBalance({ address: account });
+    const accruedAfter = (await hook.read.creatorBalances([account])) as bigint;
+    const netClaimed = ethAfter - BigInt(b.ethBefore) + gasCost(claimRecord);
+
+    if (accruedAfter !== 0n) throw new Error(`creatorBalances() is ${accruedAfter} after claim, expected exactly 0.`);
+    if (netClaimed !== accruedBeforeClaim) throw new Error(`Claimed ETH (net of gas) ${netClaimed} != pre-claim reading ${accruedBeforeClaim}.`);
+    console.log(`  Claimed exactly ${formatEther(netClaimed)} ETH (net of gas). Exact balance-delta assertion: PASS\n`);
+  }
+
+  console.log('============================================================');
+  console.log('[VERIFY V4 HOOK — PRODUCTION LOGIC, TEST SCALE] COMPLETE');
+  console.log('============================================================');
+  console.log('Every step confirmed on-chain with exact balance deltas, including the post-graduation');
+  console.log('beforeSwap AND afterSwap fee mechanisms, at test scale, against a throwaway LossRewardPool.');
+  console.log(JSON.stringify({
+    hook: hookAddress,
+    factory: factoryAddress,
+    router: routerAddress,
+    lossRewardPool: lossRewardPoolAddress,
+    testToken: tokenAddress,
+    poolId,
+    genericV4Bot: botAddress,
+    verifiedAt: new Date().toISOString(),
+    result: 'ALL EXACT BALANCE-DELTA ASSERTIONS PASSED, INCLUDING POST-GRADUATION FEE MECHANISM (TEST SCALE)',
+  }, null, 2));
+}
+
+main().catch((err) => {
+  console.error('\n[VERIFY ERROR]', err instanceof Error ? err.message : err);
+  console.error(`Progress so far is saved in ${STATE_PATH}. Re-running the exact same command resumes, not resends.`);
+  process.exitCode = 1;
+});

--- a/scripts/verify-v4-hook-production-mainnet.ts
+++ b/scripts/verify-v4-hook-production-mainnet.ts
@@ -1,0 +1,733 @@
+/**
+ * End-to-end REAL-money verification of the production IncentifiV4Hook +
+ * IncentifiV4Factory + IncentifiV4Router deployment on Robinhood Chain MAINNET,
+ * specifically exercising the ONE code path that has never touched real mainnet
+ * before: the post-graduation fee mechanism (afterSwap sell-side skim, and the
+ * beforeSwap graduated-branch buy-side skim).
+ *
+ * ============================================================================
+ * THE REAL COST — read before running:
+ * ============================================================================
+ * GRADUATION_ETH_TARGET (5.853863234375 ETH, net) is a hardcoded constant in the
+ * PRODUCTION hook — there is no cheaper parameter to reach it with, unlike the
+ * testnet hook. Reaching it requires ~5.97 ETH gross across the buys in this
+ * script (~$14,660 at ~$2,454/ETH, the price at the time this script was written
+ * — check a live price before running, it will have moved). Of that:
+ *   - ~5.854 ETH (~$14,368) becomes PERMANENTLY LOCKED AMM liquidity — by design,
+ *     non-refundable, not recoverable by anyone, ever (same as _graduate()'s own
+ *     doc comment describes).
+ *   - The remaining ~0.12 ETH splits into a creator fee (recoverable via
+ *     claimCreatorFees(), this script claims it at the end) and a real deposit
+ *     into the REAL production LossRewardPool (not recoverable by you — a
+ *     genuine deposit into the actual protocol pool).
+ * Plus real gas for every step, including the graduation transaction itself
+ * (2 liquidity mints + 1 corrective swap — meaningfully more gas than an
+ * ordinary trade).
+ *
+ * This is why GRADUATION_COST_CONFIRM below exists as its own explicit,
+ * separately-worded flag, distinct from DEPLOY_CONFIRM/V4_PRODUCTION_CONFIRM.
+ * ============================================================================
+ *
+ * Steps:
+ *   1. Launch a real, tiny, single-purpose test token through the production
+ *      IncentifiV4Factory. Verifies pool initialization independently via
+ *      StateView (a separate, real, already-deployed Uniswap contract).
+ *   2. Real pre-graduation BUY (0.005 ETH) through IncentifiV4Router.
+ *   3. Real pre-graduation SELL of everything just bought, through the router.
+ *   4. Drives a REAL graduation: one buy sized (with a modest overshoot, to
+ *      genuinely exercise the router's clamp+refund path) to cross
+ *      GRADUATION_ETH_TARGET. Verifies graduation state, the
+ *      GraduationLiquidityDeployed event, and independently cross-checks the
+ *      resulting pool price/liquidity via StateView.
+ *   5. Deploys GenericV4Bot — a minimal, Incentifi-agnostic PoolManager caller
+ *      (contracts/v4/test-helpers/GenericV4Bot.sol). IncentifiV4Router.buyToken()
+ *      /sellToken() both revert once a pool is graduated (PoolGraduated()) — it
+ *      is deliberately pre-graduation-only. Post-graduation trading, and the
+ *      hook's post-graduation fee mechanism specifically, can only be exercised
+ *      via a raw PoolManager caller like this one (or a real generic V4 router).
+ *   6. Real POST-graduation BUY via GenericV4Bot — exercises the hook's
+ *      beforeSwap graduated-branch fee skim (buy side).
+ *   7. Real POST-graduation SELL via GenericV4Bot — exercises the hook's
+ *      afterSwap fee mechanism (sell side) — THE specific code path that exists
+ *      only in the production hook and has never run against a real PoolManager
+ *      before this.
+ *   8. claimCreatorFees() — claims everything accrued across steps 2, 3, 4, 6, 7
+ *      in one call, proving pre- and post-graduation credits land in the same
+ *      pull-payment ledger.
+ *
+ * Every step asserts EXACT on-chain balance deltas (net of that step's own gas)
+ * against what the contracts themselves report moving — wallet ETH/token
+ * balances, the hook's own curveStates, and the REAL production LossRewardPool's
+ * own ETH balance and totalDeposited(token) mapping (a real, pre-existing,
+ * unmodified contract this script does not control). Where the exact AMM output
+ * of a post-graduation trade isn't independently predictable off-chain without
+ * reimplementing Uniswap's full concentrated-liquidity math, this script uses
+ * publicClient.simulateContract() immediately before sending as the independent
+ * oracle, then asserts the REAL observed balance delta matches that prediction
+ * exactly — not just "the transaction didn't revert".
+ *
+ * SAFETY GATES — ALL required:
+ *   - DEPLOYER_PRIVATE_KEY (or PRIVATE_KEY) — the SAME funded key used to deploy
+ *   - DEPLOY_CONFIRM=I_UNDERSTAND_THIS_IS_MAINNET
+ *   - V4_PRODUCTION_CONFIRM=I_ACKNOWLEDGE_V4_HOOK_IS_UNTESTED_ON_REAL_POOLMANAGER
+ *   - GRADUATION_COST_CONFIRM=I_ACCEPT_PERMANENTLY_LOCKING_ABOUT_5_9_ETH_IN_AMM_LIQUIDITY
+ *   - The hook/factory/router addresses, via V4_HOOK_ADDRESS / V4_FACTORY_ADDRESS /
+ *     V4_ROUTER_ADDRESS env vars, or scripts/.v4-hook-deployment-result.json
+ *     (written by deploy-v4-hook-production-mainnet.ts) if unset.
+ *
+ * Usage:
+ *   DEPLOYER_PRIVATE_KEY=0x... \
+ *   DEPLOY_CONFIRM=I_UNDERSTAND_THIS_IS_MAINNET \
+ *   V4_PRODUCTION_CONFIRM=I_ACKNOWLEDGE_V4_HOOK_IS_UNTESTED_ON_REAL_POOLMANAGER \
+ *   GRADUATION_COST_CONFIRM=I_ACCEPT_PERMANENTLY_LOCKING_ABOUT_5_9_ETH_IN_AMM_LIQUIDITY \
+ *     npx hardhat run scripts/verify-v4-hook-production-mainnet.ts --network robinhoodMainnet
+ *
+ * CRASH / RPC-HICCUP SAFETY (automatic — no flag needed): identical mechanism to
+ * verify-v3-fix-mainnet.ts and deploy-v4-hook-production-mainnet.ts. Every step's
+ * tx hash (and any pre-send snapshot its later exact-delta assertion depends on)
+ * is written to scripts/.v4-verify-state.json BEFORE this script ever waits on a
+ * receipt. Re-running the exact same command resumes from whatever's already on
+ * disk rather than resending anything — this matters enormously more here than in
+ * the deploy script, given the graduating buy alone moves ~6 real ETH.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { network, artifacts } from 'hardhat';
+import {
+  keccak256,
+  encodeAbiParameters,
+  parseAbiParameters,
+  parseAbi,
+  getAddress,
+  getContractAddress,
+  formatEther,
+  parseEther,
+} from 'viem';
+
+const CHAIN_ID = 4663;
+const POOL_MANAGER = getAddress('0x8366a39cc670b4001a1121b8f6a443a643e40951');
+const STATE_VIEW = getAddress('0xf3334192d15450cdd385c8b70e03f9a6bd9e673b');
+const REAL_PRODUCTION_LOSS_REWARD_POOL = getAddress('0x697bda9db5a297a9cd9ed969bbf2549d0527dcdf');
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+const TOTAL_SUPPLY = 1_000_000_000n * 10n ** 18n;
+const BUY_AMOUNT_WEI = parseEther('0.005');
+
+const STATE_VIEW_ABI = parseAbi([
+  'function getSlot0(bytes32 poolId) view returns (uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)',
+  'function getLiquidity(bytes32 poolId) view returns (uint128 liquidity)',
+]);
+
+const RESULT_PATH = path.resolve('scripts', '.v4-hook-deployment-result.json');
+const STATE_PATH = path.resolve('scripts', '.v4-verify-state.json');
+const RECEIPT_RETRY_ATTEMPTS = Number(process.env.RECEIPT_RETRY_ATTEMPTS || 6);
+const RECEIPT_RETRY_BASE_DELAY_MS = Number(process.env.RECEIPT_RETRY_DELAY_MS || 5000);
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function resolveAddresses(): { hook: `0x${string}`; factory: `0x${string}`; router: `0x${string}` } {
+  const envHook = process.env.V4_HOOK_ADDRESS;
+  const envFactory = process.env.V4_FACTORY_ADDRESS;
+  const envRouter = process.env.V4_ROUTER_ADDRESS;
+  if (envHook && envFactory && envRouter) {
+    return { hook: getAddress(envHook), factory: getAddress(envFactory), router: getAddress(envRouter) };
+  }
+  if (!fs.existsSync(RESULT_PATH)) {
+    throw new Error(
+      `Neither V4_HOOK_ADDRESS/V4_FACTORY_ADDRESS/V4_ROUTER_ADDRESS env vars nor ${RESULT_PATH} were found.\n` +
+      `Run deploy-v4-hook-production-mainnet.ts first, or set all three env vars explicitly.`
+    );
+  }
+  const deployResult = JSON.parse(fs.readFileSync(RESULT_PATH, 'utf8'));
+  return {
+    hook: getAddress(deployResult.hook.address),
+    factory: getAddress(deployResult.factory.address),
+    router: getAddress(deployResult.router.address),
+  };
+}
+
+function requireConfirmation() {
+  if (process.env.DEPLOY_CONFIRM !== 'I_UNDERSTAND_THIS_IS_MAINNET') {
+    throw new Error('\nSet DEPLOY_CONFIRM=I_UNDERSTAND_THIS_IS_MAINNET to proceed.\n');
+  }
+  if (process.env.V4_PRODUCTION_CONFIRM !== 'I_ACKNOWLEDGE_V4_HOOK_IS_UNTESTED_ON_REAL_POOLMANAGER') {
+    throw new Error('\nSet V4_PRODUCTION_CONFIRM=I_ACKNOWLEDGE_V4_HOOK_IS_UNTESTED_ON_REAL_POOLMANAGER to proceed.\n');
+  }
+  if (process.env.GRADUATION_COST_CONFIRM !== 'I_ACCEPT_PERMANENTLY_LOCKING_ABOUT_5_9_ETH_IN_AMM_LIQUIDITY') {
+    throw new Error(
+      '\nThis script drives a REAL graduation, permanently locking ~5.85 ETH (~$14,000+ at recent prices) as ' +
+      'AMM liquidity — non-refundable, by design, forever. See this file\'s header comment for the full breakdown.\n' +
+      'Set GRADUATION_COST_CONFIRM=I_ACCEPT_PERMANENTLY_LOCKING_ABOUT_5_9_ETH_IN_AMM_LIQUIDITY to proceed.\n'
+    );
+  }
+  const key = (process.env.DEPLOYER_PRIVATE_KEY || process.env.PRIVATE_KEY || '').trim();
+  if (!key) {
+    throw new Error('DEPLOYER_PRIVATE_KEY (or PRIVATE_KEY) env var is required.');
+  }
+}
+
+type StepRecord = {
+  hash?: `0x${string}`;
+  confirmed?: boolean;
+  blockNumber?: string;
+  gasUsed?: string;
+  effectiveGasPrice?: string;
+  [key: string]: unknown;
+};
+type VerifyState = { hook: `0x${string}`; factory: `0x${string}`; router: `0x${string}`; wallet: `0x${string}`; steps: Record<string, StepRecord> };
+
+function loadState(hook: `0x${string}`, factory: `0x${string}`, router: `0x${string}`, walletRaw: `0x${string}`): VerifyState {
+  const wallet = getAddress(walletRaw);
+  if (!fs.existsSync(STATE_PATH)) {
+    return { hook, factory, router, wallet, steps: {} };
+  }
+  const raw = JSON.parse(fs.readFileSync(STATE_PATH, 'utf8'));
+  const sameRun =
+    raw.hook && getAddress(raw.hook) === hook &&
+    raw.factory && getAddress(raw.factory) === factory &&
+    raw.router && getAddress(raw.router) === router &&
+    raw.wallet && getAddress(raw.wallet) === wallet;
+  if (!sameRun) {
+    throw new Error(
+      `${STATE_PATH} exists but is for a different hook/factory/router/wallet than this run.\n` +
+      `  state file: hook=${raw.hook}, factory=${raw.factory}, router=${raw.router}, wallet=${raw.wallet}\n` +
+      `  this run:   hook=${hook}, factory=${factory}, router=${router}, wallet=${wallet}\n` +
+      `Move or delete ${STATE_PATH} by hand if that earlier run is done with. Refusing to guess, given a ` +
+      `~6 ETH graduating buy may be involved.`
+    );
+  }
+  const steps = raw.steps || {};
+  if (Object.keys(steps).length > 0) {
+    console.log(`[STATE] Found ${STATE_PATH} — resuming. Steps already recorded: ${Object.keys(steps).join(', ')}\n`);
+  }
+  return { hook, factory, router, wallet, steps };
+}
+
+function persistState(state: VerifyState) {
+  fs.mkdirSync(path.dirname(STATE_PATH), { recursive: true });
+  fs.writeFileSync(STATE_PATH, JSON.stringify({ ...state, updatedAt: new Date().toISOString() }, null, 2));
+}
+
+async function main() {
+  requireConfirmation();
+  const { hook: hookAddress, factory: factoryAddress, router: routerAddress } = resolveAddresses();
+
+  const { viem } = await network.create('robinhoodMainnet');
+  const publicClient = await viem.getPublicClient();
+
+  const chainId = await publicClient.getChainId();
+  if (chainId !== CHAIN_ID) throw new Error(`Chain ID mismatch! Expected ${CHAIN_ID}, got ${chainId}.`);
+
+  const [wallet] = await viem.getWalletClients();
+  const account = getAddress(wallet.account.address);
+
+  console.log('\n============================================================');
+  console.log('[VERIFY V4 HOOK — PRODUCTION] Robinhood Chain MAINNET (Chain ID 4663)');
+  console.log('============================================================');
+  console.log(`Wallet:  ${account}`);
+  console.log(`Hook:    ${hookAddress}`);
+  console.log(`Factory: ${factoryAddress}`);
+  console.log(`Router:  ${routerAddress}`);
+  console.log('============================================================\n');
+
+  const state = loadState(hookAddress, factoryAddress, routerAddress, account);
+
+  async function waitForReceiptWithRetry(hash: `0x${string}`, label: string) {
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= RECEIPT_RETRY_ATTEMPTS; attempt++) {
+      try {
+        return await publicClient.waitForTransactionReceipt({ hash, confirmations: 1, timeout: 90_000 });
+      } catch (err) {
+        lastErr = err;
+        const delay = RECEIPT_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+        console.warn(
+          `  [${label}] receipt wait attempt ${attempt}/${RECEIPT_RETRY_ATTEMPTS} failed ` +
+          `(${err instanceof Error ? err.message : String(err)})` +
+          (attempt < RECEIPT_RETRY_ATTEMPTS ? `; retrying in ${Math.round(delay / 1000)}s...` : '')
+        );
+        if (attempt < RECEIPT_RETRY_ATTEMPTS) await sleep(delay);
+      }
+    }
+    throw new Error(
+      `[${label}] Could not confirm receipt for tx ${hash} after ${RECEIPT_RETRY_ATTEMPTS} attempts. Check a block ` +
+      `explorer before re-running — its hash is already in ${STATE_PATH}, so re-running resumes rather than resends.\n` +
+      `Last error: ${lastErr instanceof Error ? lastErr.message : String(lastErr)}`
+    );
+  }
+
+  async function runStep(
+    name: string,
+    sendFn: () => Promise<{ hash: `0x${string}`; [key: string]: unknown }>,
+    precomputedExtra: Record<string, unknown> = {}
+  ): Promise<StepRecord> {
+    let record = state.steps[name];
+    if (!record) {
+      console.log(`[${name}] sending transaction...`);
+      const sent = await sendFn();
+      record = { confirmed: false, ...precomputedExtra, ...sent };
+      state.steps[name] = record;
+      persistState(state);
+      console.log(`  Tx sent: ${record.hash}`);
+    } else {
+      console.log(`[${name}] resuming — tx already on record: ${record.hash} (confirmed: ${Boolean(record.confirmed)})`);
+    }
+    if (!record.confirmed) {
+      const receipt = await waitForReceiptWithRetry(record.hash as `0x${string}`, name);
+      if (receipt.status !== 'success') throw new Error(`[${name}] transaction reverted (status: ${receipt.status}). Tx: ${record.hash}`);
+      record.confirmed = true;
+      record.blockNumber = receipt.blockNumber.toString();
+      record.gasUsed = receipt.gasUsed.toString();
+      record.effectiveGasPrice = receipt.effectiveGasPrice.toString();
+      state.steps[name] = record;
+      persistState(state);
+      console.log(`  Confirmed in block #${receipt.blockNumber} (gas used ${receipt.gasUsed})\n`);
+    }
+    return record;
+  }
+
+  function gasCost(record: StepRecord): bigint {
+    return BigInt(record.gasUsed!) * BigInt(record.effectiveGasPrice!);
+  }
+
+  // Pre-flight: confirm the target contracts are real and correctly wired.
+  const hookArtifact = await artifacts.readArtifact('IncentifiV4Hook');
+  const hook = await viem.getContractAt('IncentifiV4Hook', hookAddress);
+  const factory = await viem.getContractAt('IncentifiV4Factory', factoryAddress);
+  const router = await viem.getContractAt('IncentifiV4Router', routerAddress);
+  for (const [label, addr] of [['Hook', hookAddress], ['Factory', factoryAddress], ['Router', routerAddress]] as const) {
+    const code = await publicClient.getCode({ address: addr });
+    if (!code || code === '0x') throw new Error(`${label} ${addr} has empty code.`);
+  }
+  if (getAddress(await factory.read.hook()) !== hookAddress) throw new Error('factory.hook() does not match the given Hook.');
+  if (getAddress(await router.read.hook()) !== hookAddress) throw new Error('router.hook() does not match the given Hook.');
+  if (getAddress(await router.read.factory()) !== factoryAddress) throw new Error('router.factory() does not match the given Factory.');
+  console.log('[PRE-FLIGHT] Hook/Factory/Router all have live code and are correctly cross-wired. OK.\n');
+
+  // ==========================================================================
+  // STAGE 1: launch a real test token
+  // ==========================================================================
+  console.log('[1/8] Test token launch...');
+  const tokenDeployRecord = await runStep('tokenDeploy', async () => {
+    const launchTokenArtifact = await artifacts.readArtifact('IncentifiLaunchToken');
+    const nonce = await publicClient.getTransactionCount({ address: account, blockTag: 'pending' });
+    const address = getContractAddress({ from: account, nonce: BigInt(nonce) });
+    const tokenName = `Incentifi V4 Verify ${Date.now()}`;
+    const hash = await wallet.deployContract({
+      abi: launchTokenArtifact.abi,
+      bytecode: launchTokenArtifact.bytecode as `0x${string}`,
+      args: [tokenName, 'IFV4', TOTAL_SUPPLY],
+      nonce,
+    });
+    return { hash, address, tokenName };
+  });
+  const tokenAddress = getAddress(tokenDeployRecord.address as string);
+  const launchTokenArtifact = await artifacts.readArtifact('IncentifiLaunchToken');
+  const token = await viem.getContractAt('IncentifiLaunchToken', tokenAddress);
+  console.log(`  Token: ${tokenAddress} ("${tokenDeployRecord.tokenName}")`);
+
+  await runStep('approveFactory', async () => ({ hash: await token.write.approve([factoryAddress, TOTAL_SUPPLY]) }));
+  await runStep('launchToken', async () => ({ hash: await factory.write.launchToken([tokenAddress]) }));
+
+  const poolKey = await factory.read.getPoolKey([tokenAddress]);
+  const poolId = keccak256(
+    encodeAbiParameters(
+      parseAbiParameters('address, address, uint24, int24, address'),
+      [poolKey.currency0, poolKey.currency1, poolKey.fee, poolKey.tickSpacing, poolKey.hooks]
+    )
+  );
+  const curveAfterLaunch = await hook.read.curveStates([poolId]);
+  // curveStates tuple order: token, creator, initialized, graduated, realEthReserve, realTokenReserve
+  if (getAddress(curveAfterLaunch[0]) !== tokenAddress) throw new Error('curveStates.token mismatch after launch.');
+  if (getAddress(curveAfterLaunch[1]) !== account) throw new Error('curveStates.creator mismatch after launch.');
+  if (curveAfterLaunch[2] !== true) throw new Error('curveStates.initialized is not true after launch.');
+  if (curveAfterLaunch[5] !== TOTAL_SUPPLY) throw new Error('curveStates.realTokenReserve != TOTAL_SUPPLY after launch.');
+
+  const slot0Launch = await publicClient.readContract({ address: STATE_VIEW, abi: STATE_VIEW_ABI, functionName: 'getSlot0', args: [poolId] });
+  const expectedLaunchPrice = await hook.read.launchSqrtPriceX96();
+  if (slot0Launch[0] !== expectedLaunchPrice) throw new Error('StateView launch price does not match hook.launchSqrtPriceX96().');
+  console.log(`  PoolId: ${poolId}`);
+  console.log('  curveStates + independent StateView launch-price cross-check: MATCH\n');
+
+  // ==========================================================================
+  // STAGE 2: real pre-graduation buy
+  // ==========================================================================
+  console.log(`[2/8] Pre-graduation buy of ${formatEther(BUY_AMOUNT_WEI)} ETH...`);
+  const buy1Before = (state.steps.preGradBuy?.before as Record<string, string>) ?? {
+    ethBefore: (await publicClient.getBalance({ address: account })).toString(),
+    tokensBefore: (await token.read.balanceOf([account])).toString(),
+    curveEthReserveBefore: ((await hook.read.curveStates([poolId]))[4] as bigint).toString(),
+    lossPoolBalanceBefore: (await publicClient.getBalance({ address: REAL_PRODUCTION_LOSS_REWARD_POOL })).toString(),
+    lossPoolDepositedBefore: (
+      await publicClient.readContract({
+        address: REAL_PRODUCTION_LOSS_REWARD_POOL,
+        abi: parseAbi(['function totalDeposited(address) view returns (uint256)']),
+        functionName: 'totalDeposited',
+        args: [tokenAddress],
+      })
+    ).toString(),
+  };
+  const buy1Record = await runStep(
+    'preGradBuy',
+    async () => {
+      const deadline = BigInt(Math.floor(Date.now() / 1000) + 600);
+      return { hash: await router.write.buyToken([tokenAddress, 0n, deadline], { value: BUY_AMOUNT_WEI }) };
+    },
+    { before: buy1Before }
+  );
+  {
+    const b = buy1Record.before as Record<string, string>;
+    const ethAfter = await publicClient.getBalance({ address: account });
+    const tokensAfter = await token.read.balanceOf([account]);
+    const curveEthReserveAfter = ((await hook.read.curveStates([poolId]))[4] as bigint);
+    const lossPoolBalanceAfter = await publicClient.getBalance({ address: REAL_PRODUCTION_LOSS_REWARD_POOL });
+    const lossPoolDepositedAfter = await publicClient.readContract({
+      address: REAL_PRODUCTION_LOSS_REWARD_POOL,
+      abi: parseAbi(['function totalDeposited(address) view returns (uint256)']),
+      functionName: 'totalDeposited',
+      args: [tokenAddress],
+    });
+
+    const ethSpent = BigInt(b.ethBefore) - ethAfter - gasCost(buy1Record);
+    const tokensReceived = tokensAfter - BigInt(b.tokensBefore);
+    const curveDelta = curveEthReserveAfter - BigInt(b.curveEthReserveBefore);
+    const lossPoolDelta = lossPoolBalanceAfter - BigInt(b.lossPoolBalanceBefore);
+    const lossPoolDepositedDelta = lossPoolDepositedAfter - BigInt(b.lossPoolDepositedBefore);
+    const expectedNetEth = BUY_AMOUNT_WEI - BUY_AMOUNT_WEI / 100n - BUY_AMOUNT_WEI / 100n;
+    const expectedFee = BUY_AMOUNT_WEI / 100n;
+
+    if (ethSpent !== BUY_AMOUNT_WEI) throw new Error(`Pre-grad buy: wallet spent ${ethSpent}, expected exactly ${BUY_AMOUNT_WEI}.`);
+    if (tokensReceived <= 0n) throw new Error('Pre-grad buy produced zero tokens.');
+    if (curveDelta !== expectedNetEth) throw new Error(`Pre-grad buy: curve realEthReserve delta ${curveDelta} != expected ${expectedNetEth}.`);
+    if (lossPoolDelta !== expectedFee) throw new Error(`Pre-grad buy: REAL LossRewardPool balance delta ${lossPoolDelta} != expected ${expectedFee}.`);
+    if (lossPoolDepositedDelta !== expectedFee) throw new Error(`Pre-grad buy: LossRewardPool.totalDeposited(token) delta ${lossPoolDepositedDelta} != expected ${expectedFee}.`);
+    console.log(`  Tokens received: ${tokensReceived}. Exact balance-delta assertions (wallet, curve, REAL LossRewardPool): PASS\n`);
+
+    if (buy1Record.tokensReceived === undefined) {
+      buy1Record.tokensReceived = tokensReceived.toString();
+      state.steps.preGradBuy = buy1Record;
+      persistState(state);
+    }
+  }
+  const preGradTokens = BigInt(buy1Record.tokensReceived as string);
+
+  // ==========================================================================
+  // STAGE 3: real pre-graduation sell
+  // ==========================================================================
+  console.log(`[3/8] Pre-graduation sell of all ${preGradTokens} tokens...`);
+  await runStep('preGradSellApprove', async () => ({ hash: await token.write.approve([routerAddress, preGradTokens]) }));
+
+  const sell1Before = (state.steps.preGradSell?.before as Record<string, string>) ?? {
+    ethBefore: (await publicClient.getBalance({ address: account })).toString(),
+    curveEthReserveBefore: ((await hook.read.curveStates([poolId]))[4] as bigint).toString(),
+    lossPoolBalanceBefore: (await publicClient.getBalance({ address: REAL_PRODUCTION_LOSS_REWARD_POOL })).toString(),
+  };
+  const sell1Record = await runStep(
+    'preGradSell',
+    async () => {
+      const deadline = BigInt(Math.floor(Date.now() / 1000) + 600);
+      return { hash: await router.write.sellToken([tokenAddress, preGradTokens, 0n, deadline]) };
+    },
+    { before: sell1Before }
+  );
+  {
+    const b = sell1Record.before as Record<string, string>;
+    const ethAfter = await publicClient.getBalance({ address: account });
+    const tokensAfter = await token.read.balanceOf([account]);
+    const curveEthReserveAfter = (await hook.read.curveStates([poolId]))[4] as bigint;
+    const lossPoolBalanceAfter = await publicClient.getBalance({ address: REAL_PRODUCTION_LOSS_REWARD_POOL });
+
+    const ethReceived = ethAfter - BigInt(b.ethBefore) + gasCost(sell1Record);
+    const curveDelta = BigInt(b.curveEthReserveBefore) - curveEthReserveAfter; // gross released
+    const expectedNet = curveDelta - curveDelta / 100n - curveDelta / 100n;
+    const lossPoolDelta = lossPoolBalanceAfter - BigInt(b.lossPoolBalanceBefore);
+
+    if (tokensAfter !== 0n) throw new Error(`Pre-grad sell: wallet still holds ${tokensAfter} tokens after selling all of them.`);
+    if (ethReceived !== expectedNet) throw new Error(`Pre-grad sell: wallet received ${ethReceived}, expected exactly ${expectedNet}.`);
+    if (lossPoolDelta !== curveDelta / 100n) throw new Error(`Pre-grad sell: LossRewardPool balance delta ${lossPoolDelta} != expected ${curveDelta / 100n}.`);
+    console.log('  Exact balance-delta assertions: PASS\n');
+  }
+
+  // ==========================================================================
+  // STAGE 4: drive a REAL graduation
+  // ==========================================================================
+  console.log('[4/8] Driving to a REAL graduation...');
+  // Only compute (and choose an msg.value) when actually about to send for the
+  // first time — resuming reuses whatever amount was already chosen and
+  // persisted, never a freshly recomputed one, since live state has moved on.
+  let overshootGrossEth: bigint;
+  let gradSnapshotBefore: Record<string, string>;
+  if (state.steps.graduatingBuy?.before) {
+    gradSnapshotBefore = state.steps.graduatingBuy.before as Record<string, string>;
+    overshootGrossEth = BigInt(state.steps.graduatingBuy.overshootGrossEth as string);
+  } else {
+    const graduationTarget = await hook.read.GRADUATION_ETH_TARGET();
+    const realEthReserveNow = (await hook.read.curveStates([poolId]))[4] as bigint;
+    const maxNetEth = graduationTarget - realEthReserveNow;
+    const maxGrossEth = 100n * (maxNetEth / 98n) + (maxNetEth % 98n);
+    overshootGrossEth = (maxGrossEth * 105n) / 100n; // modest 1.05x to genuinely exercise the clamp+refund path
+    const gasBuffer = parseEther('0.02'); // generous pad for 2 mints + 1 corrective swap
+    const walletBalance = await publicClient.getBalance({ address: account });
+    console.log(`  realEthReserve now: ${formatEther(realEthReserveNow)} ETH`);
+    console.log(`  GRADUATION_ETH_TARGET: ${formatEther(graduationTarget)} ETH`);
+    console.log(`  Exact clamp target (gross): ${formatEther(maxGrossEth)} ETH`);
+    console.log(`  Sending (1.05x, to force the real clamp path): ${formatEther(overshootGrossEth)} ETH`);
+    if (walletBalance < overshootGrossEth + gasBuffer) {
+      throw new Error(
+        `Wallet balance (${formatEther(walletBalance)} ETH) is insufficient for the graduating buy: needs ` +
+        `${formatEther(overshootGrossEth)} ETH (msg.value, ~5% refunded in this same tx) plus a ${formatEther(gasBuffer)} ETH ` +
+        `gas buffer. Fund the wallet before re-running.`
+      );
+    }
+    gradSnapshotBefore = {
+      ethBefore: walletBalance.toString(),
+      curveEthReserveBefore: realEthReserveNow.toString(),
+      lossPoolBalanceBefore: (await publicClient.getBalance({ address: REAL_PRODUCTION_LOSS_REWARD_POOL })).toString(),
+    };
+  }
+
+  const gradRecord = await runStep(
+    'graduatingBuy',
+    async () => {
+      const deadline = BigInt(Math.floor(Date.now() / 1000) + 600);
+      return { hash: await router.write.buyToken([tokenAddress, 0n, deadline], { value: overshootGrossEth }) };
+    },
+    { before: gradSnapshotBefore, overshootGrossEth: overshootGrossEth.toString() }
+  );
+  {
+    const b = gradRecord.before as Record<string, string>;
+    const ethAfter = await publicClient.getBalance({ address: account });
+    const curveEthReserveAfter = (await hook.read.curveStates([poolId]))[4] as bigint;
+    const graduated = (await hook.read.curveStates([poolId]))[3] as boolean;
+    const graduationTarget = await hook.read.GRADUATION_ETH_TARGET();
+    const lossPoolBalanceAfter = await publicClient.getBalance({ address: REAL_PRODUCTION_LOSS_REWARD_POOL });
+
+    const netOutflow = BigInt(b.ethBefore) - ethAfter - gasCost(gradRecord);
+    const curveDelta = curveEthReserveAfter - BigInt(b.curveEthReserveBefore);
+    // Derive the ACTUAL grossEth the contract processed from the real netOutflow
+    // (== whatever the contract's own live clamp decided), rather than trusting
+    // the off-chain guess used only to size msg.value — robust to any live-state
+    // drift between reading realEthReserve and this transaction executing.
+    const actualGrossEth = netOutflow;
+    const expectedCurveDelta = actualGrossEth - actualGrossEth / 100n - actualGrossEth / 100n;
+    const expectedFee = actualGrossEth / 100n;
+    const lossPoolDelta = lossPoolBalanceAfter - BigInt(b.lossPoolBalanceBefore);
+
+    if (!graduated) throw new Error('state.graduated is not true after the graduating buy.');
+    if (curveEthReserveAfter !== graduationTarget) throw new Error(`realEthReserve (${curveEthReserveAfter}) did not land exactly on GRADUATION_ETH_TARGET (${graduationTarget}).`);
+    if (curveDelta !== expectedCurveDelta) throw new Error(`Graduating buy: curve delta ${curveDelta} != expected ${expectedCurveDelta} (derived from real netOutflow ${actualGrossEth}).`);
+    if (lossPoolDelta !== expectedFee) throw new Error(`Graduating buy: LossRewardPool delta ${lossPoolDelta} != expected ${expectedFee}.`);
+    console.log(`  Real gross ETH processed (derived from wallet outflow): ${formatEther(actualGrossEth)} ETH`);
+    console.log('  state.graduated == true, realEthReserve == GRADUATION_ETH_TARGET exactly (confirmed)');
+
+    const gradLogs = await publicClient.getContractEvents({
+      address: hookAddress,
+      abi: hookArtifact.abi,
+      eventName: 'GraduationLiquidityDeployed',
+      fromBlock: BigInt(gradRecord.blockNumber!),
+      toBlock: BigInt(gradRecord.blockNumber!),
+    });
+    if (gradLogs.length !== 1) throw new Error(`Expected exactly 1 GraduationLiquidityDeployed event, got ${gradLogs.length}.`);
+    const gradEvent = gradLogs[0].args as { bootstrapLiquidity: bigint; finalLiquidity: bigint; correctedSqrtPriceX96: bigint };
+    const slot0PostGrad = await publicClient.readContract({ address: STATE_VIEW, abi: STATE_VIEW_ABI, functionName: 'getSlot0', args: [poolId] });
+    const liquidityPostGrad = await publicClient.readContract({ address: STATE_VIEW, abi: STATE_VIEW_ABI, functionName: 'getLiquidity', args: [poolId] });
+    if (slot0PostGrad[0] !== gradEvent.correctedSqrtPriceX96) throw new Error('StateView post-grad price does not match the GraduationLiquidityDeployed event.');
+    if (liquidityPostGrad !== gradEvent.bootstrapLiquidity + gradEvent.finalLiquidity) throw new Error('StateView post-grad liquidity does not match the event.');
+    console.log('  Independent StateView cross-check of post-graduation price/liquidity: MATCH\n');
+  }
+
+  // ==========================================================================
+  // STAGE 5: deploy GenericV4Bot — the only way to reach post-graduation trading
+  // ==========================================================================
+  console.log('[5/8] Deploying GenericV4Bot (Incentifi-agnostic raw PoolManager caller)...');
+  const botArtifact = await artifacts.readArtifact('GenericV4Bot');
+  const botRecord = await runStep('botDeploy', async () => {
+    const nonce = await publicClient.getTransactionCount({ address: account, blockTag: 'pending' });
+    const address = getContractAddress({ from: account, nonce: BigInt(nonce) });
+    const hash = await wallet.deployContract({ abi: botArtifact.abi, bytecode: botArtifact.bytecode as `0x${string}`, args: [POOL_MANAGER], nonce });
+    return { hash, address };
+  });
+  const botAddress = getAddress(botRecord.address as string);
+  const bot = await viem.getContractAt('GenericV4Bot', botAddress);
+  console.log(`  GenericV4Bot: ${botAddress}\n`);
+
+  // ==========================================================================
+  // STAGE 6: real POST-graduation buy — exercises the beforeSwap graduated-branch skim
+  // ==========================================================================
+  console.log(`[6/8] Post-graduation buy of ${formatEther(BUY_AMOUNT_WEI)} ETH via GenericV4Bot...`);
+  const buy2Before = (state.steps.postGradBuy?.before as Record<string, string>) ?? {
+    ethBefore: (await publicClient.getBalance({ address: account })).toString(),
+    tokensBefore: (await token.read.balanceOf([account])).toString(),
+    lossPoolBalanceBefore: (await publicClient.getBalance({ address: REAL_PRODUCTION_LOSS_REWARD_POOL })).toString(),
+    creatorBalanceBefore: ((await hook.read.creatorBalances([account])) as bigint).toString(),
+  };
+  let predictedBuy2Out: bigint | undefined = state.steps.postGradBuy?.predictedOut !== undefined
+    ? BigInt(state.steps.postGradBuy.predictedOut as string)
+    : undefined;
+  if (predictedBuy2Out === undefined) {
+    const sim = await publicClient.simulateContract({
+      address: botAddress,
+      abi: botArtifact.abi,
+      functionName: 'swap',
+      args: [poolKey, true, BUY_AMOUNT_WEI, 0n],
+      account,
+      value: BUY_AMOUNT_WEI,
+    });
+    predictedBuy2Out = sim.result as bigint;
+  }
+  const buy2Record = await runStep(
+    'postGradBuy',
+    async () => ({ hash: await bot.write.swap([poolKey, true, BUY_AMOUNT_WEI, 0n], { value: BUY_AMOUNT_WEI }) }),
+    { before: buy2Before, predictedOut: predictedBuy2Out.toString() }
+  );
+  {
+    const b = buy2Record.before as Record<string, string>;
+    const predicted = BigInt(buy2Record.predictedOut as string);
+    const ethAfter = await publicClient.getBalance({ address: account });
+    const tokensAfter = await token.read.balanceOf([account]);
+    const lossPoolBalanceAfter = await publicClient.getBalance({ address: REAL_PRODUCTION_LOSS_REWARD_POOL });
+    const creatorBalanceAfter = (await hook.read.creatorBalances([account])) as bigint;
+
+    const ethSpent = BigInt(b.ethBefore) - ethAfter - gasCost(buy2Record);
+    const tokensReceived = tokensAfter - BigInt(b.tokensBefore);
+
+    const feeLogs = await publicClient.getContractEvents({
+      address: hookAddress,
+      abi: hookArtifact.abi,
+      eventName: 'GraduatedFeeCollected',
+      fromBlock: BigInt(buy2Record.blockNumber!),
+      toBlock: BigInt(buy2Record.blockNumber!),
+    });
+    if (feeLogs.length !== 1) throw new Error(`Expected exactly 1 GraduatedFeeCollected event on post-grad buy, got ${feeLogs.length}.`);
+    const feeEvent = feeLogs[0].args as { zeroForOne: boolean; creatorFee: bigint; lossPoolFee: bigint };
+    if (feeEvent.zeroForOne !== true) throw new Error('Post-grad buy GraduatedFeeCollected.zeroForOne should be true.');
+
+    if (ethSpent !== BUY_AMOUNT_WEI) throw new Error(`Post-grad buy: wallet spent ${ethSpent}, expected exactly ${BUY_AMOUNT_WEI}.`);
+    if (tokensReceived !== predicted) throw new Error(`Post-grad buy: tokens received ${tokensReceived} != simulated prediction ${predicted}.`);
+    if (lossPoolBalanceAfter - BigInt(b.lossPoolBalanceBefore) !== feeEvent.lossPoolFee) throw new Error('Post-grad buy: LossRewardPool delta != event.lossPoolFee.');
+    if (creatorBalanceAfter - BigInt(b.creatorBalanceBefore) !== feeEvent.creatorFee) throw new Error('Post-grad buy: creatorBalances delta != event.creatorFee.');
+    console.log(`  Tokens received: ${tokensReceived} (== simulated prediction, exact)`);
+    console.log(`  GraduatedFeeCollected(zeroForOne=true): creatorFee=${feeEvent.creatorFee}, lossPoolFee=${feeEvent.lossPoolFee}`);
+    console.log('  Exact balance-delta assertions (wallet ETH, tokens, REAL LossRewardPool, creatorBalances): PASS\n');
+
+    if (buy2Record.tokensReceived === undefined) {
+      buy2Record.tokensReceived = tokensReceived.toString();
+      state.steps.postGradBuy = buy2Record;
+      persistState(state);
+    }
+  }
+  const postGradTokens = BigInt(buy2Record.tokensReceived as string);
+
+  // ==========================================================================
+  // STAGE 7: real POST-graduation sell — exercises the afterSwap fee mechanism,
+  // the specific code path that has never run against a real PoolManager before.
+  // ==========================================================================
+  console.log(`[7/8] Post-graduation sell of ${postGradTokens} tokens via GenericV4Bot (afterSwap fee path)...`);
+  await runStep('postGradSellApprove', async () => ({ hash: await token.write.approve([botAddress, postGradTokens]) }));
+
+  const sell2Before = (state.steps.postGradSell?.before as Record<string, string>) ?? {
+    ethBefore: (await publicClient.getBalance({ address: account })).toString(),
+    lossPoolBalanceBefore: (await publicClient.getBalance({ address: REAL_PRODUCTION_LOSS_REWARD_POOL })).toString(),
+    creatorBalanceBefore: ((await hook.read.creatorBalances([account])) as bigint).toString(),
+  };
+  let predictedSell2Out: bigint | undefined = state.steps.postGradSell?.predictedOut !== undefined
+    ? BigInt(state.steps.postGradSell.predictedOut as string)
+    : undefined;
+  if (predictedSell2Out === undefined) {
+    const sim = await publicClient.simulateContract({
+      address: botAddress,
+      abi: botArtifact.abi,
+      functionName: 'swap',
+      args: [poolKey, false, postGradTokens, 0n],
+      account,
+    });
+    predictedSell2Out = sim.result as bigint;
+  }
+  const sell2Record = await runStep(
+    'postGradSell',
+    async () => ({ hash: await bot.write.swap([poolKey, false, postGradTokens, 0n]) }),
+    { before: sell2Before, predictedOut: predictedSell2Out.toString() }
+  );
+  {
+    const b = sell2Record.before as Record<string, string>;
+    const predicted = BigInt(sell2Record.predictedOut as string);
+    const ethAfter = await publicClient.getBalance({ address: account });
+    const tokensAfter = await token.read.balanceOf([account]);
+    const lossPoolBalanceAfter = await publicClient.getBalance({ address: REAL_PRODUCTION_LOSS_REWARD_POOL });
+    const creatorBalanceAfter = (await hook.read.creatorBalances([account])) as bigint;
+
+    const ethReceived = ethAfter - BigInt(b.ethBefore) + gasCost(sell2Record);
+
+    const feeLogs = await publicClient.getContractEvents({
+      address: hookAddress,
+      abi: hookArtifact.abi,
+      eventName: 'GraduatedFeeCollected',
+      fromBlock: BigInt(sell2Record.blockNumber!),
+      toBlock: BigInt(sell2Record.blockNumber!),
+    });
+    if (feeLogs.length !== 1) throw new Error(`Expected exactly 1 GraduatedFeeCollected event on post-grad sell, got ${feeLogs.length}.`);
+    const feeEvent = feeLogs[0].args as { zeroForOne: boolean; creatorFee: bigint; lossPoolFee: bigint };
+    if (feeEvent.zeroForOne !== false) throw new Error('Post-grad sell GraduatedFeeCollected.zeroForOne should be false — this is THE never-before-tested code path.');
+
+    if (tokensAfter !== 0n) throw new Error(`Post-grad sell: wallet still holds ${tokensAfter} tokens after selling all of them.`);
+    if (ethReceived !== predicted) throw new Error(`Post-grad sell: ETH received ${ethReceived} != simulated prediction ${predicted}.`);
+    if (lossPoolBalanceAfter - BigInt(b.lossPoolBalanceBefore) !== feeEvent.lossPoolFee) throw new Error('Post-grad sell: LossRewardPool delta != event.lossPoolFee.');
+    if (creatorBalanceAfter - BigInt(b.creatorBalanceBefore) !== feeEvent.creatorFee) throw new Error('Post-grad sell: creatorBalances delta != event.creatorFee.');
+    console.log(`  ETH received: ${formatEther(ethReceived)} ETH (== simulated prediction, exact)`);
+    console.log(`  GraduatedFeeCollected(zeroForOne=false): creatorFee=${feeEvent.creatorFee}, lossPoolFee=${feeEvent.lossPoolFee}`);
+    console.log('  *** afterSwap sell-side fee mechanism confirmed working on REAL mainnet, real PoolManager, real production LossRewardPool ***');
+    console.log('  Exact balance-delta assertions: PASS\n');
+  }
+
+  // ==========================================================================
+  // STAGE 8: claim everything accrued across pre- and post-graduation trades
+  // ==========================================================================
+  console.log('[8/8] Claiming accrued creator fees (pre- + post-graduation, one ledger)...');
+  const claimBefore = (state.steps.claim?.before as Record<string, string>) ?? {
+    ethBefore: (await publicClient.getBalance({ address: account })).toString(),
+    accruedBefore: ((await hook.read.creatorBalances([account])) as bigint).toString(),
+  };
+  const accruedBeforeClaim = BigInt(claimBefore.accruedBefore);
+  console.log(`  creatorBalances(${account}) before claim: ${formatEther(accruedBeforeClaim)} ETH`);
+  if (!state.steps.claim && accruedBeforeClaim <= 0n) {
+    throw new Error('Expected a non-zero accrued creator balance from all the trades above, got 0.');
+  }
+  const claimRecord = await runStep('claim', async () => ({ hash: await hook.write.claimCreatorFees() }), { before: claimBefore });
+  {
+    const b = claimRecord.before as Record<string, string>;
+    const ethAfter = await publicClient.getBalance({ address: account });
+    const accruedAfter = (await hook.read.creatorBalances([account])) as bigint;
+    const netClaimed = ethAfter - BigInt(b.ethBefore) + gasCost(claimRecord);
+
+    if (accruedAfter !== 0n) throw new Error(`creatorBalances() is ${accruedAfter} after claim, expected exactly 0.`);
+    if (netClaimed !== accruedBeforeClaim) throw new Error(`Claimed ETH (net of gas) ${netClaimed} != pre-claim reading ${accruedBeforeClaim}.`);
+    console.log(`  Claimed exactly ${formatEther(netClaimed)} ETH (net of gas). Exact balance-delta assertion: PASS\n`);
+  }
+
+  console.log('============================================================');
+  console.log('[VERIFY V4 HOOK — PRODUCTION] COMPLETE');
+  console.log('============================================================');
+  console.log('Every step confirmed on-chain with exact balance deltas, including the post-graduation');
+  console.log('beforeSwap AND afterSwap fee mechanisms — both now proven against real mainnet, real');
+  console.log('PoolManager, and the real production LossRewardPool for the first time.');
+  console.log(JSON.stringify({
+    hook: hookAddress,
+    factory: factoryAddress,
+    router: routerAddress,
+    testToken: tokenAddress,
+    poolId,
+    genericV4Bot: botAddress,
+    verifiedAt: new Date().toISOString(),
+    result: 'ALL EXACT BALANCE-DELTA ASSERTIONS PASSED, INCLUDING POST-GRADUATION FEE MECHANISM',
+  }, null, 2));
+}
+
+main().catch((err) => {
+  console.error('\n[VERIFY V4 HOOK ERROR]', err instanceof Error ? err.message : err);
+  console.error(`Progress so far (including any tx hashes already sent) is saved in ${STATE_PATH}.`);
+  console.error('Re-running the exact same command will resume from here, not resend anything already sent —');
+  console.error('this matters a great deal given the graduating buy alone moves ~6 real ETH.');
+  process.exitCode = 1;
+});

--- a/src/pages/home/page.tsx
+++ b/src/pages/home/page.tsx
@@ -26,6 +26,7 @@ import {
 import WalletButton from '../../components/WalletButton';
 import { EVM_CHAIN_NAME } from '../../lib/evmNetwork';
 import { supabase } from '../../lib/supabase';
+import { getUnifiedMarketState } from '../../lib/swap';
 
 type TokenItem = {
   id: string;
@@ -81,6 +82,8 @@ const HomePage = () => {
   const [howModalOpen, setHowModalOpen] = useState(false);
 
   useEffect(() => {
+    let cancelled = false;
+
     const fetchTokens = async () => {
       try {
         const [tokensRes, snapshotsRes] = await Promise.all([
@@ -97,11 +100,26 @@ const HomePage = () => {
           }
         }
 
+        // Tokens with no row here fall through to the live on-chain fallback
+        // below — currently every V4-launched token, since
+        // token_market_snapshots_evm is written exclusively by
+        // scripts/evm-indexer.mjs, which only knows about the V3 factory/curves
+        // (see src/lib/bondingCurveV4.ts's header comment — extending that
+        // worker to also index V4 hook state is real backend work, tracked
+        // separately, not done here). Without this fallback, any V4 token
+        // shows a static, never-updating $5,000 placeholder forever, since
+        // `snap` here is permanently undefined for it.
+        const mintsNeedingLiveFallback: string[] = [];
+
         const tenMinutes = 10 * 60 * 1000;
         const tokensList = ((tokensRes.data || []).map((row: Record<string, unknown>) => {
           const createdAt = row.created_at || new Date();
           const mint = String(row.mint_address || '').toLowerCase();
           const snap = snapshotsByMint.get(mint);
+
+          if (!snap && mint) {
+            mintsNeedingLiveFallback.push(mint);
+          }
 
           // Calculate real Pump.fun market cap: 1,000,000,000 tokens * price (or initial $5,000)
           const priceEth = snap ? Number(snap.price_eth || 0) : 0;
@@ -126,6 +144,45 @@ const HomePage = () => {
 
         setTokens(tokensList);
 
+        // Live fallback, second pass: fetch real on-chain state for whichever
+        // tokens above had no indexed snapshot (V3 tokens should always have
+        // one; in practice this is V4 tokens today). Runs after the initial
+        // render so the snapshot-covered majority isn't held up waiting on
+        // extra RPC calls, and merges in per-token as each resolves rather
+        // than replacing the whole list at once.
+        if (mintsNeedingLiveFallback.length > 0) {
+          const results = await Promise.allSettled(
+            mintsNeedingLiveFallback.map(async (mint) => {
+              const market = await getUnifiedMarketState(mint);
+              return { mint, market };
+            })
+          );
+
+          if (cancelled) return;
+
+          const liveByMint = new Map<string, { priceEth: number; marketCapUsd: number }>();
+          for (const result of results) {
+            if (result.status === 'fulfilled' && result.value.market.marketCapUsd > 0) {
+              liveByMint.set(result.value.mint, {
+                priceEth: result.value.market.priceEth,
+                marketCapUsd: result.value.market.marketCapUsd,
+              });
+            } else if (result.status === 'rejected') {
+              console.warn('Live market-state fallback failed for a token with no indexed snapshot:', result.reason);
+            }
+          }
+
+          if (liveByMint.size > 0) {
+            setTokens((prev) =>
+              prev.map((token) => {
+                const mint = String(token.mint_address || '').toLowerCase();
+                const live = liveByMint.get(mint);
+                return live ? { ...token, priceEth: live.priceEth, marketCapUsd: live.marketCapUsd } : token;
+              })
+            );
+          }
+        }
+
       } catch (err) {
         console.error('Supabase fetch error:', err);
       }
@@ -133,7 +190,10 @@ const HomePage = () => {
 
     fetchTokens();
     const interval = setInterval(fetchTokens, 30000);
-    return () => clearInterval(interval);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
   }, []);
 
   const filteredTokens = useMemo(() => {

--- a/test/hardhat/v4-generic-sell-hook.test.ts
+++ b/test/hardhat/v4-generic-sell-hook.test.ts
@@ -1,0 +1,291 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { network } from 'hardhat';
+import {
+  parseEther,
+  formatEther,
+  formatUnits,
+  getAddress,
+  keccak256,
+  encodeAbiParameters,
+  parseAbiParameters,
+  encodeDeployData,
+  getContractAddress,
+  concat,
+  toHex,
+  parseAbi,
+  decodeEventLog,
+} from 'viem';
+
+/**
+ * Proves the FIX in contracts/v4/IncentifiV4HookGenericSell.sol on a mainnet fork,
+ * end-to-end, with real transactions: deploys the new hook via the SAME CREATE2
+ * singleton factory and the SAME 0x2888 permission-flag mask the production deploy
+ * used (so the address-mining path is exercised, not just the logic), a fresh
+ * factory + router pointed at it, and a FRESH throwaway LossRewardPool (never the
+ * production one). Then, against a freshly launched token:
+ *
+ *   1. generic BUY  via GenericV4Bot            -> succeeds   (was already fine)
+ *   2. generic SELL via GenericV4Bot            -> SUCCEEDS   (THE FIX — reverts on the old hook)
+ *        - seller's tokens leave, real ETH arrives, the Sold event's lossPoolFee
+ *          lands in the LossRewardPool exactly, and the hook's ERC-6909 claim
+ *          balance == tokens sold (proves the claims path, not a physical take)
+ *   3. router SELL                              -> still succeeds (regression: pre-settle order stays compatible)
+ *   4. router BUY after sells                   -> claim balance DEcreases (proves _payToken's burn path)
+ *   5. full graduation                          -> claim balance ends at 0 (proves claims × _settleMintDelta)
+ *   6. generic SELL post-graduation             -> succeeds (ZERO_DELTA pass-through regression)
+ *
+ * Companion: v4-generic-sell-proof.test.ts proves the same generic sell REVERTS on
+ * the real deployed production hook — together they bracket the root cause.
+ *
+ * Run (isolated — node:test shares a process across files):
+ *   npx hardhat test nodejs --network robinhoodFork -- test/hardhat/v4-generic-sell-hook.test.ts
+ */
+
+const POOL_MANAGER = getAddress('0x8366a39CC670B4001A1121B8F6A443A643e40951');
+const CREATE2_FACTORY = getAddress('0x4e59b44847b379578588920cA78FbF26c0B4956C');
+// beforeInitialize(13) | beforeAddLiquidity(11) | beforeSwap(7) | beforeSwapReturnDelta(3)
+// — identical to the production NoPostGradFee deploy; the new hook declares the same four.
+const REQUIRED_FLAGS = (1n << 13n) | (1n << 11n) | (1n << 7n) | (1n << 3n); // 0x2888
+const FLAG_MASK = (1n << 14n) - 1n;
+const MAX_SALT_SEARCH = 200_000;
+
+const TOTAL_SUPPLY = 1_000_000_000n * 10n ** 18n;
+const ERC6909_ABI = parseAbi(['function balanceOf(address owner, uint256 id) view returns (uint256)']);
+
+function findArtifact(name: string): { abi: any; bytecode: `0x${string}` } {
+  const root = path.resolve('artifacts');
+  const stack = [root];
+  while (stack.length) {
+    const dir = stack.pop()!;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) stack.push(full);
+      else if (entry.name === `${name}.json`) return JSON.parse(fs.readFileSync(full, 'utf8'));
+    }
+  }
+  throw new Error(`artifact ${name}.json not found under ${root} — run \`npx hardhat compile\``);
+}
+
+describe('IncentifiV4HookGenericSell fork test (real CREATE2 deploy, generic sell must succeed)', () => {
+  it('generic swap-then-settle sells succeed pre-graduation; claims flow through buys and graduation', async () => {
+    const { viem, networkHelpers } = await network.create('robinhoodFork');
+    const publicClient = await viem.getPublicClient();
+    const [deployer, creator, buyer, seller, buyer2] = await viem.getWalletClients();
+    for (const w of [deployer, creator, buyer, seller, buyer2]) {
+      await networkHelpers.setBalance(w.account.address, parseEther('100'));
+    }
+    // See v4-generic-sell-proof.test.ts: EDR cannot execute a call at exactly the
+    // fork block on chain 4663 (no hardfork history configured). Every EVM call in
+    // this test already follows a mined deployment, but mining one block up front
+    // makes that guarantee explicit rather than incidental.
+    await networkHelpers.mine(1);
+
+    console.log('--- Fork setup ---');
+    console.log('Forked at block:', await publicClient.getBlockNumber());
+    for (const [name, addr] of [['PoolManager', POOL_MANAGER], ['CREATE2 singleton factory', CREATE2_FACTORY]] as const) {
+      const code = await publicClient.getCode({ address: addr });
+      assert.ok(code && code !== '0x', `${name} must have code on the fork`);
+    }
+
+    // Fresh, throwaway LossRewardPool — never the production one.
+    const lossPool = await viem.deployContract('LossRewardPool', [deployer.account.address]);
+    console.log('Throwaway LossRewardPool:', lossPool.address);
+
+    // ------------------------------------------------------------------------
+    // Deploy the new hook via CREATE2 — same singleton factory, same flag mask.
+    // ------------------------------------------------------------------------
+    const artifact = findArtifact('IncentifiV4HookGenericSell');
+    const initCode = encodeDeployData({
+      abi: artifact.abi,
+      bytecode: artifact.bytecode,
+      args: [POOL_MANAGER, lossPool.address, deployer.account.address],
+    });
+    const initCodeHash = keccak256(initCode);
+    let salt: `0x${string}` | null = null;
+    let hookAddr: `0x${string}` | null = null;
+    for (let i = 0; i < MAX_SALT_SEARCH; i++) {
+      const candidateSalt = toHex(BigInt(i), { size: 32 });
+      const candidate = getContractAddress({ opcode: 'CREATE2', from: CREATE2_FACTORY, salt: candidateSalt, bytecodeHash: initCodeHash });
+      if ((BigInt(candidate) & FLAG_MASK) === REQUIRED_FLAGS) {
+        salt = candidateSalt;
+        hookAddr = getAddress(candidate);
+        break;
+      }
+    }
+    assert.ok(salt && hookAddr, `no CREATE2 salt found within ${MAX_SALT_SEARCH} attempts`);
+    console.log('Mined salt:', salt, '-> hook address:', hookAddr);
+
+    await publicClient.waitForTransactionReceipt({
+      hash: await deployer.sendTransaction({ to: CREATE2_FACTORY, data: concat([salt!, initCode]) }),
+    });
+    const hookCode = await publicClient.getCode({ address: hookAddr! });
+    assert.ok(hookCode && hookCode !== '0x', 'hook must be deployed at the mined address');
+    assert.equal(BigInt(hookAddr!) & FLAG_MASK, REQUIRED_FLAGS, 'deployed address must carry the 4 permission flags');
+    const hook = await viem.getContractAt('IncentifiV4HookGenericSell', hookAddr!);
+    assert.equal(getAddress(await hook.read.lossRewardPool()), getAddress(lossPool.address));
+    console.log('Hook deployed via CREATE2; flags verified (0x' + REQUIRED_FLAGS.toString(16) + ').');
+
+    const factory = await viem.deployContract('IncentifiV4Factory', [POOL_MANAGER, hookAddr!]);
+    await publicClient.waitForTransactionReceipt({ hash: await hook.write.setFactory([factory.address]) });
+    assert.equal(getAddress(await hook.read.factory()), getAddress(factory.address));
+    const router = await viem.deployContract('IncentifiV4Router', [POOL_MANAGER, hookAddr!, factory.address]);
+    console.log('Factory:', factory.address, '| Router:', router.address);
+
+    // ------------------------------------------------------------------------
+    // Launch a fresh token through the new factory.
+    // ------------------------------------------------------------------------
+    const token = await viem.deployContract('IncentifiLaunchToken', ['GenericSell Test', 'GST', TOTAL_SUPPLY], {
+      client: { wallet: creator },
+    });
+    await publicClient.waitForTransactionReceipt({
+      hash: await token.write.approve([factory.address, TOTAL_SUPPLY], { account: creator.account }),
+    });
+    await publicClient.waitForTransactionReceipt({
+      hash: await factory.write.launchToken([token.address], { account: creator.account }),
+    });
+    const rawKey = await factory.read.getPoolKey([token.address]);
+    const poolKey = {
+      currency0: getAddress(rawKey.currency0),
+      currency1: getAddress(rawKey.currency1),
+      fee: Number(rawKey.fee),
+      tickSpacing: Number(rawKey.tickSpacing),
+      hooks: getAddress(rawKey.hooks),
+    };
+    const poolId = keccak256(
+      encodeAbiParameters(parseAbiParameters('address, address, uint24, int24, address'), [
+        poolKey.currency0, poolKey.currency1, poolKey.fee, poolKey.tickSpacing, poolKey.hooks,
+      ])
+    );
+    assert.equal(poolKey.hooks, hookAddr, 'launched pool must be bound to the NEW hook');
+    assert.equal((await hook.read.curveStates([poolId]))[2], true, 'pool must be initialized');
+    console.log('Token:', token.address, '| poolId:', poolId);
+
+    const claimId = BigInt(token.address); // CurrencyLibrary.toId() == uint160(address)
+    const claimsOf = () => publicClient.readContract({ address: POOL_MANAGER, abi: ERC6909_ABI, functionName: 'balanceOf', args: [hookAddr!, claimId] });
+    const deadline = () => BigInt(Math.floor(Date.now() / 1000) + 300);
+    const bot = await viem.deployContract('GenericV4Bot', [POOL_MANAGER]);
+
+    // ------------------------------------------------------------------------
+    // 1. generic BUY (buyer) + router BUY (seller, to hold a balance to sell)
+    // ------------------------------------------------------------------------
+    console.log('\n=== 1. buys ===');
+    await publicClient.waitForTransactionReceipt({
+      hash: await bot.write.swap([poolKey, true, parseEther('0.5'), 0n], { account: buyer.account, value: parseEther('0.5') }),
+    });
+    assert.ok((await token.read.balanceOf([buyer.account.address])) > 0n, 'generic buy must deliver tokens');
+    await publicClient.waitForTransactionReceipt({
+      hash: await router.write.buyToken([token.address, 0n, deadline()], { account: seller.account, value: parseEther('1') }),
+    });
+    const sellerBal = await token.read.balanceOf([seller.account.address]);
+    assert.ok(sellerBal > 0n);
+    console.log('generic buy OK | seller holds', formatUnits(sellerBal, 18), 'GST');
+    assert.equal(await claimsOf(), 0n, 'no claims should exist before any sell');
+
+    // ------------------------------------------------------------------------
+    // 2. THE FIX — generic swap-then-settle SELL succeeds.
+    // ------------------------------------------------------------------------
+    console.log('\n=== 2. generic SELL via GenericV4Bot (THE FIX) ===');
+    const sellAmt = sellerBal / 2n;
+    await publicClient.waitForTransactionReceipt({
+      hash: await token.write.approve([bot.address, sellAmt], { account: seller.account }),
+    });
+    const poolDepositedBefore = await lossPool.read.totalDeposited([token.address]);
+    const ethBefore = await publicClient.getBalance({ address: seller.account.address });
+    const sellHash = await bot.write.swap([poolKey, false, sellAmt, 0n], { account: seller.account });
+    const sellReceipt = await publicClient.waitForTransactionReceipt({ hash: sellHash });
+    assert.equal(sellReceipt.status, 'success');
+    const gas = sellReceipt.gasUsed * sellReceipt.effectiveGasPrice;
+    const ethAfter = await publicClient.getBalance({ address: seller.account.address });
+    const ethReceived = ethAfter - ethBefore + gas;
+    assert.equal(sellerBal - (await token.read.balanceOf([seller.account.address])), sellAmt, 'exactly sellAmt must leave the seller');
+    assert.ok(ethReceived > 0n, 'seller must receive real ETH');
+
+    let soldFee: bigint | null = null;
+    for (const log of sellReceipt.logs) {
+      if (getAddress(log.address) !== hookAddr) continue;
+      try {
+        const ev = decodeEventLog({ abi: hook.abi, data: log.data, topics: log.topics });
+        if (ev.eventName === 'Sold') soldFee = (ev.args as any).lossPoolFee as bigint;
+      } catch {}
+    }
+    assert.ok(soldFee !== null && soldFee > 0n, 'Sold event with a lossPoolFee must be emitted');
+    const poolDepositedAfter = await lossPool.read.totalDeposited([token.address]);
+    assert.equal(poolDepositedAfter - poolDepositedBefore, soldFee!, 'LossRewardPool must receive exactly the emitted lossPoolFee');
+    const claimsAfterSell = await claimsOf();
+    assert.equal(claimsAfterSell, sellAmt, 'hook must hold ERC-6909 claims == tokens sold (claims path, not a physical take)');
+    console.log('generic sell tx:', sellHash);
+    console.log('  sold', formatUnits(sellAmt, 18), 'GST | received', formatEther(ethReceived), 'ETH | lossPoolFee', formatEther(soldFee!), 'ETH -> pool (exact)');
+    console.log('  hook claim balance:', formatUnits(claimsAfterSell, 18), '(== sold)');
+    console.log('PASS: generic swap-then-settle sell SUCCEEDS on the new hook.');
+
+    // ------------------------------------------------------------------------
+    // 3. router SELL still works (pre-settle order remains compatible)
+    // ------------------------------------------------------------------------
+    console.log('\n=== 3. router SELL (regression) ===');
+    const buyerBal = await token.read.balanceOf([buyer.account.address]);
+    const routerSellAmt = buyerBal / 4n;
+    await publicClient.waitForTransactionReceipt({
+      hash: await token.write.approve([router.address, routerSellAmt], { account: buyer.account }),
+    });
+    const rs = await publicClient.waitForTransactionReceipt({
+      hash: await router.write.sellToken([token.address, routerSellAmt, 0n, deadline()], { account: buyer.account }),
+    });
+    assert.equal(rs.status, 'success');
+    const claimsAfterRouterSell = await claimsOf();
+    assert.equal(claimsAfterRouterSell, sellAmt + routerSellAmt, 'router sell must also accrue as claims');
+    console.log('router sell OK | claims now', formatUnits(claimsAfterRouterSell, 18));
+
+    // ------------------------------------------------------------------------
+    // 4. BUY after sells — _payToken must burn claims first
+    // ------------------------------------------------------------------------
+    console.log('\n=== 4. buy after sells (burn path) ===');
+    await publicClient.waitForTransactionReceipt({
+      hash: await router.write.buyToken([token.address, 0n, deadline()], { account: buyer2.account, value: parseEther('0.3') }),
+    });
+    const claimsAfterBuy = await claimsOf();
+    assert.ok(claimsAfterBuy < claimsAfterRouterSell, 'a buy must spend claims first (burn), reducing the claim balance');
+    console.log('claims', formatUnits(claimsAfterRouterSell, 18), '->', formatUnits(claimsAfterBuy, 18), 'after buy');
+    console.log('PASS: _payToken burn path exercised.');
+
+    // ------------------------------------------------------------------------
+    // 5. graduation — claims must be fully consumed by _settleMintDelta
+    // ------------------------------------------------------------------------
+    console.log('\n=== 5. graduation ===');
+    let buys = 0;
+    while (!(await hook.read.curveStates([poolId]))[3]) {
+      const w = buys % 2 === 0 ? buyer : buyer2;
+      await publicClient.waitForTransactionReceipt({
+        hash: await router.write.buyToken([token.address, 0n, deadline()], { account: w.account, value: parseEther('2'), gas: 3_000_000n }),
+      });
+      buys++;
+      assert.ok(buys < 12, 'did not graduate within a reasonable number of buys');
+    }
+    assert.equal((await hook.read.curveStates([poolId]))[3], true, 'must be graduated');
+    const claimsAfterGrad = await claimsOf();
+    assert.equal(claimsAfterGrad, 0n, 'all claims must be burned into the graduation liquidity mints');
+    console.log('graduated after', buys, 'buys | hook claim balance:', claimsAfterGrad.toString(), '(== 0)');
+    console.log('PASS: claims × _settleMintDelta handled at graduation.');
+
+    // ------------------------------------------------------------------------
+    // 6. post-graduation generic SELL — ZERO_DELTA pass-through regression
+    // ------------------------------------------------------------------------
+    console.log('\n=== 6. post-graduation generic SELL (pass-through) ===');
+    const pgBal = await token.read.balanceOf([buyer2.account.address]);
+    const pgSell = pgBal / 10n;
+    assert.ok(pgSell > 0n);
+    await publicClient.waitForTransactionReceipt({
+      hash: await token.write.approve([bot.address, pgSell], { account: buyer2.account }),
+    });
+    const pg = await publicClient.waitForTransactionReceipt({
+      hash: await bot.write.swap([poolKey, false, pgSell, 0n], { account: buyer2.account }),
+    });
+    assert.equal(pg.status, 'success');
+    assert.equal(pgBal - (await token.read.balanceOf([buyer2.account.address])), pgSell);
+    console.log('post-graduation generic sell OK.');
+
+    console.log('\n=== RESULT: IncentifiV4HookGenericSell — generic sells work pre- AND post-graduation; claims accounting holds through buys and graduation ===');
+  });
+});

--- a/test/hardhat/v4-generic-sell-hook.test.ts
+++ b/test/hardhat/v4-generic-sell-hook.test.ts
@@ -272,7 +272,17 @@ describe('IncentifiV4HookGenericSell fork test (real CREATE2 deploy, generic sel
     // ------------------------------------------------------------------------
     // 6. post-graduation generic SELL — ZERO_DELTA pass-through regression
     // ------------------------------------------------------------------------
-    console.log('\n=== 6. post-graduation generic SELL (pass-through) ===');
+    // ------------------------------------------------------------------------
+    // 6. post-graduation: BOTH behaviors together. The generic caller must still
+    //    be able to sell AND buy (ZERO_DELTA pass-through), and — the
+    //    NoPostGradFee half of this hook — NO Incentifi fee of any kind may be
+    //    taken on either trade: LossRewardPool deposits and the creator's
+    //    pull-payment balance must be exactly unchanged across both.
+    // ------------------------------------------------------------------------
+    console.log('\n=== 6. post-graduation generic SELL + BUY: pass-through AND zero fee ===');
+    const pgPoolBefore = await lossPool.read.totalDeposited([token.address]);
+    const pgCreatorBefore = await hook.read.creatorBalances([creator.account.address]);
+
     const pgBal = await token.read.balanceOf([buyer2.account.address]);
     const pgSell = pgBal / 10n;
     assert.ok(pgSell > 0n);
@@ -284,7 +294,21 @@ describe('IncentifiV4HookGenericSell fork test (real CREATE2 deploy, generic sel
     });
     assert.equal(pg.status, 'success');
     assert.equal(pgBal - (await token.read.balanceOf([buyer2.account.address])), pgSell);
-    console.log('post-graduation generic sell OK.');
+    assert.equal(await lossPool.read.totalDeposited([token.address]), pgPoolBefore, 'post-graduation SELL must deposit NOTHING to the LossRewardPool');
+    assert.equal(await hook.read.creatorBalances([creator.account.address]), pgCreatorBefore, 'post-graduation SELL must accrue NO creator fee');
+    console.log('post-graduation generic sell OK — pool deposit delta 0, creator fee delta 0.');
+
+    const pgBuyWei = parseEther('0.05');
+    const pgBuyBalBefore = await token.read.balanceOf([buyer.account.address]);
+    const pgb = await publicClient.waitForTransactionReceipt({
+      hash: await bot.write.swap([poolKey, true, pgBuyWei, 0n], { account: buyer.account, value: pgBuyWei }),
+    });
+    assert.equal(pgb.status, 'success');
+    assert.ok((await token.read.balanceOf([buyer.account.address])) > pgBuyBalBefore, 'post-graduation generic buy must deliver tokens');
+    assert.equal(await lossPool.read.totalDeposited([token.address]), pgPoolBefore, 'post-graduation BUY must deposit NOTHING to the LossRewardPool');
+    assert.equal(await hook.read.creatorBalances([creator.account.address]), pgCreatorBefore, 'post-graduation BUY must accrue NO creator fee');
+    console.log('post-graduation generic buy OK — pool deposit delta 0, creator fee delta 0.');
+    console.log('PASS: both fixes hold together — generic trading works post-graduation with zero Incentifi fee.');
 
     console.log('\n=== RESULT: IncentifiV4HookGenericSell — generic sells work pre- AND post-graduation; claims accounting holds through buys and graduation ===');
   });

--- a/test/hardhat/v4-generic-sell-proof.test.ts
+++ b/test/hardhat/v4-generic-sell-proof.test.ts
@@ -1,0 +1,187 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { network } from 'hardhat';
+import {
+  parseEther,
+  parseUnits,
+  formatEther,
+  formatUnits,
+  getAddress,
+  keccak256,
+  encodeAbiParameters,
+  parseAbiParameters,
+} from 'viem';
+
+/**
+ * ROOT-CAUSE PROOF, against the REAL deployed production V4 hook and a REAL
+ * production pool on a mainnet fork — not a re-derivation from a fresh deploy.
+ *
+ * The claim being proven: a generic V4 caller (standard order — swap() FIRST,
+ * settle AFTER; exactly what UniversalRouter and every third-party bot do) can
+ * BUY a pre-graduation token through IncentifiV4HookNoPostGradFee but can NEVER
+ * SELL one, while the same sell through IncentifiV4Router succeeds. The cause is
+ * settlement ORDER (the hook's mid-swap take() needs tokens already inside
+ * PoolManager, which only the router pre-settles), not approvals — see
+ * contracts/v4/IncentifiV4HookGenericSell.sol's header for the full argument.
+ *
+ * Instrument: contracts/v4/test-helpers/GenericV4Bot.sol, whose _executeSwap()
+ * calls poolManager.swap() at line 158 and only settles at 169-173 — the
+ * generic pattern. The seller is the REAL creator wallet, impersonated, spending
+ * its REAL TESTING balance against the REAL production pool; nothing here is
+ * synthetic except the fork itself.
+ *
+ * Three assertions, all required:
+ *   1. generic SELL via GenericV4Bot  -> REVERTS   (the bug)
+ *   2. same SELL via IncentifiV4Router -> SUCCEEDS  (control: the only working path)
+ *   3. generic BUY  via GenericV4Bot  -> SUCCEEDS  (the asymmetry — same caller)
+ *
+ * Run (isolated — node:test shares a process across files):
+ *   npx hardhat test nodejs --network robinhoodFork -- test/hardhat/v4-generic-sell-proof.test.ts
+ */
+
+const POOL_MANAGER = getAddress('0x8366a39CC670B4001A1121B8F6A443A643e40951');
+const V4_FACTORY = getAddress('0xdEca2efDB578B6E5F298885b97F64d52f92f5Aa9');
+const V4_ROUTER = getAddress('0x0666399367fa585d672BF793158b35290b7F4082');
+const V4_HOOK = getAddress('0x5bBcf2CDAAA00c285eEc903AA1E2aB9142782888');
+const TESTING = getAddress('0xB122425D30d77f37d8C237CD3a85Bf04F3dbb936');
+const CREATOR = getAddress('0xba69Ca72CD2B87113471c4C38f08928761Edb5cE');
+
+const SELL_AMOUNT = parseUnits('100000', 18);
+const BUY_WEI = parseEther('0.01');
+
+describe('V4 generic-sell root-cause proof (real production hook + pool, mainnet fork)', () => {
+  it('generic sell reverts, router sell succeeds, generic buy succeeds — same caller, same pool', async () => {
+    const { viem, networkHelpers } = await network.create('robinhoodFork');
+    const publicClient = await viem.getPublicClient();
+
+    console.log('--- Fork setup ---');
+    console.log('Forked at block:', await publicClient.getBlockNumber());
+    for (const [name, addr] of [
+      ['PoolManager', POOL_MANAGER],
+      ['IncentifiV4Factory (production)', V4_FACTORY],
+      ['IncentifiV4Router (production)', V4_ROUTER],
+      ['IncentifiV4HookNoPostGradFee (production)', V4_HOOK],
+      ['TESTING token', TESTING],
+    ] as const) {
+      const code = await publicClient.getCode({ address: addr });
+      assert.ok(code && code !== '0x', `${name} must have deployed code on the fork`);
+      console.log(`  ${name}: deployed (${(code.length - 2) / 2} bytes)`);
+    }
+
+    // The REAL creator wallet, impersonated. It is nearly drained of ETH on real
+    // mainnet (a deposit into the bot swept it), so gas is topped up here — the
+    // TESTING balance being spent is its real one.
+    await networkHelpers.impersonateAccount(CREATOR);
+    await networkHelpers.setBalance(CREATOR, parseEther('10'));
+    // impersonateAccount/setBalance edit state without mining, so "latest" is still
+    // the fork block itself — and EDR refuses to EXECUTE a call at exactly the fork
+    // block on a chain it has no hardfork history for ("No known hardfork for
+    // execution on historical block N (relative to fork block number N) in chain
+    // with id 4663"). Mining one local block first makes "latest" a local block
+    // with a known hardfork. Hit for real on the first run of this test; the other
+    // fork tests never saw it only because their first EVM read always came after
+    // a mined deployment.
+    await networkHelpers.mine(1);
+    const creator = await viem.getWalletClient(CREATOR);
+
+    const factory = await viem.getContractAt('IncentifiV4Factory', V4_FACTORY);
+    const token = await viem.getContractAt('IncentifiLaunchToken', TESTING);
+    const router = await viem.getContractAt('IncentifiV4Router', V4_ROUTER);
+    const hook = await viem.getContractAt('IncentifiV4HookNoPostGradFee', V4_HOOK);
+
+    // Real PoolKey from the real factory; poolId derived exactly as PoolIdLibrary.toId().
+    const rawKey = await factory.read.getPoolKey([TESTING]);
+    const poolKey = {
+      currency0: getAddress(rawKey.currency0),
+      currency1: getAddress(rawKey.currency1),
+      fee: Number(rawKey.fee),
+      tickSpacing: Number(rawKey.tickSpacing),
+      hooks: getAddress(rawKey.hooks),
+    };
+    const poolId = keccak256(
+      encodeAbiParameters(parseAbiParameters('address, address, uint24, int24, address'), [
+        poolKey.currency0,
+        poolKey.currency1,
+        poolKey.fee,
+        poolKey.tickSpacing,
+        poolKey.hooks,
+      ])
+    );
+    assert.equal(poolKey.hooks, V4_HOOK, 'the real pool must be bound to the real production hook');
+    assert.equal(poolKey.currency1, TESTING);
+
+    const curve = await hook.read.curveStates([poolId]);
+    assert.equal(curve[2], true, 'pool must be initialized');
+    assert.equal(curve[3], false, 'pool must be PRE-graduation — the constraint under test only applies there');
+    console.log('Real poolId:', poolId, '| initialized:', curve[2], '| graduated:', curve[3]);
+
+    const balStart = await token.read.balanceOf([CREATOR]);
+    assert.ok(balStart >= SELL_AMOUNT, `creator must hold >= ${formatUnits(SELL_AMOUNT, 18)} TESTING (has ${formatUnits(balStart, 18)})`);
+    console.log('Creator real TESTING balance:', formatUnits(balStart, 18));
+
+    // The generic caller: zero Incentifi knowledge, standard swap-then-settle order.
+    const bot = await viem.deployContract('GenericV4Bot', [POOL_MANAGER]);
+    console.log('GenericV4Bot deployed:', bot.address);
+
+    // ------------------------------------------------------------------------
+    // ASSERTION 1 — the bug: generic SELL reverts.
+    // ------------------------------------------------------------------------
+    console.log('\n=== ASSERTION 1: generic (swap-then-settle) SELL via GenericV4Bot ===');
+    await publicClient.waitForTransactionReceipt({
+      hash: await token.write.approve([bot.address, SELL_AMOUNT], { account: creator.account }),
+    });
+    // Note: hardhat-viem simulates before broadcasting, so this fails at the same
+    // stage a real bot's "pre-broadcast simulation" does — no tx hash ever exists,
+    // exactly the symptom observed on mainnet.
+    let genericSellError: Error | null = null;
+    try {
+      await bot.write.swap([poolKey, false, SELL_AMOUNT, 0n], { account: creator.account });
+    } catch (err) {
+      genericSellError = err as Error;
+    }
+    assert.ok(genericSellError, 'generic sell MUST revert against the production hook (it did not — root cause not reproduced)');
+    console.log('Reverted as expected. First line:', genericSellError.message.split('\n')[0]);
+    assert.equal(await token.read.balanceOf([CREATOR]), balStart, 'a reverted sell must move no tokens');
+    console.log('PASS: generic sell reverts; balance unchanged.');
+
+    // ------------------------------------------------------------------------
+    // ASSERTION 2 — control: the SAME sell through IncentifiV4Router succeeds.
+    // (Its _executeSell pre-settles tokens INTO PoolManager before swap().)
+    // ------------------------------------------------------------------------
+    console.log('\n=== ASSERTION 2: same SELL via IncentifiV4Router ===');
+    await publicClient.waitForTransactionReceipt({
+      hash: await token.write.approve([V4_ROUTER, SELL_AMOUNT], { account: creator.account }),
+    });
+    const ethBeforeRouterSell = await publicClient.getBalance({ address: CREATOR });
+    const deadline = BigInt(Math.floor(Date.now() / 1000) + 300);
+    const sellHash = await router.write.sellToken([TESTING, SELL_AMOUNT, 0n, deadline], { account: creator.account });
+    const sellReceipt = await publicClient.waitForTransactionReceipt({ hash: sellHash });
+    assert.equal(sellReceipt.status, 'success');
+    const sellGas = sellReceipt.gasUsed * sellReceipt.effectiveGasPrice;
+    const ethAfterRouterSell = await publicClient.getBalance({ address: CREATOR });
+    const balAfterRouterSell = await token.read.balanceOf([CREATOR]);
+    const ethReceived = ethAfterRouterSell - ethBeforeRouterSell + sellGas;
+    console.log('Router sell tx:', sellHash, '| gas:', sellReceipt.gasUsed.toString());
+    console.log('TESTING delta:', formatUnits(balStart - balAfterRouterSell, 18), '| ETH received (net of gas):', formatEther(ethReceived));
+    assert.equal(balStart - balAfterRouterSell, SELL_AMOUNT, 'router sell must remove exactly SELL_AMOUNT');
+    assert.ok(ethReceived > 0n, 'router sell must pay out real ETH');
+    console.log('PASS: router sell succeeds — the only working pre-graduation sell path.');
+
+    // ------------------------------------------------------------------------
+    // ASSERTION 3 — the asymmetry: the SAME generic caller CAN buy.
+    // (The hook take()s native ETH there, borrowing against PoolManager's real
+    // ETH from other pools; a fresh token has no such shared reserve.)
+    // ------------------------------------------------------------------------
+    console.log('\n=== ASSERTION 3: generic BUY via GenericV4Bot (same caller) ===');
+    const balBeforeBuy = await token.read.balanceOf([CREATOR]);
+    const buyHash = await bot.write.swap([poolKey, true, BUY_WEI, 0n], { account: creator.account, value: BUY_WEI });
+    const buyReceipt = await publicClient.waitForTransactionReceipt({ hash: buyHash });
+    assert.equal(buyReceipt.status, 'success');
+    const balAfterBuy = await token.read.balanceOf([CREATOR]);
+    console.log('Generic buy tx:', buyHash, '| tokens out:', formatUnits(balAfterBuy - balBeforeBuy, 18));
+    assert.ok(balAfterBuy > balBeforeBuy, 'generic buy must deliver tokens');
+    console.log('PASS: generic buy succeeds — buy works, sell does not, for the identical generic caller.');
+
+    console.log('\n=== RESULT: root cause CONFIRMED on the real production hook — settlement order, not approvals ===');
+  });
+});


### PR DESCRIPTION
## Why

A real, root-caused production incident. Third-party trading bots can **buy** any token launched through the live V4 hook (`IncentifiV4HookNoPostGradFee`, `0x5bBcf2CD…`) — real mainnet transactions, real PoolManager routing, real 1% LossRewardPool fee — but can never **sell** one pre-graduation. Every attempt dies in the bot's own pre-broadcast simulation with no transaction hash, while sells through `IncentifiV4Router` work.

It was first chased as an approval problem. It is not — the bot already held an unlimited direct token allowance (confirmed on-chain). The cause is **settlement order**: the hook's `_executeSell` physically `take()`s the seller's tokens out of PoolManager *inside* `beforeSwap`, which only works if the caller settled them **in** before calling `swap()` — which only `IncentifiV4Router` does. Every generic V4 router (UniversalRouter, third-party bots, `GenericV4Bot`) uses the standard swap-then-settle order, so that `take()` fires against a PoolManager holding none of a fresh token and reverts. Buys are unaffected because the hook `take()`s native ETH there, momentarily borrowing against PoolManager's ETH from other pools; a fresh token has no such shared reserve. Every generic-caller sell tested before this was post-graduation (where the hook passes through), which is exactly why it was never caught.

## The fix

`IncentifiV4HookGenericSell.sol` — `IncentifiV4HookNoPostGradFee.sol` with **one** mechanical change: a pre-graduation sell receives the seller's tokens as **ERC-6909 claims** (`PoolManager.mint`) instead of a physical `take()`. `mint()` needs no backing at that instant, and PoolManager's own settle accounting reverts the whole unlock if the caller under-delivers (fee-on-transfer safety, now enforced by the platform). Claims are spent via `burn()` on the buy and graduation outbound legs. Pricing, fees, reserves, graduation and the post-graduation `ZERO_DELTA` pass-through are unchanged; same four permission flags, same `0x2888` CREATE2 mask. Diff the two hook files to see every change.

## Verification (mainnet fork, real transactions)

- **`test/hardhat/v4-generic-sell-proof.test.ts`** (PASS) — against the **real deployed production hook**, the **real TESTING pool**, the **real creator wallet's balance**: generic sell reverts, router sell succeeds, generic buy succeeds. Root cause confirmed; approvals ruled out.
- **`test/hardhat/v4-generic-sell-hook.test.ts`** (PASS) — deploys the new hook via the same CREATE2 factory + flag mask the mainnet script uses; a generic swap-then-settle sell **succeeds**, the 1% fee lands in the pool exactly, ERC-6909 claims equal tokens sold, claims burn down on buys, and a full graduation consumes every claim to zero.

## Scope / commits

1. **Track the V4 contract suite + deploy/verify scripts** — these had never been in git (earlier V4 PRs committed only `src/` and `.mjs` workers). Includes the `@uniswap/v4-*` build deps.
2. **The fix** — new hook, its CREATE2 deploy script (gated behind `DEPLOY_CONFIRM`, **not yet run**), and the two fork tests.
3. **Home page V4 market-cap fallback** — an uncommitted working-tree change from earlier this session, committed here to preserve it; independent of the hook fix and can be split out.

## Not included / follow-ups

- **No mainnet deployment yet** — the deploy script is ready; running it costs real gas and is a separate step.
- **Existing tokens** on the old hook are permanently bound to it (immutable pool→hook binding) and stay sellable only via `IncentifiV4Router`. This helps only launches made through a factory pointed at the new hook — which also requires re-pointing the website's factory/router/hook addresses after deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)