### PR TITLE
Add creator-fee balance and wallet-signed claimCreatorFees() to the token page (V3 + V4)

### DIFF
--- a/src/lib/creatorFees.ts
+++ b/src/lib/creatorFees.ts
@@ -1,0 +1,141 @@
+import { encodeFunctionData, parseAbi, getAddress, formatEther } from 'viem';
+import { publicClient, getEvmProvider, ensureEvmChain, waitForTransactionReceipt } from './evmNetwork';
+import { INCENTIFI_V4_HOOK } from './uniswapAddresses';
+import { getBondingCurveAddress } from './bondingCurve';
+import { isV4LaunchedToken, getV4PoolKey, computeV4PoolId } from './bondingCurveV4';
+
+// ----------------------------------------------------------------------------
+// Creator fees are PULL payments on both venues, bound to msg.sender:
+//   * V3: each token has its own IncentifiBondingCurve; the creator's 1% accrues in that
+//     curve's creatorBalances[creator] (buys/sells on the curve AND post-graduation router
+//     trades via depositCreatorFee) and is withdrawn with curve.claimCreatorFees().
+//   * V4: one shared hook for every pool; creatorBalances[creator] there is GLOBAL across all
+//     of that creator's V4 tokens, withdrawn with hook.claimCreatorFees() in one go.
+// Both contracts pay msg.sender, so — exactly like loss-reward claims after PR #13 — the
+// claim MUST be signed and sent by the creator's own connected wallet. No relayer.
+// ----------------------------------------------------------------------------
+
+const CREATOR_FEES_ABI = parseAbi([
+  'function creatorBalances(address creator) view returns (uint256)',
+  'function claimCreatorFees()',
+  // V3 curve: who this token's creator is
+  'function creator() view returns (address)',
+  // V4 hook: per-pool state (creator is the 2nd field)
+  'function curveStates(bytes32 poolId) view returns (address token, address creator, bool initialized, bool graduated, uint256 realEthReserve, uint256 realTokenReserve)',
+  // custom errors, so a pre-flight simulation decodes by name
+  'error NoBalanceToClaim()',
+  'error EthTransferFailed()',
+]);
+
+export type CreatorFeeSource =
+  | { kind: 'v3'; contract: `0x${string}`; scope: 'token' }
+  | { kind: 'v4'; contract: `0x${string}`; scope: 'creator' };
+
+export type CreatorFeeStatus = {
+  source: CreatorFeeSource;
+  /** The on-chain creator of THIS token. */
+  creator: `0x${string}`;
+  /** Whether `walletAddress` is that creator. */
+  isCreator: boolean;
+  /** creatorBalances(walletAddress) on the source contract (V4: across all the wallet's V4 tokens). */
+  balanceWei: bigint;
+  balanceEth: number;
+};
+
+/**
+ * Which contract holds the creator-fee balance for this token: its V3 curve if the V3 factory
+ * knows it, else the shared V4 hook if the V4 factory launched it, else null (not an Incentifi
+ * launch, or not resolvable).
+ */
+export async function resolveCreatorFeeSource(tokenAddress: string): Promise<CreatorFeeSource | null> {
+  const token = getAddress(tokenAddress);
+  const curve = await getBondingCurveAddress(token);
+  if (curve) return { kind: 'v3', contract: getAddress(curve), scope: 'token' };
+  if (await isV4LaunchedToken(token)) return { kind: 'v4', contract: getAddress(INCENTIFI_V4_HOOK), scope: 'creator' };
+  return null;
+}
+
+/**
+ * Live, on-chain creator-fee status for (token, wallet): who the creator is, whether this wallet
+ * is it, and the wallet's claimable balance on the relevant contract.
+ */
+export async function fetchCreatorFeeStatus(tokenAddress: string, walletAddress: string): Promise<CreatorFeeStatus | null> {
+  const token = getAddress(tokenAddress);
+  const wallet = getAddress(walletAddress);
+  const source = await resolveCreatorFeeSource(token);
+  if (!source) return null;
+
+  let creator: `0x${string}`;
+  if (source.kind === 'v3') {
+    creator = getAddress(
+      (await publicClient.readContract({ address: source.contract, abi: CREATOR_FEES_ABI, functionName: 'creator' } as any)) as string
+    );
+  } else {
+    const poolId = computeV4PoolId(await getV4PoolKey(token));
+    const state = (await publicClient.readContract({
+      address: source.contract,
+      abi: CREATOR_FEES_ABI,
+      functionName: 'curveStates',
+      args: [poolId],
+    } as any)) as readonly [string, string, boolean, boolean, bigint, bigint];
+    creator = getAddress(state[1]);
+  }
+
+  const balanceWei = (await publicClient.readContract({
+    address: source.contract,
+    abi: CREATOR_FEES_ABI,
+    functionName: 'creatorBalances',
+    args: [wallet],
+  } as any)) as bigint;
+
+  return { source, creator, isCreator: creator === wallet, balanceWei, balanceEth: Number(formatEther(balanceWei)) };
+}
+
+export type CreatorFeeClaimResult = { txHash: string; claimedEth: string; source: CreatorFeeSource };
+
+/**
+ * Withdraw the connected wallet's accrued creator fees for this token's venue, signed and sent
+ * by that wallet (same eth_sendTransaction mechanics as buys, sells and loss-reward claims).
+ * On V4 this pays out the wallet's balance across ALL its V4 tokens, by contract design.
+ */
+export async function claimCreatorFees(tokenAddress: string, walletAddress: string): Promise<CreatorFeeClaimResult> {
+  const wallet = getAddress(walletAddress);
+  const status = await fetchCreatorFeeStatus(tokenAddress, wallet);
+  if (!status) throw new Error('This token has no Incentifi creator-fee contract to claim from.');
+  if (status.balanceWei === 0n) throw new Error('No accrued creator fees to claim for this wallet.');
+
+  const provider = getEvmProvider();
+  if (!provider) throw new Error('No EVM wallet detected. Please connect your wallet.');
+  await ensureEvmChain();
+  const accounts = (await provider.request({ method: 'eth_accounts' })) as string[];
+  const sender = accounts?.[0];
+  if (!sender) throw new Error('Wallet is connected, but no active account was found.');
+  if (getAddress(sender) !== wallet) {
+    throw new Error(
+      `The wallet's active account (${sender.slice(0, 6)}…${sender.slice(-4)}) is not the wallet these creator fees belong to ` +
+        `(${wallet.slice(0, 6)}…${wallet.slice(-4)}). Switch accounts in your wallet and try again.`
+    );
+  }
+
+  // Pre-flight as the sender so a revert is decoded by name before the wallet prompts.
+  try {
+    await publicClient.simulateContract({ address: status.source.contract, abi: CREATOR_FEES_ABI, functionName: 'claimCreatorFees', account: wallet } as any);
+  } catch (err: any) {
+    const text = [err?.shortMessage, err?.message, err?.details, err?.cause?.message].filter(Boolean).join(' ');
+    if (/NoBalanceToClaim/.test(text)) throw new Error('No accrued creator fees to claim for this wallet.');
+    throw new Error(`Creator fee claim would revert on-chain: ${err?.shortMessage || err?.message || String(err)}`);
+  }
+
+  const data = encodeFunctionData({ abi: CREATOR_FEES_ABI, functionName: 'claimCreatorFees' });
+  const txHash = (await provider.request({
+    method: 'eth_sendTransaction',
+    params: [{ from: sender, to: status.source.contract, data }],
+  })) as string;
+
+  await waitForTransactionReceipt(txHash, {
+    description: 'Creator fee claim',
+    revertedMessage: 'Creator fee claim reverted on-chain. Nothing was paid out.',
+  });
+
+  return { txHash, claimedEth: formatEther(status.balanceWei), source: status.source };
+}

