### PR TITLE
Deploy IncentifiV4HookGenericSell to mainnet and re-point new V4 launches to it

### DIFF
--- a/scripts/evm-indexer.mjs
+++ b/scripts/evm-indexer.mjs
@@ -93,7 +93,12 @@ const ERC20_SYMBOL_ABI = parseAbi(['function symbol() view returns (string)']);
 const INCENTIFI_BONDING_CURVE_FACTORY = (process.env.VITE_INCENTIFI_BONDING_CURVE_FACTORY || '0xa0143de84fba1753b887e4e32941e4fb342e473f');
 const LOSS_REWARD_POOL = (process.env.VITE_LOSS_REWARD_POOL || '0x697bda9db5a297a9cd9ed969bbf2549d0527dcdf');
 const INCENTIFI_SWAP_ROUTER = (process.env.VITE_INCENTIFI_SWAP_ROUTER || '0x4c1f4197b5eebb6cc15c37e053f963a56787575e');
-const INCENTIFI_V4_FACTORY = (process.env.VITE_INCENTIFI_V4_FACTORY || '0xdEca2efDB578B6E5F298885b97F64d52f92f5Aa9');
+// The IncentifiV4HookGenericSell factory (see src/lib/uniswapAddresses.ts for the
+// full provenance). Discovery watches THIS factory's TokenLaunched events only:
+// tokens on the previous factory (0xdEca2efD… — TESTTT, TESST, TESTING) are
+// deliberately no longer refreshed here, matching the site's single-factory
+// resolution; their last token_market_snapshots_evm rows simply stop updating.
+const INCENTIFI_V4_FACTORY = (process.env.VITE_INCENTIFI_V4_FACTORY || '0x4166418Ceec501f6d4F6D1fb279d23e7fDD259d0');
 
 // Reference ETH/USD used for price_usd — kept numerically identical to
 // src/lib/bondingCurve.ts's REFERENCE_ETH_USD (also 2500) so V3 and V4 rows in

