### PR TITLE
Land the V4 re-point on master (PR #9 merged into its stacked base, not master)

### DIFF
--- a/scripts/evm-indexer.mjs
+++ b/scripts/evm-indexer.mjs
@@ -93,7 +93,12 @@ const ERC20_SYMBOL_ABI = parseAbi(['function symbol() view returns (string)']);
 const INCENTIFI_BONDING_CURVE_FACTORY = (process.env.VITE_INCENTIFI_BONDING_CURVE_FACTORY || '0xa0143de84fba1753b887e4e32941e4fb342e473f');
 const LOSS_REWARD_POOL = (process.env.VITE_LOSS_REWARD_POOL || '0x697bda9db5a297a9cd9ed969bbf2549d0527dcdf');
 const INCENTIFI_SWAP_ROUTER = (process.env.VITE_INCENTIFI_SWAP_ROUTER || '0x4c1f4197b5eebb6cc15c37e053f963a56787575e');
-const INCENTIFI_V4_FACTORY = (process.env.VITE_INCENTIFI_V4_FACTORY || '0xdEca2efDB578B6E5F298885b97F64d52f92f5Aa9');
+// The IncentifiV4HookGenericSell factory (see src/lib/uniswapAddresses.ts for the
+// full provenance). Discovery watches THIS factory's TokenLaunched events only:
+// tokens on the previous factory (0xdEca2efD… — TESTTT, TESST, TESTING) are
+// deliberately no longer refreshed here, matching the site's single-factory
+// resolution; their last token_market_snapshots_evm rows simply stop updating.
+const INCENTIFI_V4_FACTORY = (process.env.VITE_INCENTIFI_V4_FACTORY || '0x4166418Ceec501f6d4F6D1fb279d23e7fDD259d0');
 
 // Reference ETH/USD used for price_usd — kept numerically identical to
 // src/lib/bondingCurve.ts's REFERENCE_ETH_USD (also 2500) so V3 and V4 rows in

--- a/src/lib/uniswapAddresses.ts
+++ b/src/lib/uniswapAddresses.ts
@@ -38,29 +38,38 @@ export const INCENTIFI_BONDING_CURVE_FACTORY = String(
 
 // V4: new token launches go through this factory/router/hook instead of the V3
 // ones above (which remain here, unchanged, so already-launched V3 tokens stay
-// tradeable). This is IncentifiV4HookNoPostGradFee — the core, already
-// real-mainnet-proven bonding-curve/graduation logic at full production
-// economics ($5,000 launch / $69,000 graduation), wired to the real production
-// LossRewardPool — WITHOUT the newer afterSwap post-graduation fee mechanism
-// (that 6-flag hook remains deployed and paused pending funding). Once a token
-// launched here graduates, its pool trades with zero Incentifi protocol fee —
-// deliberate, not a bug: see contracts/v4/IncentifiV4HookNoPostGradFee.sol's
-// header comment. Independently verified on-chain (code, cross-wiring,
-// deployer, lossRewardPool == real production pool, GRADUATION_ETH_TARGET ==
-// full production value) before this address was ever used here.
+// tradeable). This is IncentifiV4HookGenericSell — IncentifiV4HookNoPostGradFee's
+// exact bonding-curve/graduation logic at full production economics ($5,000
+// launch / $69,000 graduation), wired to the real production LossRewardPool,
+// no fee of any kind once graduated — PLUS the claims-based sell fix: a
+// pre-graduation sell receives tokens as ERC-6909 claims instead of a physical
+// take(), so generic V4 routers and third-party bots (which settle AFTER
+// swap()) can sell, not only IncentifiV4Router. Root cause, fix rationale and
+// the fork-test evidence: contracts/v4/IncentifiV4HookGenericSell.sol's header.
+// Independently verified on-chain after deployment (flag bits 0x2888,
+// deployer, lossRewardPool == real production pool, GRADUATION_ETH_TARGET /
+// VIRTUAL_ETH == production values, exact 4-flag permission set, and the
+// factory/hook/router cross-wiring) before these addresses were used here.
+//
+// The PREVIOUS hook (IncentifiV4HookNoPostGradFee, 0x5bBcf2CD…) and its factory
+// (0xdEca2efD…) / router (0x0666399…) stay live on-chain. Tokens launched on
+// them (TESTTT, TESST, TESTING) are permanently bound to that hook — a pool's
+// hook address is immutable — and are deliberately NOT resolved by this site
+// any more (a single-factory lookup was chosen over multi-factory support;
+// they were test tokens). Their pools remain tradeable via the old router.
 export const INCENTIFI_V4_FACTORY = String(
-  import.meta.env.VITE_INCENTIFI_V4_FACTORY || '0xdEca2efDB578B6E5F298885b97F64d52f92f5Aa9'
+  import.meta.env.VITE_INCENTIFI_V4_FACTORY || '0x4166418Ceec501f6d4F6D1fb279d23e7fDD259d0'
 ).trim() as `0x${string}`;
 
 export const INCENTIFI_V4_ROUTER = String(
-  import.meta.env.VITE_INCENTIFI_V4_ROUTER || '0x0666399367fa585d672BF793158b35290b7F4082'
+  import.meta.env.VITE_INCENTIFI_V4_ROUTER || '0x762b4D9e514e4B19E54E99b62E7b731CE37FF1E6'
 ).trim() as `0x${string}`;
 
 // The shared hook every V4-launched token's pool uses. Not a per-token
 // contract (unlike the V3 bonding curve) — there is no "curve address" for a
 // V4 token; its state lives in this hook's own curveStates(poolId) mapping.
 export const INCENTIFI_V4_HOOK = String(
-  import.meta.env.VITE_INCENTIFI_V4_HOOK || '0x5bBcf2CDAAA00c285eEc903AA1E2aB9142782888'
+  import.meta.env.VITE_INCENTIFI_V4_HOOK || '0xC5Ef9Cb8c95cd8540E71b6D4c00a90257625a888'
 ).trim() as `0x${string}`;
 
 // Canonical Uniswap Permit2 + UniversalRouter deployments on Robinhood Chain mainnet.


### PR DESCRIPTION
## Why this PR exists

PR #9 (the re-point of new V4 launches to the deployed `IncentifiV4HookGenericSell`) was stacked on `v4-hook-generic-sell` and **merged into that branch, not `master`** — #8 merged 17 seconds earlier without deleting the base branch, so GitHub did not retarget #9. Result: `master` still has the **old** factory/router/hook at `uniswapAddresses.ts` lines 52/56/63, and Vercel built #8's merge without the address change. Nothing malfunctioned; the merge went exactly where #9 was targeted.

This PR carries #9's content to `master`. Since #8 is already in `master`, the diff is exactly the two re-point files — verified:

```
scripts/evm-indexer.mjs     |  7 ++++++-
src/lib/uniswapAddresses.ts | 35 ++++++++++++++++++++++-------------
```

## What it changes (identical to #9)

- `src/lib/uniswapAddresses.ts` — `INCENTIFI_V4_FACTORY/ROUTER/HOOK` defaults → the deployed, on-chain-verified contracts:
  - Hook `0xC5Ef9Cb8c95cd8540E71b6D4c00a90257625a888`
  - Factory `0x4166418Ceec501f6d4F6D1fb279d23e7fDD259d0`
  - Router `0x762b4D9e514e4B19E54E99b62E7b731CE37FF1E6`
- `scripts/evm-indexer.mjs` — token discovery watches the new factory.

Full deployment evidence (tx hashes, gas, per-argument on-chain verification) is in #9's description and the commit message of `7d7c537`.

## After merging

- Confirm Vercel builds a new Production deployment from this merge.
- Check the Vercel project's env: `VITE_INCENTIFI_V4_FACTORY/ROUTER/HOOK` are read first and these addresses are only fallbacks — if those vars are set to the old addresses, the live site keeps launching on the old factory.
- Restart the production indexer (reads its factory constant at startup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)