### PR TITLE
Clarify the Permit2 "Allow External Bots to Sell" card copy (Universal Router tools only)

### DIFF
--- a/src/pages/token-preview/page.tsx
+++ b/src/pages/token-preview/page.tsx
@@ -2066,8 +2066,9 @@ const TokenPreviewPage = () => {
       <div className="bg-[#0B1120] border border-[#1D2940] rounded-2xl p-4 sm:p-5 shadow-xl shadow-black/20">
         <h3 className="text-white font-bold text-sm mb-1">Allow External Bots to Sell This Token</h3>
         <p className="text-[#8DA3CD] text-[11px] leading-relaxed mb-3">
-          This lets Uniswap's Universal Router move this token from your wallet, so third-party trading bots and
-          tools (e.g. Telegram trading bots) can sell it for you. Two on-chain transactions, paid by your own wallet.
+          Lets tools that trade through Uniswap's Universal Router (e.g. the Uniswap app, Permit2-based bots) sell this
+          token. Bots using their own direct approval — like most sniper bots — don't need this. Two on-chain
+          transactions, paid by your own wallet.
         </p>
 
         {botSellingStatus?.fullyEnabled ? (


### PR DESCRIPTION
## What

Copy-only change to the **Allow External Bots to Sell This Token** card on the token page. No logic, no tests affected.

**Before:** "This lets Uniswap's Universal Router move this token from your wallet, so third-party trading bots and tools (e.g. Telegram trading bots) can sell it for you. Two on-chain transactions, paid by your own wallet."

**After:** "Lets tools that trade through Uniswap's Universal Router (e.g. the Uniswap app, Permit2-based bots) sell this token. Bots using their own direct approval — like most sniper bots — don't need this. Two on-chain transactions, paid by your own wallet."

## Why

The old wording implied the Permit2 approvals were needed for *any* bot. Live on-chain state for the TESTINGG creator wallet says otherwise: ERC20 → Permit2 allowance **0**, Permit2 → UniversalRouter **0**, ERC20 → the bot contract `0xEd09…` **MAX** — every successful bot sell tonight happened with the card *not* enabled, because that bot pulls with its own direct approval and hands tokens to the router itself. The approvals matter only for tools that act with the user's wallet as `msg.sender` through Universal Router (the Uniswap app, Permit2-based bots).

The GenericSell hook fix is orthogonal (settlement order inside PoolManager vs. how a router obtains the tokens), so the card remains relevant for new-hook tokens; this just describes it accurately.

ESLint on `page.tsx`: 0 errors (the 2 `react-hooks/exhaustive-deps` warnings are pre-existing on master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
