### PR TITLE
Send loss-reward claims from the holder's wallet instead of the operator relayer

### DIFF
--- a/scripts/claim-loss-rewards.mjs
+++ b/scripts/claim-loss-rewards.mjs
@@ -1,0 +1,199 @@
+/**
+ * Claim loss-reward epochs DIRECTLY from the holder's own wallet (no relayer).
+ *
+ * Why this exists: the gateway's gasless /claim relays claimBatch from the OPERATOR wallet, but
+ * LossRewardPool binds the Merkle leaf (and the payout) to msg.sender — so a relayed claim
+ * reverts InvalidProof (0x09bde339) for every wallet except the operator itself. Until the UI
+ * signs claims from the connected wallet, this script does exactly that, safely.
+ *
+ * Safety pattern (same as tonight's deploy scripts):
+ *   - CLAIMER_PRIVATE_KEY is read from the environment of YOUR shell only; it is never printed.
+ *   - DRY RUN by default: fetches your unclaimed epochs, verifies each proof locally against the
+ *     on-chain root, and SIMULATES the exact claimBatch. Nothing is broadcast.
+ *   - Broadcast only with CLAIM_CONFIRM=I_UNDERSTAND_THIS_IS_MAINNET.
+ *   - After broadcast: waits for the receipt and checks your balance rose by EXACTLY the claimed
+ *     total net of gas, and that hasClaimed() flipped for every epoch.
+ *   - Keyless preview: `--preview 0xYourAddress` runs the read-only part for any address.
+ *
+ * Usage (PowerShell):
+ *   $env:CLAIMER_PRIVATE_KEY = "0x<your key>"
+ *   node scripts/claim-loss-rewards.mjs 0x7F9b8A09877F6e8096b0b8c6027DC49580b05474            # dry run
+ *   $env:CLAIM_CONFIRM = "I_UNDERSTAND_THIS_IS_MAINNET"
+ *   node scripts/claim-loss-rewards.mjs 0x7F9b8A09877F6e8096b0b8c6027DC49580b05474            # real claim
+ *   Remove-Item Env:CLAIMER_PRIVATE_KEY; Remove-Item Env:CLAIM_CONFIRM
+ * Optional: --epochs 26,27 to restrict which epochs to claim.
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { createClient } from '@supabase/supabase-js';
+import {
+  createPublicClient, createWalletClient, http, defineChain, getAddress, parseAbi, formatEther, formatGwei,
+  keccak256, encodeAbiParameters, parseAbiParameters, concat, hexToBigInt,
+} from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+
+// ---- config ---------------------------------------------------------------------------------
+const env = {};
+if (existsSync('.env.local')) {
+  for (const line of readFileSync('.env.local', 'utf8').split(/\r?\n/)) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
+    if (m) env[m[1]] = m[2].replace(/^['"]|['"]$/g, '');
+  }
+}
+const RPC_URL = process.env.VITE_EVM_RPC_URL || env.VITE_EVM_RPC_URL || 'https://rpc.mainnet.chain.robinhood.com';
+const POOL = getAddress(process.env.VITE_LOSS_REWARD_POOL || env.VITE_LOSS_REWARD_POOL || '0x697BDA9db5a297a9Cd9ED969BBF2549d0527DcdF');
+const SUPABASE_URL = env.VITE_SUPABASE_URL || env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
+const SUPABASE_KEY = env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+const CONFIRM = process.env.CLAIM_CONFIRM === 'I_UNDERSTAND_THIS_IS_MAINNET';
+
+const args = process.argv.slice(2);
+const tokenArg = args.find((a) => /^0x[0-9a-fA-F]{40}$/.test(a));
+const previewIdx = args.indexOf('--preview');
+const previewAddr = previewIdx !== -1 ? args[previewIdx + 1] : null;
+const epochsIdx = args.indexOf('--epochs');
+const onlyEpochs = epochsIdx !== -1 ? new Set(args[epochsIdx + 1].split(',').map((s) => Number(s.trim()))) : null;
+if (!tokenArg) {
+  console.error('Usage: node scripts/claim-loss-rewards.mjs <tokenAddress> [--epochs 26,27] [--preview 0xAddress]');
+  process.exit(1);
+}
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing Supabase credentials (.env.local: VITE_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY) - needed to read your unclaimed epochs/proofs.');
+  process.exit(1);
+}
+const TOKEN = getAddress(tokenArg);
+
+const robinhood = defineChain({
+  id: 4663,
+  name: 'Robinhood Chain',
+  nativeCurrency: { name: 'ETH', symbol: 'ETH', decimals: 18 },
+  rpcUrls: { default: { http: [RPC_URL] } },
+});
+const publicClient = createPublicClient({ chain: robinhood, transport: http(RPC_URL, { timeout: 30_000, retryCount: 3, retryDelay: 1500 }) });
+
+// Full ABI INCLUDING the custom errors, so any revert decodes to a name instead of a bare selector.
+const POOL_ABI = parseAbi([
+  'function claimReward(address token, uint256 epochId, uint256 amount, bytes32[] merkleProof)',
+  'function claimBatch(address token, uint256[] epochIds, uint256[] amounts, bytes32[][] merkleProofs)',
+  'function epochMerkleRoots(address token, uint256 epochId) view returns (bytes32)',
+  'function hasClaimed(address token, uint256 epochId, address claimant) view returns (bool)',
+  'error Unauthorized()',
+  'error ZeroAddress()',
+  'error ZeroAmount()',
+  'error EpochAlreadyPublished()',
+  'error InsufficientUnallocatedPool()',
+  'error InvalidMerkleRoot()',
+  'error EpochNotPublished()',
+  'error AlreadyClaimed()',
+  'error InvalidProof()',
+  'error EthTransferFailed()',
+  'error ArrayLengthMismatch()',
+  'error ReentrancyGuardReentrantCall()',
+]);
+
+// ---- who is claiming ------------------------------------------------------------------------
+let account = null;
+let claimer;
+if (previewAddr) {
+  claimer = getAddress(previewAddr);
+  console.log(`PREVIEW MODE (read-only, no key) for ${claimer}`);
+} else {
+  const pk = process.env.CLAIMER_PRIVATE_KEY;
+  if (!pk) {
+    console.error('CLAIMER_PRIVATE_KEY is not set in this shell (or use --preview 0xAddress for a keyless dry run).');
+    process.exit(1);
+  }
+  account = privateKeyToAccount(pk.startsWith('0x') ? pk : `0x${pk}`);
+  claimer = account.address;
+  console.log(`Claimer wallet (derived from CLAIMER_PRIVATE_KEY; the key itself is never printed): ${claimer}`);
+}
+const mode = previewAddr ? 'preview' : CONFIRM ? '*** BROADCAST (mainnet) ***' : 'DRY RUN (set CLAIM_CONFIRM=I_UNDERSTAND_THIS_IS_MAINNET to broadcast)';
+console.log(`Token: ${TOKEN}\nPool:  ${POOL}\nRPC:   ${RPC_URL}\nMode:  ${mode}\n`);
+
+// ---- fetch unclaimed published epochs for (token, claimer) -----------------------------------
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
+const { data: rows, error } = await supabase
+  .from('epoch_holder_rewards')
+  .select('id, epoch_id, final_reward_eth, merkle_proof, claimed, reward_epochs!inner(epoch_number, status, merkle_root)')
+  .eq('token_address', TOKEN.toLowerCase())
+  .eq('wallet_address', claimer.toLowerCase())
+  .eq('claimed', false);
+if (error) {
+  console.error(`DB error: ${error.code} ${error.message}`);
+  process.exit(1);
+}
+
+// Leaf exactly as LossRewardPool._claimEpoch computes it: keccak256(bytes.concat(keccak256(abi.encode(token, epochId, claimant, amount))))
+const leafFor = (epochNumber, amountWei) =>
+  keccak256(keccak256(encodeAbiParameters(parseAbiParameters('address,uint256,address,uint256'), [TOKEN, BigInt(epochNumber), claimer, amountWei])));
+// OpenZeppelin MerkleProof: sorted-pair hashing up the tree; an empty proof means leaf == root.
+const verifyProof = (leaf, proof, root) => {
+  let h = leaf;
+  for (const p of proof) h = hexToBigInt(h) < hexToBigInt(p) ? keccak256(concat([h, p])) : keccak256(concat([p, h]));
+  return h === root;
+};
+
+const candidates = [];
+for (const r of rows || []) {
+  const epochNumber = Number(r.reward_epochs?.epoch_number ?? r.epoch_id);
+  if (onlyEpochs && !onlyEpochs.has(epochNumber)) continue;
+  if (r.reward_epochs?.status !== 'published') {
+    console.log(`  skip epoch #${epochNumber}: status=${r.reward_epochs?.status} (not published)`);
+    continue;
+  }
+  const amountWei = BigInt(Math.round(Number(r.final_reward_eth) * 1e18)); // same rounding the worker/gateway use
+  const proof = Array.isArray(r.merkle_proof) ? r.merkle_proof : [];
+  const [rootChain, claimed] = await Promise.all([
+    publicClient.readContract({ address: POOL, abi: POOL_ABI, functionName: 'epochMerkleRoots', args: [TOKEN, BigInt(epochNumber)] }),
+    publicClient.readContract({ address: POOL, abi: POOL_ABI, functionName: 'hasClaimed', args: [TOKEN, BigInt(epochNumber), claimer] }),
+  ]);
+  const unset = /^0x0+$/.test(rootChain);
+  const ok = !unset && !claimed && verifyProof(leafFor(epochNumber, amountWei), proof, rootChain);
+  console.log(
+    `  epoch #${epochNumber}: ${formatEther(amountWei)} ETH (${amountWei} wei) proof_len=${proof.length} root_on_chain=${unset ? 'UNSET' : rootChain.slice(0, 10) + '...'} hasClaimed=${claimed} local_proof_check=${ok ? 'VALID' : 'INVALID/SKIP'}`
+  );
+  if (ok) candidates.push({ epochNumber, amountWei, proof });
+}
+if (candidates.length === 0) {
+  console.log('\nNothing claimable for this wallet on this token.');
+  process.exit(0);
+}
+candidates.sort((a, b) => a.epochNumber - b.epochNumber);
+const total = candidates.reduce((s, c) => s + c.amountWei, 0n);
+const callArgs = [TOKEN, candidates.map((c) => BigInt(c.epochNumber)), candidates.map((c) => c.amountWei), candidates.map((c) => c.proof)];
+console.log(`\nclaimBatch(${TOKEN}, [${callArgs[1].join(',')}], [${callArgs[2].join(',')}], [${callArgs[3].map((p) => '[' + p.join(',') + ']').join(',')}])`);
+console.log(`Total to claim: ${formatEther(total)} ETH (${total} wei) across ${candidates.length} epoch(s)`);
+
+// ---- simulate (exactly what will be sent, as the claimer) -----------------------------------
+try {
+  await publicClient.simulateContract({ address: POOL, abi: POOL_ABI, functionName: 'claimBatch', args: callArgs, account: claimer });
+  const gas = await publicClient.estimateContractGas({ address: POOL, abi: POOL_ABI, functionName: 'claimBatch', args: callArgs, account: claimer });
+  const gasPrice = await publicClient.getGasPrice();
+  const fee = gas * gasPrice;
+  console.log(`Simulation: OK. Estimated gas ${gas} @ ${formatGwei(gasPrice)} gwei = ${formatEther(fee)} ETH fee (reward is ${(Number(total) / Number(fee)).toFixed(1)}x the fee)`);
+} catch (e) {
+  console.error(`Simulation FAILED - not broadcasting. Decoded: ${e.shortMessage || e.message}`);
+  process.exit(1);
+}
+
+if (previewAddr || !CONFIRM) {
+  console.log('\nDRY RUN complete - nothing was broadcast.');
+  process.exit(0);
+}
+
+// ---- broadcast ------------------------------------------------------------------------------
+const walletClient = createWalletClient({ account, chain: robinhood, transport: http(RPC_URL, { timeout: 30_000, retryCount: 3, retryDelay: 1500 }) });
+const balBefore = await publicClient.getBalance({ address: claimer });
+console.log(`\nBroadcasting claimBatch from ${claimer} ...`);
+const hash = await walletClient.writeContract({ address: POOL, abi: POOL_ABI, functionName: 'claimBatch', args: callArgs });
+console.log(`tx hash: ${hash}\nWaiting for receipt...`);
+const receipt = await publicClient.waitForTransactionReceipt({ hash, timeout: 180_000 });
+const fee = receipt.gasUsed * receipt.effectiveGasPrice;
+const balAfter = await publicClient.getBalance({ address: claimer });
+const netDelta = balAfter - balBefore + fee;
+console.log(`status=${receipt.status} block=${receipt.blockNumber} gasUsed=${receipt.gasUsed} fee=${formatEther(fee)} ETH`);
+console.log(`balance delta net of gas = ${formatEther(netDelta)} ETH -> ${netDelta === total ? 'EXACTLY the claimed total (OK)' : 'MISMATCH (expected ' + formatEther(total) + ')'}`);
+for (const c of candidates) {
+  const claimed = await publicClient.readContract({ address: POOL, abi: POOL_ABI, functionName: 'hasClaimed', args: [TOKEN, BigInt(c.epochNumber), claimer] });
+  console.log(`  hasClaimed(epoch #${c.epochNumber}) = ${claimed}${claimed ? ' (OK)' : ' (NOT SET?)'}`);
+}
+console.log('\nNote: the site marks these rows claimed automatically the next time the token page loads (the gateway reconciles against hasClaimed on-chain).');
+if (receipt.status !== 'success') process.exit(1);

--- a/src/lib/lossReward.ts
+++ b/src/lib/lossReward.ts
@@ -1,15 +1,11 @@
-import { encodeFunctionData, parseAbi, getAddress } from 'viem';
+import { encodeFunctionData, parseAbi, getAddress, formatEther } from 'viem';
 import { supabase } from './supabase';
-import { publicClient } from './evmNetwork';
+import { publicClient, getEvmProvider, ensureEvmChain, waitForTransactionReceipt } from './evmNetwork';
 import { LOSS_REWARD_POOL } from './uniswapAddresses';
-import {
-  getStoredSession,
-  fetchLossRewardData,
-  getGatewayBaseUrl,
-  authenticateWallet,
-  clearStoredSession,
-} from './lossRewardAuth';
+import { getStoredSession, fetchLossRewardData } from './lossRewardAuth';
 
+// Includes LossRewardPool's custom errors so a pre-flight simulation of a claim decodes a
+// revert to its name (e.g. AlreadyClaimed / InvalidProof) instead of a bare 4-byte selector.
 const LOSS_POOL_ABI = parseAbi([
   'function getUnallocatedBalance(address token) view returns (uint256)',
   'function totalDeposited(address token) view returns (uint256)',
@@ -18,6 +14,12 @@ const LOSS_POOL_ABI = parseAbi([
   'function hasClaimed(address token, uint256 epochId, address account) view returns (bool)',
   'function claimReward(address token, uint256 epochId, uint256 amount, bytes32[] calldata merkleProof)',
   'function claimBatch(address token, uint256[] calldata epochIds, uint256[] calldata amounts, bytes32[][] calldata merkleProofs)',
+  'error EpochNotPublished()',
+  'error AlreadyClaimed()',
+  'error InvalidProof()',
+  'error EthTransferFailed()',
+  'error ArrayLengthMismatch()',
+  'error ReentrancyGuardReentrantCall()',
 ]);
 
 /** Snapshot interval: 5 minutes (300 seconds) */