--- a/src/lib/uniswapAddresses.ts
+++ b/src/lib/uniswapAddresses.ts
@@ -38,29 +38,38 @@ export const INCENTIFI_BONDING_CURVE_FACTORY = String(
 
 // V4: new token launches go through this factory/router/hook instead of the V3
 // ones above (which remain here, unchanged, so already-launched V3 tokens stay
-// tradeable). This is IncentifiV4HookNoPostGradFee — the core, already
-// real-mainnet-proven bonding-curve/graduation logic at full production
-// economics ($5,000 launch / $69,000 graduation), wired to the real production
-// LossRewardPool — WITHOUT the newer afterSwap post-graduation fee mechanism
-// (that 6-flag hook remains deployed and paused pending funding). Once a token
-// launched here graduates, its pool trades with zero Incentifi protocol fee —
-// deliberate, not a bug: see contracts/v4/IncentifiV4HookNoPostGradFee.sol's
-// header comment. Independently verified on-chain (code, cross-wiring,
-// deployer, lossRewardPool == real production pool, GRADUATION_ETH_TARGET ==
-// full production value) before this address was ever used here.
+// tradeable). This is IncentifiV4HookGenericSell — IncentifiV4HookNoPostGradFee's
+// exact bonding-curve/graduation logic at full production economics ($5,000
+// launch / $69,000 graduation), wired to the real production LossRewardPool,
+// no fee of any kind once graduated — PLUS the claims-based sell fix: a
+// pre-graduation sell receives tokens as ERC-6909 claims instead of a physical
+// take(), so generic V4 routers and third-party bots (which settle AFTER
+// swap()) can sell, not only IncentifiV4Router. Root cause, fix rationale and
+// the fork-test evidence: contracts/v4/IncentifiV4HookGenericSell.sol's header.
+// Independently verified on-chain after deployment (flag bits 0x2888,
+// deployer, lossRewardPool == real production pool, GRADUATION_ETH_TARGET /
+// VIRTUAL_ETH == production values, exact 4-flag permission set, and the
+// factory/hook/router cross-wiring) before these addresses were used here.
+//
+// The PREVIOUS hook (IncentifiV4HookNoPostGradFee, 0x5bBcf2CD…) and its factory
+// (0xdEca2efD…) / router (0x0666399…) stay live on-chain. Tokens launched on
+// them (TESTTT, TESST, TESTING) are permanently bound to that hook — a pool's
+// hook address is immutable — and are deliberately NOT resolved by this site
+// any more (a single-factory lookup was chosen over multi-factory support;
+// they were test tokens). Their pools remain tradeable via the old router.
 export const INCENTIFI_V4_FACTORY = String(
-  import.meta.env.VITE_INCENTIFI_V4_FACTORY || '0xdEca2efDB578B6E5F298885b97F64d52f92f5Aa9'
+  import.meta.env.VITE_INCENTIFI_V4_FACTORY || '0x4166418Ceec501f6d4F6D1fb279d23e7fDD259d0'
 ).trim() as `0x${string}`;
 
 export const INCENTIFI_V4_ROUTER = String(
-  import.meta.env.VITE_INCENTIFI_V4_ROUTER || '0x0666399367fa585d672BF793158b35290b7F4082'
+  import.meta.env.VITE_INCENTIFI_V4_ROUTER || '0x762b4D9e514e4B19E54E99b62E7b731CE37FF1E6'
 ).trim() as `0x${string}`;
 
 // The shared hook every V4-launched token's pool uses. Not a per-token
 // contract (unlike the V3 bonding curve) — there is no "curve address" for a
 // V4 token; its state lives in this hook's own curveStates(poolId) mapping.
 export const INCENTIFI_V4_HOOK = String(
-  import.meta.env.VITE_INCENTIFI_V4_HOOK || '0x5bBcf2CDAAA00c285eEc903AA1E2aB9142782888'
+  import.meta.env.VITE_INCENTIFI_V4_HOOK || '0xC5Ef9Cb8c95cd8540E71b6D4c00a90257625a888'
 ).trim() as `0x${string}`;
 
 // Canonical Uniswap Permit2 + UniversalRouter deployments on Robinhood Chain mainnet.


### PR DESCRIPTION
**Stacked on #8** (base branch is `v4-hook-generic-sell`) — merge #8 first; GitHub will retarget this to `master` automatically. **Do not merge automatically** — for review.

## What this is

The combined production V4 hook is live on Robinhood Chain mainnet: `IncentifiV4HookNoPostGradFee`'s exact logic (zero Incentifi fee once graduated) **plus** the ERC-6909 claims-based sell intake so generic V4 routers and third-party bots can sell pre-graduation. Both behaviors were fork-proven *together* before deploying (`test/hardhat/v4-generic-sell-hook.test.ts`: generic sell succeeds pre-graduation, claims drain to zero at graduation, post-graduation generic sell **and** buy pass through with pool deposits and creator balance exactly unchanged).

## Deployment — every step independently re-verified on-chain, all `success`

| Step | Address | Tx | Block | Gas |
|---|---|---|---|---|
| HookMinerCheck | `0xeC5e20BC…B8c912` | `0x758f3513…` | 56198952 | 136,653 |
| **Hook (CREATE2)** | **`0xC5Ef9Cb8c95cd8540E71b6D4c00a90257625a888`** | `0x775c1c50…` | 56199005 | 2,392,066 |
| Factory | **`0x4166418Ceec501f6d4F6D1fb279d23e7fDD259d0`** | `0x79c989f0…` | 56199065 | 450,206 |
| setFactory | — | `0x18c4a2a0…` | 56199117 | 44,077 |
| Router | **`0x762b4D9e514e4B19E54E99b62E7b731CE37FF1E6`** | `0xf9e99b9c…` | 56199156 | 966,217 |

Total ≈ **0.00147 ETH**. Deployer `0xe9091668…C808`.

Verified with my own reads (not the deploy script's logs): hook flag bits `0x2888`; `lossRewardPool()` == real production pool `0x697BDA9d…`; `deployer()` == deploying wallet; `GRADUATION_ETH_TARGET` 5.853863234375 ETH / `VIRTUAL_ETH` 2.15625 ETH; permissions exactly the four flags; `hook.factory()`, `factory.hook()`/`poolManager()`, `router.hook()`/`factory()`/`poolManager()` all cross-wired.

## Changes in this PR

- `src/lib/uniswapAddresses.ts` — `INCENTIFI_V4_FACTORY/ROUTER/HOOK` defaults → the new deployment (+ provenance comment). `createEvmToken.ts`/`bondingCurveV4.ts` import these, so they need no edit.
- `scripts/evm-indexer.mjs` — token discovery now watches the new factory.

Typecheck and production build pass.

## Deliberate consequence

TESTTT, TESST and TESTING were launched on the previous hook and are permanently bound to it (a pool's hook address is immutable). They are **no longer resolved by the site or refreshed by the indexer** — single-factory resolution was chosen over multi-factory support since they're test tokens. Their pools remain live and tradeable through the old router `0x0666399…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)