--- a/src/pages/token-preview/page.tsx
+++ b/src/pages/token-preview/page.tsx
@@ -53,6 +53,7 @@ import {
   type HolderCostBasis,
   type ClaimableRewardsState,
 } from '../../lib/lossReward';
+import { fetchCreatorFeeStatus, claimCreatorFees, type CreatorFeeStatus } from '../../lib/creatorFees';
 import {
   getStoredSession,
   authenticateWallet,
@@ -270,6 +271,12 @@ const TokenPreviewPage = () => {
   const [botSellingStatus, setBotSellingStatus] = useState<ExternalBotSellingStatus | null>(null);
   const [enablingBotSelling, setEnablingBotSelling] = useState(false);
   const [botSellingMsg, setBotSellingMsg] = useState<string | null>(null);
+
+  // Creator fees (pull-payment; V3 curve per token, V4 hook across all of a creator's tokens).
+  // Read live from-chain, claimed by the connected wallet itself — see src/lib/creatorFees.ts.
+  const [creatorFeeStatus, setCreatorFeeStatus] = useState<CreatorFeeStatus | null>(null);
+  const [claimingCreatorFees, setClaimingCreatorFees] = useState(false);
+  const [creatorFeeMsg, setCreatorFeeMsg] = useState<string | null>(null);
 
   // Fetch live ETH/USD price from Coinbase
   useEffect(() => {
@@ -1973,6 +1980,84 @@ const TokenPreviewPage = () => {
     </div>
   );
 
+  const loadCreatorFeeStatus = async () => {
+    if (!tokenData?.mintAddress || !connectedWallet) {
+      setCreatorFeeStatus(null);
+      return;
+    }
+    try {
+      setCreatorFeeStatus(await fetchCreatorFeeStatus(tokenData.mintAddress, connectedWallet));
+    } catch (err) {
+      console.warn('Creator fee status load issue:', err);
+    }
+  };
+
+  useEffect(() => {
+    setCreatorFeeMsg(null);
+    loadCreatorFeeStatus();
+    const timer = setInterval(loadCreatorFeeStatus, 30_000);
+    return () => clearInterval(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tokenData?.mintAddress, connectedWallet]);
+
+  const handleClaimCreatorFees = async () => {
+    const wallet = connectedWallet || getWalletAccount();
+    if (!wallet || !tokenData?.mintAddress || !creatorFeeStatus || creatorFeeStatus.balanceWei === 0n) return;
+    try {
+      setClaimingCreatorFees(true);
+      setCreatorFeeMsg(null);
+      const res = await claimCreatorFees(tokenData.mintAddress, wallet);
+      const shortTx = `${res.txHash.slice(0, 8)}...${res.txHash.slice(-6)}`;
+      setCreatorFeeMsg(`Claimed ${Number(res.claimedEth).toFixed(6)} ${EVM_NATIVE_SYMBOL} in creator fees (Tx: ${shortTx})`);
+      await loadCreatorFeeStatus();
+      await refreshOnchainBalances();
+    } catch (err: any) {
+      console.error('Creator fee claim failed:', err);
+      setStatus(describeError(err));
+    } finally {
+      setClaimingCreatorFees(false);
+    }
+  };
+
+  // Only the token's creator (or a wallet that actually holds a balance on the relevant
+  // contract) sees this; everyone else sees nothing rather than a permanently-empty card.
+  const renderCreatorFeesCard = () => {
+    if (!connectedWallet || !creatorFeeStatus) return null;
+    if (!creatorFeeStatus.isCreator && creatorFeeStatus.balanceWei === 0n) return null;
+    const isV4 = creatorFeeStatus.source.kind === 'v4';
+    return (
+      <div className="bg-[#0B1120] border border-[#1D2940] rounded-2xl p-4 sm:p-5 shadow-xl shadow-black/20">
+        <div className="flex items-center justify-between mb-1">
+          <h3 className="text-white font-bold text-sm">Creator Fees</h3>
+          <span className="text-[10px] font-bold px-2 py-0.5 rounded-md bg-sky-500/10 text-sky-300 border border-sky-500/20 uppercase tracking-wider">
+            {isV4 ? 'V4 · All Your Tokens' : 'V3 · This Token'}
+          </span>
+        </div>
+        <p className="text-[#8DA3CD] text-[11px] leading-relaxed mb-3">
+          1% of every trade accrues to the creator on-chain and is withdrawn on your own schedule, paid to your wallet by
+          the {isV4 ? 'shared V4 hook — the balance below covers every V4 token you created' : 'token\'s bonding curve'}.
+          Signed and sent by your connected wallet.
+        </p>
+        <div className="rounded-xl bg-gradient-to-br from-[#0C1A30] to-[#0A1424] p-3.5 border border-[#23385D] space-y-2.5 text-xs">
+          <div className="flex items-center justify-between">
+            <span className="text-[#9FB0CF]">Accrued, unclaimed:</span>
+            <span className="text-white font-bold text-xs sm:text-sm">
+              {creatorFeeStatus.balanceWei > 0n ? `${creatorFeeStatus.balanceEth.toFixed(6)} ${EVM_NATIVE_SYMBOL}` : '0.000000 ETH'}
+            </span>
+          </div>
+          <button
+            onClick={handleClaimCreatorFees}
+            disabled={claimingCreatorFees || creatorFeeStatus.balanceWei === 0n}
+            className="w-full py-2.5 rounded-xl bg-gradient-to-r from-[#0EA5E9] to-[#0284C7] hover:from-[#0284C7] hover:to-[#0369A1] text-white font-bold text-xs disabled:opacity-40 disabled:cursor-not-allowed transition flex items-center justify-center gap-2 shadow-md shadow-sky-500/20"
+          >
+            {claimingCreatorFees ? <span>Claiming...</span> : <span>Claim Creator Fees</span>}
+          </button>
+          {creatorFeeMsg && <p className="text-center text-sky-300 text-[11px] font-medium">{creatorFeeMsg}</p>}
+        </div>
+      </div>
+    );
+  };
+
   // Deliberately its own card, its own button, its own copy — never merged into the
   // buy/sell panel above. See src/lib/permit2.ts's header comment for why.
   const renderBotSellingCard = () => {
@@ -2313,6 +2398,7 @@ const TokenPreviewPage = () => {
                 {renderPositionCard()}
                 {renderLossRewardCard()}
                 {renderBotSellingCard()}
+                {renderCreatorFeesCard()}
               </div>
 
               {/* 2. TOKEN ABOUT / DESCRIPTION */}
@@ -2470,6 +2556,7 @@ const TokenPreviewPage = () => {
               {renderPositionCard()}
               {renderLossRewardCard()}
               {renderBotSellingCard()}
+              {renderCreatorFeesCard()}
               {renderContractDetailsCard()}
             </aside>
           </div>

--- a/test/hardhat/creator-fees-fork.test.ts
+++ b/test/hardhat/creator-fees-fork.test.ts
@@ -1,0 +1,245 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { network } from 'hardhat';
+import http from 'node:http';
+import { parseEther, getAddress, formatEther, parseAbi } from 'viem';
+import { createServer as createViteServer } from 'vite';
+
+/**
+ * CREATOR FEE CLAIMS — fork test for src/lib/creatorFees.ts (V3 curve + V4 hook).
+ *
+ * Both contracts are pull-payments bound to msg.sender (curve.claimCreatorFees(),
+ * hook.claimCreatorFees()), so the claim must be signed by the creator's own wallet — the same
+ * wallet-signed pattern PR #13 established for loss-reward claims. This test drives the REAL
+ * frontend module (loaded through Vite SSR, wired to a local proxy over the fork) through a
+ * minimal EIP-1193 wallet and checks exact wei deltas net of gas.
+ *
+ *   V3: a fresh IncentifiBondingCurveFactory + IncentifiSwapRouter (same source as production)
+ *       deployed on the fork; a real router buy accrues a real 1% creator fee into
+ *       curve.creatorBalances[creator]; the creator claims it via the real function.
+ *   V4: the REAL production hook and the REAL TESTINGG pool; a real IncentifiV4Router buy accrues
+ *       a real 1% fee to TESTINGG's real creator 0xba69…5cE on the hook; the impersonated creator
+ *       claims its whole hook balance via the real function.
+ *   Guards: zero balance -> refused before any tx; wrong active account -> refused before any tx;
+ *       non-creator wallet -> isCreator=false, balance 0.
+ *
+ * Run (isolated): npx hardhat test nodejs --network robinhoodFork -- test/hardhat/creator-fees-fork.test.ts
+ */
+
+const WETH = getAddress('0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73');
+const UNISWAP_V3_FACTORY = getAddress('0x1f7d7550B1b028f7571E69A784071F0205FD2EfA');
+const UNISWAP_POSITION_MANAGER = getAddress('0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3');
+const SWAP_ROUTER02 = getAddress('0xcaf681a66D020601342297493863e78C959e5Cb2');
+const LOSS_REWARD_POOL = getAddress('0x697BDA9db5a297a9Cd9ED969BBF2549d0527DcdF');
+const V4_HOOK = getAddress('0xC5Ef9Cb8c95cd8540E71b6D4c00a90257625a888');
+const V4_ROUTER = getAddress('0x762b4D9e514e4B19E54E99b62E7b731CE37FF1E6');
+const TESTINGG = getAddress('0x7F9b8A09877F6e8096b0b8c6027DC49580b05474');
+const TESTINGG_CREATOR = getAddress('0xba69Ca72CD2B87113471c4C38f08928761Edb5cE');
+
+const CURVE_EVENTS = parseAbi([
+  'event TokensPurchased(address indexed buyer, address indexed recipient, uint256 ethInGross, uint256 tokensOut, uint256 creatorFee, uint256 lossPoolFee)',
+]);
+const HOOK_EVENTS = parseAbi([
+  'event Bought(bytes32 indexed poolId, address indexed trader, uint256 ethIn, uint256 tokensOut, uint256 creatorFee, uint256 lossPoolFee)',
+]);
+
+function extractRevertData(err: any): string | undefined {
+  const candidates = [err?.data?.data, err?.data, err?.cause?.data?.data, err?.cause?.data, err?.error?.data];
+  for (const c of candidates) if (typeof c === 'string' && /^0x[0-9a-fA-F]{8,}$/.test(c)) return c;
+  const text = [err?.message, err?.details, err?.cause?.message].filter(Boolean).join(' ');
+  const m = text.match(/0x[0-9a-fA-F]{8,}/);
+  return m ? m[0] : undefined;
+}
+
+async function startRpcProxy(provider: { request: (args: { method: string; params?: unknown[] }) => Promise<unknown> }) {
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (chunk) => (body += chunk));
+    req.on('end', async () => {
+      try {
+        const payload = JSON.parse(body);
+        const handleOne = async (item: any) => {
+          try {
+            return { jsonrpc: '2.0', id: item.id, result: await provider.request({ method: item.method, params: item.params }) };
+          } catch (err: any) {
+            const data = extractRevertData(err);
+            return { jsonrpc: '2.0', id: item.id, error: { code: data ? 3 : (err?.code ?? -32000), message: err?.shortMessage || err?.message || String(err), data } };
+          }
+        };
+        const out = Array.isArray(payload) ? await Promise.all(payload.map(handleOne)) : await handleOne(payload);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(out));
+      } catch (err: any) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: String(err) }));
+      }
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  const port = typeof address === 'object' && address ? address.port : 0;
+  return { server, url: `http://127.0.0.1:${port}` };
+}
+
+describe('Creator fee claims (V3 curve + real V4 hook on a mainnet fork, real frontend module, exact balance deltas)', () => {
+  it('reads accrued fees and claims them from the creator wallet on both venues; guards refuse before any tx', async () => {
+    const { viem, networkHelpers, provider } = await network.create('robinhoodFork');
+    const publicClient = await viem.getPublicClient();
+    const [, creatorWallet, buyerWallet, strangerWallet] = await viem.getWalletClients();
+    const CREATOR = getAddress(creatorWallet.account.address);
+    const BUYER = getAddress(buyerWallet.account.address);
+    const STRANGER = getAddress(strangerWallet.account.address);
+    for (const a of [CREATOR, BUYER, STRANGER]) await networkHelpers.setBalance(a, parseEther('10'));
+    await networkHelpers.mine(1);
+    console.log('--- Fork setup ---');
+    console.log('Forked at block:', await publicClient.getBlockNumber());
+
+    // ---- V3: fresh factory/router (production source) wired to the real LossRewardPool ----
+    const factory = await viem.deployContract('IncentifiBondingCurveFactory', [LOSS_REWARD_POOL, WETH, UNISWAP_POSITION_MANAGER, UNISWAP_V3_FACTORY]);
+    const router = await viem.deployContract('IncentifiSwapRouter', [SWAP_ROUTER02, WETH, LOSS_REWARD_POOL, factory.address]);
+    const totalSupply = 1_000_000_000n * 10n ** 18n;
+    const token = await viem.deployContract('IncentifiLaunchToken', ['Creator Fee Fork Test', 'CFFT', totalSupply], { client: { wallet: creatorWallet } });
+    await publicClient.waitForTransactionReceipt({ hash: await token.write.approve([factory.address, totalSupply], { account: creatorWallet.account }) });
+    await publicClient.waitForTransactionReceipt({ hash: await factory.write.registerExistingToken([token.address, CREATOR], { account: creatorWallet.account }) });
+    const curveAddr = getAddress(await factory.read.getBondingCurve([token.address]));
+    const curve = await viem.getContractAt('IncentifiBondingCurve', curveAddr);
+    assert.equal(getAddress(await curve.read.creator()), CREATOR);
+    console.log('Fresh V3 factory:', factory.address, '| token:', token.address, '| curve:', curveAddr);
+
+    const rpcProxy = await startRpcProxy(provider);
+    let vite: Awaited<ReturnType<typeof createViteServer>> | null = null;
+    try {
+      // Frontend env: RPC -> fork proxy; V3 factory -> the fresh one (V4 hook/factory stay real).
+      process.env.VITE_EVM_RPC_URL = rpcProxy.url;
+      process.env.VITE_INCENTIFI_BONDING_CURVE_FACTORY = factory.address;
+      vite = await createViteServer({ server: { middlewareMode: true }, appType: 'custom', logLevel: 'error' });
+      const evmNetwork = await vite.ssrLoadModule('/src/lib/evmNetwork.ts');
+      assert.equal(evmNetwork.EVM_RPC_URL, rpcProxy.url, 'frontend must be wired to the fork');
+      const addresses = await vite.ssrLoadModule('/src/lib/uniswapAddresses.ts');
+      assert.equal(getAddress(addresses.INCENTIFI_BONDING_CURVE_FACTORY), getAddress(factory.address), 'frontend must see the fresh V3 factory');
+      assert.equal(getAddress(addresses.INCENTIFI_V4_HOOK), V4_HOOK, 'frontend must see the REAL V4 hook');
+      const creatorFees = await vite.ssrLoadModule('/src/lib/creatorFees.ts');
+      console.log('Real src/lib/creatorFees.ts loaded via Vite SSR');
+
+      let activeAccount: `0x${string}` = CREATOR;
+      const sent: string[] = [];
+      (globalThis as any).window = {
+        ethereum: {
+          request: async ({ method, params }: { method: string; params?: unknown[] }) => {
+            if (method === 'eth_accounts' || method === 'eth_requestAccounts') return [activeAccount];
+            if (method === 'wallet_switchEthereumChain' || method === 'wallet_addEthereumChain') return null;
+            const result = await provider.request({ method, params });
+            if (method === 'eth_sendTransaction') sent.push(result as string);
+            return result;
+          },
+        },
+      };
+
+      const claimVia = async (tokenAddr: `0x${string}`, wallet: `0x${string}`) => {
+        const before = await publicClient.getBalance({ address: wallet });
+        const sentBefore = sent.length;
+        const res = await creatorFees.claimCreatorFees(tokenAddr, wallet);
+        const after = await publicClient.getBalance({ address: wallet });
+        const receipt = await publicClient.getTransactionReceipt({ hash: res.txHash });
+        const tx = await publicClient.getTransaction({ hash: res.txHash });
+        const fee = receipt.gasUsed * receipt.effectiveGasPrice;
+        return { res, receipt, tx, netDelta: after - before + fee, txsSent: sent.length - sentBefore };
+      };
+
+      // ================================================================================
+      // V3
+      // ================================================================================
+      console.log('\n=== V3: real router buy accrues a real 1% creator fee; creator claims it ===');
+      const deadline = BigInt(Math.floor(Date.now() / 1000) + 600);
+      const buyReceipt = await publicClient.waitForTransactionReceipt({
+        hash: await router.write.buyToken([token.address, 0n, deadline], { account: buyerWallet.account, value: parseEther('0.5') }),
+      });
+      const purchase = (await publicClient.getLogs({ address: curveAddr, event: CURVE_EVENTS[0], fromBlock: buyReceipt.blockNumber, toBlock: buyReceipt.blockNumber }))[0];
+      const v3Fee = purchase.args.creatorFee!;
+      assert.ok(v3Fee > 0n);
+      assert.equal(await curve.read.creatorBalances([CREATOR]), v3Fee, 'curve must credit exactly the emitted creatorFee');
+      console.log(`  buy 0.5 ETH -> emitted creatorFee ${formatEther(v3Fee)} ETH; curve.creatorBalances[creator] == emitted  OK`);
+
+      // status read through the real module
+      const v3Status = await creatorFees.fetchCreatorFeeStatus(token.address, CREATOR);
+      assert.equal(v3Status.source.kind, 'v3');
+      assert.equal(getAddress(v3Status.source.contract), curveAddr, 'V3 source must be this token\'s curve');
+      assert.equal(v3Status.isCreator, true);
+      assert.equal(v3Status.balanceWei, v3Fee, 'status balance must equal the real on-chain creatorBalances');
+      console.log(`  fetchCreatorFeeStatus: kind=${v3Status.source.kind} isCreator=${v3Status.isCreator} balance=${formatEther(v3Status.balanceWei)} ETH  OK`);
+
+      // non-creator sees isCreator=false and 0
+      const strangerStatus = await creatorFees.fetchCreatorFeeStatus(token.address, STRANGER);
+      assert.equal(strangerStatus.isCreator, false);
+      assert.equal(strangerStatus.balanceWei, 0n);
+
+      // wrong active account -> refused, 0 txs
+      activeAccount = STRANGER;
+      const sentBeforeGuard = sent.length;
+      await assert.rejects(creatorFees.claimCreatorFees(token.address, CREATOR), /not the wallet these creator fees belong to/);
+      assert.equal(sent.length - sentBeforeGuard, 0);
+      activeAccount = CREATOR;
+      console.log('  wrong active account: refused, 0 transactions  OK');
+
+      // the real claim
+      const v3 = await claimVia(token.address, CREATOR);
+      assert.equal(v3.receipt.status, 'success');
+      assert.equal(getAddress(v3.tx.from), CREATOR, 'claim must be sent by the creator wallet');
+      assert.equal(getAddress(v3.tx.to), curveAddr, 'V3 claim goes to the token\'s curve');
+      assert.equal(v3.netDelta, v3Fee, 'creator balance must rise by EXACTLY the accrued fee, net of gas');
+      assert.equal(v3.res.claimedEth, formatEther(v3Fee));
+      assert.equal(await curve.read.creatorBalances([CREATOR]), 0n, 'balance must be zero after the claim');
+      console.log(`  tx ${v3.res.txHash} from=${v3.tx.from} gasUsed=${v3.receipt.gasUsed} | net delta ${formatEther(v3.netDelta)} == ${formatEther(v3Fee)} ETH  PASS`);
+
+      // zero balance -> refused before any tx
+      const sentBeforeZero = sent.length;
+      await assert.rejects(creatorFees.claimCreatorFees(token.address, CREATOR), /No accrued creator fees/);
+      assert.equal(sent.length - sentBeforeZero, 0);
+      console.log('  second claim with zero balance: refused, 0 transactions  PASS');
+
+      // ================================================================================
+      // V4 — REAL hook, REAL TESTINGG pool, REAL creator
+      // ================================================================================
+      console.log('\n=== V4: real IncentifiV4Router buy on TESTINGG accrues to the real creator on the real hook ===');
+      const hook = await viem.getContractAt('IncentifiV4HookGenericSell', V4_HOOK);
+      const v4Router = await viem.getContractAt('IncentifiV4Router', V4_ROUTER);
+      const hookBalBefore = await hook.read.creatorBalances([TESTINGG_CREATOR]);
+      console.log(`  real creator ${TESTINGG_CREATOR} hook balance before: ${formatEther(hookBalBefore)} ETH`);
+      const v4BuyReceipt = await publicClient.waitForTransactionReceipt({
+        hash: await v4Router.write.buyToken([TESTINGG, 0n, deadline], { account: buyerWallet.account, value: parseEther('0.02') }),
+      });
+      const bought = (await publicClient.getLogs({ address: V4_HOOK, event: HOOK_EVENTS[0], fromBlock: v4BuyReceipt.blockNumber, toBlock: v4BuyReceipt.blockNumber }))[0];
+      const v4Fee = bought.args.creatorFee!;
+      const hookBalAfterBuy = await hook.read.creatorBalances([TESTINGG_CREATOR]);
+      assert.equal(hookBalAfterBuy - hookBalBefore, v4Fee, 'hook must credit exactly the emitted Bought.creatorFee to the real creator');
+      console.log(`  buy 0.02 ETH -> emitted creatorFee ${formatEther(v4Fee)} ETH; hook balance now ${formatEther(hookBalAfterBuy)} ETH  OK`);
+
+      const v4Status = await creatorFees.fetchCreatorFeeStatus(TESTINGG, TESTINGG_CREATOR);
+      assert.equal(v4Status.source.kind, 'v4');
+      assert.equal(getAddress(v4Status.source.contract), V4_HOOK);
+      assert.equal(getAddress(v4Status.creator), TESTINGG_CREATOR, 'module must identify the real creator from hook.curveStates');
+      assert.equal(v4Status.isCreator, true);
+      assert.equal(v4Status.balanceWei, hookBalAfterBuy, 'status must report the FULL hook balance (all of the creator\'s V4 tokens)');
+      console.log(`  fetchCreatorFeeStatus: kind=${v4Status.source.kind} creator=${v4Status.creator} balance=${formatEther(v4Status.balanceWei)} ETH  OK`);
+
+      await networkHelpers.impersonateAccount(TESTINGG_CREATOR);
+      await networkHelpers.setBalance(TESTINGG_CREATOR, parseEther('1')); // gas only
+      activeAccount = TESTINGG_CREATOR;
+      const v4 = await claimVia(TESTINGG, TESTINGG_CREATOR);
+      assert.equal(v4.receipt.status, 'success');
+      assert.equal(getAddress(v4.tx.from), TESTINGG_CREATOR, 'the real creator must be msg.sender');
+      assert.equal(getAddress(v4.tx.to), V4_HOOK, 'V4 claim goes to the shared hook');
+      assert.equal(v4.netDelta, hookBalAfterBuy, 'creator balance must rise by EXACTLY the whole hook balance, net of gas');
+      assert.equal(await hook.read.creatorBalances([TESTINGG_CREATOR]), 0n);
+      console.log(`  tx ${v4.res.txHash} from=${v4.tx.from} gasUsed=${v4.receipt.gasUsed} | net delta ${formatEther(v4.netDelta)} == ${formatEther(hookBalAfterBuy)} ETH  PASS`);
+
+      console.log('\n=== RESULT: creator fees read and claimed by the creator wallet on V3 and the real V4 hook, exact deltas ===');
+    } finally {
+      if (vite) await vite.close();
+      rpcProxy.server.close();
+      rpcProxy.server.closeAllConnections?.();
+      delete (globalThis as any).window;
+      delete process.env.VITE_INCENTIFI_BONDING_CURVE_FACTORY;
+    }
+  });
+});


### PR DESCRIPTION
## What

The site never showed a token's creator their accrued 1% fees or let them withdraw. This adds a **Creator Fees** card to the token page (visible only to the creator, or to a wallet that holds a balance) reading `creatorBalances(wallet)` live and claiming with `claimCreatorFees()` **signed by the connected wallet** - the same pattern as PR #13.

There was no relayer bug to fix here: neither venue's creator-fee path existed in the frontend at all. Both contracts are `msg.sender`-bound pull payments, so this is wallet-signed from day one.

## Venues

| | Source contract | Scope of the balance |
|---|---|---|
| V3 | the token's `IncentifiBondingCurve` (`factory.getBondingCurve(token)`) | this token |
| V4 | the shared hook `IncentifiV4HookGenericSell` | **all** of the creator's V4 tokens (by contract design) - the card says so |

`src/lib/creatorFees.ts`: `resolveCreatorFeeSource` -> `fetchCreatorFeeStatus` (creator identity via `curve.creator()` / `hook.curveStates`, live balance) -> `claimCreatorFees` (active account must be the wallet; pre-flight `simulateContract` as the wallet with custom errors in the ABI; `eth_sendTransaction`; receipt).

## Verification - `test/hardhat/creator-fees-fork.test.ts` (mainnet fork, REAL frontend module via Vite SSR, minimal EIP-1193 wallet, exact wei deltas net of gas)

| Case | Result |
|---|---|
| V3 buy 0.5 ETH via fresh production-source router | curve credits exactly the emitted `creatorFee` = 0.005 ETH |
| V3 `fetchCreatorFeeStatus` | `kind=v3`, `isCreator=true`, balance == on-chain |
| V3 wrong active account | refused before sending, 0 txs |
| **V3 claim** | `from=` creator, `to=` curve, **net delta 0.005 == 0.005 ETH**, balance 0 after |
| V3 second claim at zero | refused before sending, 0 txs |
| **V4 real router buy on REAL TESTINGG** | hook credits exactly the emitted `Bought.creatorFee` (0.0002 ETH) to the real creator |
| V4 `fetchCreatorFeeStatus` | `kind=v4`, creator = `0xba69...5cE` from `curveStates`, balance = full hook balance |
| **V4 claim by the real (impersonated) creator** | `from=` creator, `to=` hook, **net delta 0.006811034743833257 ETH == exact**, balance 0 after |

Run: `npx hardhat test nodejs --network robinhoodFork -- test/hardhat/creator-fees-fork.test.ts`

ESLint: `creatorFees.ts` clean; the two `react-hooks/exhaustive-deps` warnings in `page.tsx` are pre-existing on master (the pre-existing bot-selling and loss-reward effects), unchanged here. `tsc`: no errors in the changed files (the `permit2.ts` errors are pre-existing on master).

## Note

Independent of #13 (based on master directly). The real creator `0xba69...5cE` currently has ~0.0066 ETH accrued on the V4 hook from TESTINGG trading, claimable as soon as this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