@@ -65,6 +67,8 @@ export type UnclaimedEpoch = {
   epochId: number;
   epochNumber: number;
   finalRewardEth: number;
+  /** Exact wei amount as the gateway computed it (BigInt(Math.round(finalRewardEth * 1e18)).toString()). */
+  amountWei?: string;
   merkleProof: string[];
 };
 
@@ -175,7 +179,7 @@ export const getClaimableRewards = async (
 };
 
 /**
- * Execute gasless on-chain claim for a single or multiple epochs via authenticated relayer gateway.
+ * Claim one or more epochs — a thin alias for claimBatchRewards kept for existing call sites.
  */
 export const claimReward = async (
   tokenAddress: string,
@@ -188,56 +192,106 @@ export const claimReward = async (
   return claimBatchRewards(tokenAddress, walletAddress);
 };
 
+export type ClaimResult = {
+  success: boolean;
+  txHash: string | null;
+  claimedEth?: string;
+  alreadyClaimed?: boolean;
+  message?: string;
+};
+
 /**
- * Execute gasless on-chain batch claim for all uncollected epochs in a single transaction via server relayer.
+ * Claim every uncollected published epoch for (token, wallet) in ONE transaction, signed and sent
+ * by the user's own connected wallet — the same eth_sendTransaction path buys and sells use.
+ *
+ * Why not the gateway's relayer: LossRewardPool binds each Merkle leaf (and the ETH payout) to
+ * msg.sender (`_claimEpoch(..., msg.sender)`), and the worker builds leaves for the HOLDER. A claim
+ * relayed from the operator wallet therefore reverts InvalidProof for every wallet except the
+ * operator itself — and even a matching leaf would pay the operator, not the holder. Only the
+ * holder's wallet can be msg.sender, so the holder must sign.
+ *
+ * The authenticated gateway is still the source of truth for WHAT is claimable (`/query` returns
+ * the unclaimed epochs, exact wei amounts and Merkle proofs, reconciled against on-chain
+ * hasClaimed); callers may pass that list in to avoid a second round-trip.
  */
 export const claimBatchRewards = async (
   tokenAddress: string,
   walletAddress: string,
-  _unclaimedEpochs?: UnclaimedEpoch[]
-): Promise<{ success: boolean; txHash: string | null; claimedEth?: string; alreadyClaimed?: boolean; message?: string }> => {
+  unclaimedEpochs?: UnclaimedEpoch[]
+): Promise<ClaimResult> => {
   if (!tokenAddress || !walletAddress) {
     throw new Error('Token address and connected wallet are required.');
   }
+  const token = getAddress(tokenAddress);
+  const wallet = getAddress(walletAddress);
 
-  const normalizedWallet = getAddress(walletAddress).toLowerCase();
-  let sessionToken = getStoredSession(normalizedWallet);
-
-  // If session token is missing or expired, prompt gas-free EIP-191 signature
-  if (!sessionToken) {
-    sessionToken = await authenticateWallet(walletAddress);
+  // 1. What is claimable — from the caller's already-fetched state, else the authenticated gateway.
+  let epochs = (unclaimedEpochs || []).filter((e) => Number.isFinite(e.epochNumber));
+  if (epochs.length === 0) {
+    const data = await fetchLossRewardData(token, wallet);
+    epochs = data.claimable.unclaimedEpochs || [];
+  }
+  if (epochs.length === 0) {
+    return { success: true, txHash: null, claimedEth: '0', alreadyClaimed: true, message: 'No claimable rewards available.' };
   }
 
-  const gatewayUrl = getGatewayBaseUrl();
-  const makeRequest = async (token: string) => {
-    return await fetch(`${gatewayUrl}/claim`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-        apikey: (import.meta.env.VITE_SUPABASE_ANON_KEY || '').trim(),
-      },
-      body: JSON.stringify({
-        tokenAddress: getAddress(tokenAddress),
-      }),
-    });
-  };
-
-  let response = await makeRequest(sessionToken);
-
-  if (response.status === 401) {
-    // Session expired: clear and re-authenticate once
-    clearStoredSession(normalizedWallet);
-    const newSessionToken = await authenticateWallet(walletAddress);
-    response = await makeRequest(newSessionToken);
+  // 2. The connected wallet MUST be the holder the proofs were built for.
+  const provider = getEvmProvider();
+  if (!provider) throw new Error('No EVM wallet detected. Please connect your wallet.');
+  await ensureEvmChain();
+  const accounts = (await provider.request({ method: 'eth_accounts' })) as string[];
+  const sender = accounts?.[0];
+  if (!sender) throw new Error('Wallet is connected, but no active account was found.');
+  if (getAddress(sender) !== wallet) {
+    throw new Error(
+      `The wallet's active account (${sender.slice(0, 6)}…${sender.slice(-4)}) is not the holder these rewards belong to ` +
+        `(${wallet.slice(0, 6)}…${wallet.slice(-4)}). Switch accounts in your wallet and try again.`
+    );
   }
 
-  if (!response.ok) {
-    const err = await response.json().catch(() => ({}));
-    throw new Error(err.error || `Gasless claim request failed (${response.status})`);
+  // 3. Exact arguments. amountWei is the gateway's exact figure when present; the fallback is the
+  //    identical rounding the worker used to build the leaf, so the two can't drift.
+  const sorted = [...epochs].sort((a, b) => a.epochNumber - b.epochNumber);
+  const epochIds = sorted.map((e) => BigInt(e.epochNumber));
+  const amounts = sorted.map((e) => (e.amountWei ? BigInt(e.amountWei) : BigInt(Math.round(e.finalRewardEth * 1e18))));
+  const proofs = sorted.map((e) => (Array.isArray(e.merkleProof) ? e.merkleProof : []) as `0x${string}`[]);
+  const totalWei = amounts.reduce((s, a) => s + a, 0n);
+  const pool = getAddress(LOSS_REWARD_POOL);
+
+  const call =
+    sorted.length === 1
+      ? ({ functionName: 'claimReward', args: [token, epochIds[0], amounts[0], proofs[0]] } as const)
+      : ({ functionName: 'claimBatch', args: [token, epochIds, amounts, proofs] } as const);
+
+  // 4. Pre-flight the exact call as the sender so a revert surfaces by name (AlreadyClaimed,
+  //    InvalidProof, …) BEFORE the wallet prompts — instead of a failed tx the user paid for.
+  try {
+    await publicClient.simulateContract({ address: pool, abi: LOSS_POOL_ABI, account: wallet, ...call } as any);
+  } catch (err: any) {
+    // Wallet RPCs differ in where the decoded reason lands (shortMessage vs details vs cause);
+    // look at all of them before deciding.
+    const fullText = [err?.shortMessage, err?.message, err?.details, err?.cause?.message, err?.cause?.details]
+      .filter(Boolean)
+      .join(' ');
+    if (/AlreadyClaimed/.test(fullText)) {
+      return { success: true, txHash: null, claimedEth: '0', alreadyClaimed: true, message: 'Rewards were already claimed on-chain.' };
+    }
+    throw new Error(`Claim would revert on-chain: ${err?.shortMessage || err?.message || String(err)}`);
   }
 
-  return await response.json();
+  // 5. Send from the user's wallet — identical mechanics to executeV4Buy / swap.ts.
+  const data = encodeFunctionData({ abi: LOSS_POOL_ABI, ...call } as any);
+  const txHash = (await provider.request({
+    method: 'eth_sendTransaction',
+    params: [{ from: sender, to: pool, data }],
+  })) as string;
+
+  await waitForTransactionReceipt(txHash, {
+    description: 'Reward claim',
+    revertedMessage: 'Reward claim reverted on-chain. Nothing was paid out.',
+  });
+
+  return { success: true, txHash, claimedEth: formatEther(totalWei) };
 };
 
 /**

--- a/test/hardhat/wallet-claim-fork.test.ts
+++ b/test/hardhat/wallet-claim-fork.test.ts
@@ -1,0 +1,301 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { network } from 'hardhat';
+import http from 'node:http';
+import fs from 'node:fs';
+import { parseEther, getAddress, keccak256, encodeAbiParameters, parseAbiParameters, formatEther } from 'viem';
+import { createServer as createViteServer } from 'vite';
+import { createClient } from '@supabase/supabase-js';
+
+/**
+ * WALLET-SIGNED CLAIM — fork test for src/lib/lossReward.ts claimBatchRewards().
+ *
+ * The bug this replaces: the gateway's "gasless" /claim relayed claimBatch from the OPERATOR
+ * wallet, but LossRewardPool binds each Merkle leaf and the payout to msg.sender — so it reverted
+ * InvalidProof for every wallet except the operator itself (the only wallet that ever claimed).
+ *
+ * What is REAL here: the production LossRewardPool at its real address on a mainnet fork, the
+ * real, unmodified frontend module (loaded through Vite SSR exactly as scripts/evm-indexer.mjs
+ * loads bondingCurveV4.ts), real eth_sendTransaction transactions signed by the fork's accounts,
+ * real receipts, and exact wei balance deltas net of gas. The only stand-in is `window.ethereum`:
+ * a minimal EIP-1193 object that answers account/chain queries and forwards everything else
+ * (eth_sendTransaction included) to the fork — i.e. what a wallet extension does, minus the popup.
+ *
+ * Scenario B (always runs): the impersonated pool OWNER publishes synthetic epochs whose single
+ * leaf belongs to a fresh test wallet; that wallet claims them through the real function —
+ * batch (2 epochs, claimBatch path), single (claimReward path), double-claim (must short-circuit
+ * as alreadyClaimed with NO transaction), wrong-active-account (must refuse before any tx).
+ *
+ * Scenario A (runs when possible): the REAL holder 0xba69…5cE claims its REAL published TESTINGG
+ * epochs — amounts/proofs read from production Supabase (read-only) — impersonated on the fork.
+ * Skipped with a clear message if the holder already claimed on mainnet before the fork block.
+ *
+ * Run (isolated — node:test shares a process across files):
+ *   npx hardhat test nodejs --network robinhoodFork -- test/hardhat/wallet-claim-fork.test.ts
+ */
+
+const POOL = getAddress('0x697BDA9db5a297a9Cd9ED969BBF2549d0527DcdF');
+const OWNER = getAddress('0x78a4E4BCC8ab559B6d3B1Cb9eab0A04a2411c726'); // owner == operator on the real pool
+const TESTINGG = getAddress('0x7F9b8A09877F6e8096b0b8c6027DC49580b05474');
+const HOLDER = getAddress('0xba69Ca72CD2B87113471c4C38f08928761Edb5cE');
+
+// Exactly LossRewardPool._claimEpoch's leaf: keccak256(bytes.concat(keccak256(abi.encode(token, epochId, claimant, amount))))
+const leafFor = (token: `0x${string}`, epochId: bigint, claimant: `0x${string}`, amount: bigint) =>
+  keccak256(keccak256(encodeAbiParameters(parseAbiParameters('address,uint256,address,uint256'), [token, epochId, claimant, amount])));
+
+// Hardhat/EDR surfaces revert bytes in different places depending on the error type; a real
+// JSON-RPC node returns them as `error.data` (hex). Normalise so viem can decode custom errors
+// through the proxy exactly as it would against mainnet.
+let loggedErrorShape = false;
+function extractRevertData(err: any): string | undefined {
+  const candidates = [err?.data?.data, err?.data, err?.cause?.data?.data, err?.cause?.data, err?.error?.data];
+  for (const c of candidates) if (typeof c === 'string' && /^0x[0-9a-fA-F]{8,}$/.test(c)) return c;
+  const text = [err?.message, err?.details, err?.cause?.message, err?.data?.message].filter(Boolean).join(' ');
+  const m = text.match(/0x[0-9a-fA-F]{8,}/);
+  return m ? m[0] : undefined;
+}
+
+async function startRpcProxy(provider: { request: (args: { method: string; params?: unknown[] }) => Promise<unknown> }) {
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (chunk) => (body += chunk));
+    req.on('end', async () => {
+      try {
+        const payload = JSON.parse(body);
+        const handleOne = async (item: any) => {
+          try {
+            return { jsonrpc: '2.0', id: item.id, result: await provider.request({ method: item.method, params: item.params }) };
+          } catch (err: any) {
+            if (!loggedErrorShape) {
+              loggedErrorShape = true;
+              console.log(`  [proxy] first provider error shape: keys=${JSON.stringify(Object.keys(err || {}))} data=${JSON.stringify(err?.data)} message=${JSON.stringify(err?.message).slice(0, 200)}`);
+            }
+            const data = extractRevertData(err);
+            return { jsonrpc: '2.0', id: item.id, error: { code: data ? 3 : (err?.code ?? -32000), message: err?.shortMessage || err?.message || String(err), data } };
+          }
+        };
+        const out = Array.isArray(payload) ? await Promise.all(payload.map(handleOne)) : await handleOne(payload);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(out));
+      } catch (err: any) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: String(err) }));
+      }
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  const port = typeof address === 'object' && address ? address.port : 0;
+  return { server, url: `http://127.0.0.1:${port}` };
+}
+
+// Last definition wins, exactly like the scripts' own .env.local loaders (a key defined twice in
+// the file resolves to its later value there too).
+function readEnvLocal(key: string): string | undefined {
+  if (!fs.existsSync('.env.local')) return undefined;
+  let value: string | undefined;
+  for (const line of fs.readFileSync('.env.local', 'utf8').split(/\r?\n/)) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
+    if (m && m[1] === key) value = m[2].replace(/^['"]|['"]$/g, '');
+  }
+  return value;
+}
+
+describe('Wallet-signed loss-reward claim (real pool on mainnet fork, real frontend module, exact balance deltas)', () => {
+  it('claims from the holder wallet: batch, single, double-claim guard, wrong-account guard, and the real holder if still unclaimed', async () => {
+    const { viem, networkHelpers, provider } = await network.create('robinhoodFork');
+    const publicClient = await viem.getPublicClient();
+    const [, , claimantWallet, strangerWallet] = await viem.getWalletClients();
+    const CLAIMANT = getAddress(claimantWallet.account.address);
+    const STRANGER = getAddress(strangerWallet.account.address);
+    await networkHelpers.setBalance(CLAIMANT, parseEther('1'));
+    await networkHelpers.setBalance(STRANGER, parseEther('1'));
+    // EDR refuses to execute a call at exactly the fork block on this chain — mine one first.
+    await networkHelpers.mine(1);
+
+    console.log('--- Fork setup ---');
+    console.log('Forked at block:', await publicClient.getBlockNumber());
+    const code = await publicClient.getCode({ address: POOL });
+    assert.ok(code && code !== '0x', 'real LossRewardPool must have code on the fork');
+
+    const rpcProxy = await startRpcProxy(provider);
+    console.log('Local RPC proxy (same fork state):', rpcProxy.url);
+
+    let vite: Awaited<ReturnType<typeof createViteServer>> | null = null;
+    try {
+      // The frontend resolves its RPC from import.meta.env.VITE_EVM_RPC_URL at module load; point
+      // it at the fork BEFORE Vite starts, then PROVE it took effect — otherwise the "real function"
+      // would be quietly hitting mainnet.
+      process.env.VITE_EVM_RPC_URL = rpcProxy.url;
+      vite = await createViteServer({ server: { middlewareMode: true }, appType: 'custom', logLevel: 'error' });
+      const evmNetwork = await vite.ssrLoadModule('/src/lib/evmNetwork.ts');
+      assert.equal(evmNetwork.EVM_RPC_URL, rpcProxy.url, 'frontend module must be wired to the fork proxy, not mainnet');
+      const lossReward = await vite.ssrLoadModule('/src/lib/lossReward.ts');
+      assert.equal(typeof lossReward.claimBatchRewards, 'function');
+      console.log('Real src/lib/lossReward.ts loaded via Vite SSR; EVM_RPC_URL =', evmNetwork.EVM_RPC_URL);
+
+      // Minimal EIP-1193 wallet: answers accounts/chain-switch itself, forwards everything else
+      // (eth_sendTransaction, eth_getTransactionReceipt, eth_chainId, ...) to the fork.
+      let activeAccount: `0x${string}` = CLAIMANT;
+      const sent: string[] = [];
+      (globalThis as any).window = {
+        ethereum: {
+          request: async ({ method, params }: { method: string; params?: unknown[] }) => {
+            if (method === 'eth_accounts' || method === 'eth_requestAccounts') return [activeAccount];
+            if (method === 'wallet_switchEthereumChain' || method === 'wallet_addEthereumChain') return null;
+            const result = await provider.request({ method, params });
+            if (method === 'eth_sendTransaction') sent.push(result as string);
+            return result;
+          },
+        },
+      };
+
+      const pool = await viem.getContractAt('LossRewardPool', POOL);
+      await networkHelpers.impersonateAccount(OWNER);
+      await networkHelpers.setBalance(OWNER, parseEther('1'));
+      const ownerWallet = await viem.getWalletClient(OWNER);
+      assert.equal(getAddress(await pool.read.owner()), OWNER, 'impersonated account must be the real pool owner');
+
+      const claimVia = async (wallet: `0x${string}`, epochs: any[]) => {
+        const before = await publicClient.getBalance({ address: wallet });
+        const sentBefore = sent.length;
+        const res = await lossReward.claimBatchRewards(TESTINGG, wallet, epochs);
+        const after = await publicClient.getBalance({ address: wallet });
+        let fee = 0n;
+        let tx: any = null;
+        let receipt: any = null;
+        if (res.txHash) {
+          receipt = await publicClient.getTransactionReceipt({ hash: res.txHash });
+          tx = await publicClient.getTransaction({ hash: res.txHash });
+          fee = receipt.gasUsed * receipt.effectiveGasPrice;
+        }
+        return { res, netDelta: after - before + fee, tx, receipt, txsSent: sent.length - sentBefore };
+      };
+
+      // ================================================================================
+      // SCENARIO B — synthetic epochs published by the real owner, claimed by a fresh wallet.
+      // ================================================================================
+      console.log('\n=== SCENARIO B: owner publishes synthetic epochs; fresh wallet claims via the real function ===');
+      const unallocated = await pool.read.getUnallocatedBalance([TESTINGG]);
+      const synth = [
+        { epochNumber: 900001, amountWei: 1_000_000_000_000_000n },
+        { epochNumber: 900002, amountWei: 700_000_000_000_000n },
+        { epochNumber: 900003, amountWei: 300_000_000_000_000n },
+      ];
+      const synthTotal = synth.reduce((s, e) => s + e.amountWei, 0n);
+      console.log(`Pool unallocated for TESTINGG: ${formatEther(unallocated)} ETH; publishing ${formatEther(synthTotal)} ETH across 3 synthetic epochs`);
+      assert.ok(unallocated >= synthTotal, 'real pool must have enough unallocated ETH to fund the synthetic epochs');
+      for (const e of synth) {
+        const root = leafFor(TESTINGG, BigInt(e.epochNumber), CLAIMANT, e.amountWei);
+        await publicClient.waitForTransactionReceipt({
+          hash: await pool.write.setEpochMerkleRoot([TESTINGG, BigInt(e.epochNumber), root, e.amountWei], { account: ownerWallet.account }),
+        });
+        assert.equal(await pool.read.epochMerkleRoots([TESTINGG, BigInt(e.epochNumber)]), root, `epoch #${e.epochNumber} root must be on-chain`);
+      }
+      const asUnclaimed = (e: { epochNumber: number; amountWei: bigint }) => ({
+        id: e.epochNumber, epochId: e.epochNumber, epochNumber: e.epochNumber,
+        finalRewardEth: Number(e.amountWei) / 1e18, amountWei: e.amountWei.toString(), merkleProof: [],
+      });
+
+      // B1: batch of two -> claimBatch path
+      console.log('\n[B1] batch claim of epochs 900001 + 900002');
+      const b1 = await claimVia(CLAIMANT, [asUnclaimed(synth[1]), asUnclaimed(synth[0])]); // deliberately unsorted
+      assert.equal(b1.res.success, true);
+      assert.ok(b1.res.txHash, 'a real tx hash must be returned');
+      assert.equal(b1.receipt.status, 'success');
+      assert.equal(getAddress(b1.tx.from), CLAIMANT, 'tx MUST be sent by the holder wallet — not the operator');
+      assert.notEqual(getAddress(b1.tx.from), OWNER, 'tx must NOT come from the operator/owner wallet');
+      assert.equal(getAddress(b1.tx.to), POOL);
+      assert.equal(b1.netDelta, synth[0].amountWei + synth[1].amountWei, 'balance must rise by EXACTLY the two rewards, net of gas');
+      assert.equal(b1.res.claimedEth, formatEther(synth[0].amountWei + synth[1].amountWei));
+      assert.equal(await pool.read.hasClaimed([TESTINGG, 900001n, CLAIMANT]), true);
+      assert.equal(await pool.read.hasClaimed([TESTINGG, 900002n, CLAIMANT]), true);
+      console.log(`  tx ${b1.res.txHash} from=${b1.tx.from} gasUsed=${b1.receipt.gasUsed} | net delta ${formatEther(b1.netDelta)} ETH == ${formatEther(synth[0].amountWei + synth[1].amountWei)} ETH  PASS`);
+
+      // B2: single -> claimReward path
+      console.log('\n[B2] single claim of epoch 900003');
+      const b2 = await claimVia(CLAIMANT, [asUnclaimed(synth[2])]);
+      assert.equal(b2.receipt.status, 'success');
+      assert.equal(getAddress(b2.tx.from), CLAIMANT);
+      assert.equal(b2.netDelta, synth[2].amountWei, 'single claim must pay exactly its amount net of gas');
+      assert.equal(await pool.read.hasClaimed([TESTINGG, 900003n, CLAIMANT]), true);
+      console.log(`  tx ${b2.res.txHash} | net delta ${formatEther(b2.netDelta)} ETH == ${formatEther(synth[2].amountWei)} ETH  PASS`);
+
+      // B3: double-claim -> must short-circuit as alreadyClaimed, sending NO transaction
+      console.log('\n[B3] double-claim of epoch 900001 (must not send a tx)');
+      const b3 = await claimVia(CLAIMANT, [asUnclaimed(synth[0])]);
+      assert.equal(b3.res.alreadyClaimed, true, 'pre-flight must decode AlreadyClaimed and return alreadyClaimed');
+      assert.equal(b3.res.txHash, null);
+      assert.equal(b3.txsSent, 0, 'no eth_sendTransaction may be issued for an already-claimed epoch');
+      assert.equal(b3.netDelta, 0n);
+      console.log('  short-circuited as alreadyClaimed, 0 transactions sent  PASS');
+
+      // B4: wrong active account -> must refuse before any tx
+      console.log('\n[B4] wallet active account != holder (must refuse before sending)');
+      const rootStranger = leafFor(TESTINGG, 900004n, CLAIMANT, 100_000_000_000_000n);
+      await publicClient.waitForTransactionReceipt({ hash: await pool.write.setEpochMerkleRoot([TESTINGG, 900004n, rootStranger, 100_000_000_000_000n], { account: ownerWallet.account }) });
+      activeAccount = STRANGER;
+      const sentBeforeB4 = sent.length;
+      await assert.rejects(
+        lossReward.claimBatchRewards(TESTINGG, CLAIMANT, [asUnclaimed({ epochNumber: 900004, amountWei: 100_000_000_000_000n })]),
+        /not the holder these rewards belong to/,
+        'must refuse when the connected account is not the holder'
+      );
+      assert.equal(sent.length - sentBeforeB4, 0, 'no transaction may be sent from the wrong account');
+      assert.equal(await pool.read.hasClaimed([TESTINGG, 900004n, CLAIMANT]), false);
+      activeAccount = CLAIMANT;
+      console.log('  refused with a clear error, 0 transactions sent  PASS');
+
+      // ================================================================================
+      // SCENARIO A — the REAL holder claims its REAL published TESTINGG epochs (if unclaimed).
+      // ================================================================================
+      console.log('\n=== SCENARIO A: real holder, real published epochs (read-only DB read, claim on fork) ===');
+      const sbUrl = readEnvLocal('VITE_SUPABASE_URL') || readEnvLocal('SUPABASE_URL');
+      const sbKey = readEnvLocal('SUPABASE_SERVICE_ROLE_KEY');
+      if (!sbUrl || !sbKey) {
+        console.log('  SKIPPED: no Supabase credentials in .env.local to read the real proofs.');
+      } else {
+        const sb = createClient(sbUrl, sbKey, { auth: { persistSession: false } });
+        const { data: rows, error } = await sb
+          .from('epoch_holder_rewards')
+          .select('id, epoch_id, final_reward_eth, merkle_proof, reward_epochs!inner(epoch_number, status)')
+          .eq('token_address', TESTINGG.toLowerCase())
+          .eq('wallet_address', HOLDER.toLowerCase())
+          .eq('claimed', false);
+        assert.equal(error, null, `DB read failed: ${error?.message}`);
+        const real: any[] = [];
+        for (const r of rows || []) {
+          if ((r as any).reward_epochs?.status !== 'published') continue;
+          const epochNumber = Number((r as any).reward_epochs.epoch_number);
+          const amountWei = BigInt(Math.round(Number(r.final_reward_eth) * 1e18));
+          const root = await pool.read.epochMerkleRoots([TESTINGG, BigInt(epochNumber)]);
+          const claimed = await pool.read.hasClaimed([TESTINGG, BigInt(epochNumber), HOLDER]);
+          if (/^0x0+$/.test(root) || claimed) continue;
+          real.push({ id: r.id, epochId: r.epoch_id, epochNumber, finalRewardEth: Number(r.final_reward_eth), amountWei: amountWei.toString(), merkleProof: Array.isArray(r.merkle_proof) ? r.merkle_proof : [] });
+        }
+        if (real.length === 0) {
+          console.log('  SKIPPED: the real holder has no unclaimed published epochs at the fork block (already claimed on mainnet).');
+        } else {
+          const realTotal = real.reduce((s, e) => s + BigInt(e.amountWei), 0n);
+          console.log(`  ${real.length} real unclaimed epoch(s) [${real.map((e) => e.epochNumber).join(', ')}], total ${formatEther(realTotal)} ETH`);
+          await networkHelpers.impersonateAccount(HOLDER);
+          await networkHelpers.setBalance(HOLDER, parseEther('1')); // gas only; the reward is paid by the pool
+          activeAccount = HOLDER;
+          const a = await claimVia(HOLDER, real);
+          assert.equal(a.receipt.status, 'success');
+          assert.equal(getAddress(a.tx.from), HOLDER, 'the real holder must be msg.sender');
+          assert.equal(a.netDelta, realTotal, 'real holder balance must rise by EXACTLY the sum of its published rewards, net of gas');
+          for (const e of real) assert.equal(await pool.read.hasClaimed([TESTINGG, BigInt(e.epochNumber), HOLDER]), true, `epoch #${e.epochNumber} must be marked claimed`);
+          console.log(`  tx ${a.res.txHash} from=${a.tx.from} gasUsed=${a.receipt.gasUsed} | net delta ${formatEther(a.netDelta)} ETH == ${formatEther(realTotal)} ETH  PASS`);
+        }
+      }
+
+      console.log('\n=== RESULT: wallet-signed claims verified against the real pool with exact balance deltas ===');
+    } finally {
+      if (vite) await vite.close();
+      rpcProxy.server.close();
+      rpcProxy.server.closeAllConnections?.();
+      delete (globalThis as any).window;
+    }
+  });
+});


### PR DESCRIPTION
## Problem

"Claim Rewards" reverted with `0x09bde339` = `InvalidProof()` for the real holder. The gateway's gasless `/claim` relays `claimBatch` **from the operator wallet**, but `LossRewardPool._claimEpoch(..., msg.sender)` derives the Merkle leaf from - and pays - `msg.sender`. Leaves are built for the holder, so a relayed claim can never verify (and would pay the operator if it did). Every claim that ever succeeded (89 rows, Sept 3) was the operator wallet claiming for itself.

## Fix (frontend only, no contract change)

`src/lib/lossReward.ts` `claimBatchRewards()` now signs and sends the claim from the **connected wallet** via `eth_sendTransaction` - identical mechanics to `executeV4Buy`/`swap.ts`:

- uses the claimable list the page already has (else fetches it from the authenticated gateway `/query`, which remains the source of truth for amounts/proofs/on-chain `hasClaimed` reconciliation);
- refuses if the wallet's active account is not the holder;
- pre-flights the exact call as the holder so reverts decode by name; `AlreadyClaimed` short-circuits with **no** transaction;
- `claimBatch` for many epochs, `claimReward` for one.

Also: pool custom errors added to the frontend ABI; optional `amountWei` on `UnclaimedEpoch` (gateway already returns it; fallback = worker's exact rounding); `scripts/claim-loss-rewards.mjs` CLI equivalent (env-only key, dry-run default, `CLAIM_CONFIRM` gate, exact balance-delta check).

## Verification - `test/hardhat/wallet-claim-fork.test.ts` (mainnet fork of the REAL pool, REAL frontend module via Vite SSR, minimal EIP-1193 wallet)

| Case | Result |
|---|---|
| B1 batch claim (2 synthetic epochs published by impersonated owner) | tx from holder, **net delta 0.0017 ETH == 0.0017** |
| B2 single claim (`claimReward` path) | **net delta 0.0003 == 0.0003** |
| B3 double-claim | `alreadyClaimed`, **0 transactions sent** |
| B4 wallet active account != holder | refused before sending, **0 transactions** |
| **A real holder `0xba69...5cE`, 9 real published TESTINGG epochs [26-34]** | tx from holder, gas 297,320, **net delta 0.000717684769514685 ETH == exact sum**, `hasClaimed` true for all 9 |

Run: `npx hardhat test nodejs --network robinhoodFork -- test/hardhat/wallet-claim-fork.test.ts`

ESLint clean on `lossReward.ts`; `tsc` errors in `src/lib/permit2.ts` are pre-existing on master (unchanged here).

## Notes for reviewers

- The gateway `/claim` endpoint is now unused by the app. It is left in place (out of scope) but can never succeed for a non-operator wallet; consider removing it in a follow-up.
- Truly gasless claiming would need a new pool function (`claimFor(claimant, ...)`) and a LossRewardPool redeploy (cascades into the V4 hook trio) - a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
