### PR TITLE
Close the phantom-payout hole: fail-loud V4 discovery (indexer) + on-chain balance cap (worker)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "node test/loss-reward-audit.test.mjs && node test/worker-hardening.test.mjs && node test/session-daemon.test.mjs && node test/symbol-registry.test.mjs && node test/bonding-curve-v3-harness.test.mjs && node test/comprehensive-bonding-curve.test.mjs && node test/fee-on-transfer-accounting.test.mjs && node test/graduation-price-continuity.test.mjs && node test/creator-pull-payment.test.mjs && node test/indexer-freshness-gate.test.mjs && node test/underwater-requalification.test.mjs && node test/integration-layer.test.mjs",
+    "test": "node test/loss-reward-audit.test.mjs && node test/worker-hardening.test.mjs && node test/session-daemon.test.mjs && node test/symbol-registry.test.mjs && node test/bonding-curve-v3-harness.test.mjs && node test/comprehensive-bonding-curve.test.mjs && node test/fee-on-transfer-accounting.test.mjs && node test/graduation-price-continuity.test.mjs && node test/creator-pull-payment.test.mjs && node test/indexer-freshness-gate.test.mjs && node test/underwater-requalification.test.mjs && node test/indexer-v4-discovery-retry.test.mjs && node test/balance-guard.test.mjs && node test/integration-layer.test.mjs",
     "daemon": "node scripts/daemon.mjs",
     "test:v4-replay": "node test/v4-trade-replay.test.mjs",
     "test:fork": "hardhat test nodejs --network robinhoodFork",

--- a/scripts/evm-indexer.mjs
+++ b/scripts/evm-indexer.mjs
@@ -703,34 +703,44 @@ export async function updateV4MarketSnapshot(tokenAddress, symbol, fetchV4CurveS
 }
 
 /**
- * Main Indexer Poller Loop
+ * Brings V4 TokenLaunched discovery up to `toBlock`, RESUMABLY: progress is committed to
+ * v4LastScannedBlock after every 5,000-block chunk, so a failure (RPC rate limit, timeout)
+ * retries only the remaining range on the next call instead of restarting from the floor.
+ * Throws on failure — callers decide what that means (see runIndexer / createIndexer).
+ *
+ * Why this replaced the old one-shot startup scan: on 2026-09-07 the daemon restarted while
+ * the RPC was rate-limited, the one-shot scan threw, v4LastScannedBlock stayed null, and the
+ * process silently indexed NO V4 trades for the rest of its life while V3 indexing continued
+ * and the heartbeat stayed "ok" — so the loss-reward worker kept paying a wallet that had
+ * fully sold. V4 discovery is now a hard precondition of every tick (below), never a
+ * best-effort startup step.
  */
-export async function runIndexer() {
-  console.log('--- Starting Incentifi EVM Indexer ---');
-  console.log(`RPC: ${RPC_URL}`);
-  console.log(`Factory: ${INCENTIFI_BONDING_CURVE_FACTORY}`);
-  console.log(`V4 Factory: ${INCENTIFI_V4_FACTORY}`);
+export async function advanceV4Discovery(toBlock) {
+  let from = v4LastScannedBlock === null ? V4_DISCOVERY_FLOOR_BLOCK : v4LastScannedBlock + 1n;
+  while (from <= toBlock) {
+    const to = from + 5000n > toBlock ? toBlock : from + 5000n;
+    await discoverV4TokensInRange(from, to);
+    v4LastScannedBlock = to;
+    from = to + 1n;
+  }
+}
 
+/** True once V4 discovery covers `block` — i.e. V4 trades in windows up to it can be indexed. */
+export function isV4DiscoveryReadyThrough(block) {
+  return v4LastScannedBlock !== null && v4LastScannedBlock >= block;
+}
+
+/**
+ * The indexer's per-tick unit of work, exposed for tests. `tick()` never throws: a failure
+ * is recorded as heartbeat status "error" (which scripts/loss-reward-worker.mjs's freshness
+ * gate treats as NOT fresh, blocking epochs) and the cursor does not advance, so the same
+ * window is retried next tick.
+ */
+export function createIndexer() {
   let lastPolledBlock = 0n;
   const curveAddressCache = new Map();
 
-  // One-time V4 TokenLaunched historical catch-up: without this, the per-tick
-  // incremental scan below (which only ever looks at the current tick's small block
-  // window) would never see a V4 token launched before this process started — there is
-  // no `tokens`-table-style registry this side can fall back on, since the whole point
-  // of event-based discovery is to work independently of that (see the V4 section's
-  // header comment above for why). Runs once, before the poller loop begins.
-  try {
-    const catchupEndBlock = await client.getBlockNumber();
-    console.log(`[V4 DISCOVERY] Running one-time historical catch-up scan (block ${V4_DISCOVERY_FLOOR_BLOCK} → ${catchupEndBlock})...`);
-    await discoverV4TokensInRange(V4_DISCOVERY_FLOOR_BLOCK, catchupEndBlock);
-    v4LastScannedBlock = catchupEndBlock;
-    console.log(`[V4 DISCOVERY] Historical catch-up complete. Found ${v4TokenSymbolCache.size} V4 token(s) so far.`);
-  } catch (err) {
-    console.error('[V4 DISCOVERY] Historical catch-up scan failed — V4 tokens will not be indexed until this succeeds on a future restart:', err.message);
-  }
-
-  setInterval(async () => {
+  async function tick() {
     try {
       const currentBlock = await client.getBlockNumber();
       if (lastPolledBlock === 0n) {
@@ -762,26 +772,28 @@ export async function runIndexer() {
       const CHUNK_SIZE = 5000n;
       const toBlock = currentBlock > fromBlock + CHUNK_SIZE ? fromBlock + CHUNK_SIZE : currentBlock;
 
-      // V4: independent of the `tokens` table (see the V4 section's header comment) and
-      // of whether any V3 tokens exist, so this runs unconditionally every tick, in its
-      // own try/catch so a V4-specific hiccup never blocks V3 indexing for this tick.
-      if (v4LastScannedBlock !== null) {
+      // V4 discovery is a HARD precondition of indexing this window: the poolId cache must
+      // cover [.., toBlock] or a V4 trade in this window would be silently skipped and the
+      // cursor would move past it for good. A failure here throws to the outer catch —
+      // heartbeat "error", cursor unchanged, retried next tick (resumably, see
+      // advanceV4Discovery) — so the loss-reward worker is blocked by its freshness gate for
+      // exactly as long as V4 holder data cannot be trusted.
+      try {
+        await advanceV4Discovery(toBlock);
+      } catch (err) {
+        throw new Error(`V4 discovery not ready (scanned through block ${v4LastScannedBlock ?? 'none yet'}, need ${toBlock}): ${err.message}`);
+      }
+
+      // V4 market snapshots: display-only, so a hiccup here (module load, RPC) is logged and
+      // retried next tick without blocking trade indexing.
+      if (v4TokenSymbolCache.size > 0) {
         try {
-          // Guard against toBlock (bounded by the unrelated V3 cursor's own chunking)
-          // ever being behind v4LastScannedBlock — keeps this cursor monotonic even if
-          // V3's own cursor is temporarily lagging chain head for some other reason.
-          if (toBlock > v4LastScannedBlock) {
-            await discoverV4TokensInRange(v4LastScannedBlock + 1n, toBlock);
-            v4LastScannedBlock = toBlock;
-          }
-          if (v4TokenSymbolCache.size > 0) {
-            const v4Module = await getV4Module();
-            for (const [tokenAddr, symbol] of v4TokenSymbolCache) {
-              await updateV4MarketSnapshot(tokenAddr, symbol, v4Module.fetchV4CurveState);
-            }
+          const v4Module = await getV4Module();
+          for (const [tokenAddr, symbol] of v4TokenSymbolCache) {
+            await updateV4MarketSnapshot(tokenAddr, symbol, v4Module.fetchV4CurveState);
           }
         } catch (err) {
-          console.warn('[V4] Discovery/snapshot pass failed this tick (will retry next tick):', err.message);
+          console.warn('[V4] Snapshot pass failed this tick (will retry next tick):', err.message);
         }
       }
 
@@ -800,9 +812,10 @@ export async function runIndexer() {
       if (tokensErr) {
         throw new Error(`[DB ERROR] Failed to fetch active tokens: ${tokensErr.code} ${tokensErr.message}`);
       }
-      if (!tokens || tokens.length === 0) return;
-
-      for (const t of tokens) {
+      // No early return on an empty registry: the cursor and heartbeat below must still
+      // advance (V4 indexing above is registry-independent, and a V4-only deployment would
+      // otherwise never heartbeat at all).
+      for (const t of tokens || []) {
         if (!t.mint_address) continue;
         const tokenAddr = t.mint_address.toLowerCase();
 
@@ -873,11 +886,45 @@ export async function runIndexer() {
       // Successfully processed all events for range; advance block pointer safely
       lastPolledBlock = toBlock;
       await upsertIndexerHeartbeat('ok', `Indexed through block ${toBlock}`);
+      return { ok: true, indexedThrough: toBlock };
     } catch (err) {
       console.error('Indexer loop error (will retry next interval without advancing block):', err.message);
       await upsertIndexerHeartbeat('error', err.message);
+      return { ok: false, error: err.message, lastPolledBlock };
     }
-  }, EVM_INDEXER_LOOP_MS);
+  }
+
+  return {
+    tick,
+    get lastPolledBlock() {
+      return lastPolledBlock;
+    },
+  };
+}
+
+/**
+ * Main Indexer Poller Loop
+ */
+export async function runIndexer() {
+  console.log('--- Starting Incentifi EVM Indexer ---');
+  console.log(`RPC: ${RPC_URL}`);
+  console.log(`Factory: ${INCENTIFI_BONDING_CURVE_FACTORY}`);
+  console.log(`V4 Factory: ${INCENTIFI_V4_FACTORY}`);
+
+  // Best-effort warm-up of V4 discovery to chain head so the first ticks are fast. NOT
+  // load-bearing: every tick re-runs advanceV4Discovery (resumable) and refuses to index
+  // until discovery covers its window, so a failure here only delays, never disables.
+  try {
+    const head = await client.getBlockNumber();
+    console.log(`[V4 DISCOVERY] Warming up discovery (block ${V4_DISCOVERY_FLOOR_BLOCK} → ${head})...`);
+    await advanceV4Discovery(head);
+    console.log(`[V4 DISCOVERY] Warm-up complete through block ${head}. Found ${v4TokenSymbolCache.size} V4 token(s) so far.`);
+  } catch (err) {
+    console.error(`[V4 DISCOVERY] Warm-up incomplete (scanned through ${v4LastScannedBlock ?? 'none yet'}); every tick will keep retrying and the heartbeat reports "error" until discovery is ready:`, err.message);
+  }
+
+  const indexer = createIndexer();
+  setInterval(() => indexer.tick(), EVM_INDEXER_LOOP_MS);
 }
 
 if (process.argv[1]?.endsWith('evm-indexer.mjs')) {

--- a/scripts/loss-reward-worker.mjs
+++ b/scripts/loss-reward-worker.mjs
@@ -156,8 +156,33 @@ export function evaluateDustGuard(totalDistributedEth, thresholdWei = MIN_EPOCH_
   return { candidateAllocatedWei, isDust: candidateAllocatedWei < thresholdWei };
 }
 
+/**
+ * On-chain balance guard (pure). `holder_cost_basis` is fed by scripts/evm-indexer.mjs and can
+ * lag or miss a sell entirely (2026-09-07: a failed V4 discovery scan left a fully-sold wallet
+ * recorded as holding 18.7M tokens and the worker published 15 epochs against it). The chain
+ * is the authority on what a wallet holds, so every payout is computed on
+ * min(dbBalance, onChainBalance). `invested` is scaled by the SAME ratio — the loss formula
+ * is `invested - balance * price`, so capping balance alone would INFLATE the loss (a zero
+ * balance would pay 10% of everything ever invested); scaling both preserves the recorded
+ * average cost basis and pays only for tokens actually held.
+ */
+export function applyOnChainBalanceCap(holder, onChainBalanceTokens) {
+  const dbBalance = Number(holder.token_balance);
+  const invested = Number(holder.total_invested_eth);
+  if (!Number.isFinite(onChainBalanceTokens) || onChainBalanceTokens < 0) {
+    throw new Error(`[BALANCE GUARD] Invalid on-chain balance for ${holder.wallet_address}: ${onChainBalanceTokens}`);
+  }
+  if (onChainBalanceTokens >= dbBalance) {
+    return { balance: dbBalance, invested, capped: false, dbBalance, onChainBalance: onChainBalanceTokens };
+  }
+  const ratio = dbBalance > 0 ? onChainBalanceTokens / dbBalance : 0;
+  return { balance: onChainBalanceTokens, invested: invested * ratio, capped: true, dbBalance, onChainBalance: onChainBalanceTokens };
+}
+
 const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 const publicClient = createPublicClient({ transport: http(RPC_URL) });
+
+const ERC20_BALANCE_ABI = parseAbi(['function balanceOf(address account) view returns (uint256)']);
 
 const FACTORY_ABI = parseAbi([
   'function getBondingCurve(address token) view returns (address)',
@@ -683,9 +708,29 @@ export async function executeEpochForToken(tokenAddress, options = {}) {
     const eligibleAllocations = [];
 
     for (const h of holders) {
-      const balance = Number(h.token_balance);
+      // On-chain balance guard — see applyOnChainBalanceCap(). FAIL CLOSED: if the chain can't
+      // be read, this epoch is skipped for this token rather than paid on unverified data.
+      let onChainBalanceTokens;
+      try {
+        const raw = await publicClient.readContract({
+          address: getAddress(token),
+          abi: ERC20_BALANCE_ABI,
+          functionName: 'balanceOf',
+          args: [getAddress(h.wallet_address)],
+        });
+        onChainBalanceTokens = Number(raw) / 1e18;
+      } catch (err) {
+        throw new Error(`[BALANCE GUARD] Could not read on-chain balance for ${h.wallet_address} — refusing to compute epoch on unverified holder data: ${err.message}`);
+      }
+      const capped = applyOnChainBalanceCap(h, onChainBalanceTokens);
+      if (capped.capped) {
+        console.warn(`[BALANCE GUARD] ${h.wallet_address}: DB balance ${capped.dbBalance} > on-chain ${capped.onChainBalance} (indexer lag or a missed sell). Paying on ${capped.balance} only.`);
+      }
+      if (!(capped.balance > 0)) continue;
+
+      const balance = capped.balance;
       const costBasis = Number(h.avg_cost_basis_eth);
-      const invested = Number(h.total_invested_eth);
+      const invested = capped.invested;
       const currentVal = balance * benchmarkPriceEth;
       const unrealizedLoss = Math.max(0, invested - currentVal);
       const theoreticalReward = 0.10 * unrealizedLoss;
@@ -947,9 +992,16 @@ export async function runEpochWorker(options = {}) {
 
   const results = [];
   for (const t of tokens) {
-    if (t.mint_address) {
+    if (!t.mint_address) continue;
+    // Per-token isolation: one token's failure (an RPC read, an unfunded operator wallet, a
+    // revert) must not abort the cycle for every token after it in the list — which is
+    // exactly what happened on 2026-09-06 when the operator ran out of gas.
+    try {
       const res = await executeEpochForToken(t.mint_address, options);
       results.push(res);
+    } catch (err) {
+      console.error(`[EPOCH WORKER] Epoch failed for ${t.mint_address} (continuing with remaining tokens): ${err.message}`);
+      results.push({ tokenAddress: String(t.mint_address).toLowerCase(), skipped: true, reason: 'error', detail: err.message });
     }
   }
   return results;

--- a/test/balance-guard.test.mjs
+++ b/test/balance-guard.test.mjs
@@ -1,0 +1,64 @@
+/**
+ * BALANCE GUARD TEST — scripts/loss-reward-worker.mjs applyOnChainBalanceCap()
+ *
+ * Pure-function coverage of the on-chain balance cap the worker now applies to every eligible
+ * holder before computing a payout (the fork counterpart, test/hardhat/phantom-balance-fork.test.ts,
+ * drives the real executeEpochForToken() end-to-end). The property that matters most: `invested`
+ * is scaled by the same ratio as `balance`, so the recorded average cost basis is preserved and a
+ * phantom (fully-sold) position pays exactly zero rather than 10% of everything ever invested.
+ *
+ * Run: node test/balance-guard.test.mjs   (offline; part of `npm test`)
+ */
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+console.log('======================================================');
+console.log('  BALANCE GUARD TEST (applyOnChainBalanceCap)');
+console.log('======================================================\n');
+
+// The worker creates its Supabase client at import; give it inert values if .env.local is absent.
+process.env.VITE_SUPABASE_URL ||= 'https://balance-guard-test.supabase.co';
+process.env.SUPABASE_SERVICE_ROLE_KEY ||= 'balance-guard-test-key';
+const { applyOnChainBalanceCap } = await import('../scripts/loss-reward-worker.mjs');
+void fs;
+
+const holder = { wallet_address: '0xba69ca72cd2b87113471c4c38f08928761edb5ce', token_balance: 18744983.522532888, total_invested_eth: 0.04, avg_cost_basis_eth: 0.04 / 18744983.522532888 };
+const basis = (r) => (r.balance > 0 ? r.invested / r.balance : 0);
+
+console.log('Testing [1/5] On-chain equals DB: no cap...');
+{
+  const r = applyOnChainBalanceCap(holder, holder.token_balance);
+  assert.equal(r.capped, false); assert.equal(r.balance, holder.token_balance); assert.equal(r.invested, 0.04);
+  console.log('  ✓ unchanged\n');
+}
+console.log('Testing [2/5] On-chain HIGHER than DB (indexer behind on a buy): pays on DB figures, never more...');
+{
+  const r = applyOnChainBalanceCap(holder, holder.token_balance * 2);
+  assert.equal(r.capped, false); assert.equal(r.balance, holder.token_balance); assert.equal(r.invested, 0.04);
+  console.log('  ✓ DB balance kept (a missed BUY can only under-pay, never over-pay)\n');
+}
+console.log('Testing [3/5] THE 2026-09-07 CASE — on-chain ZERO, DB says 18.7M: phantom position pays nothing...');
+{
+  const r = applyOnChainBalanceCap(holder, 0);
+  assert.equal(r.capped, true); assert.equal(r.balance, 0); assert.equal(r.invested, 0, 'invested MUST scale to 0 too, or the loss formula (invested - balance*price) would pay 10% of 0.04 ETH');
+  console.log(`  ✓ balance=0 invested=0 → theoretical reward 0 (uncapped code would have paid ${(0.1 * 0.04).toFixed(4)} ETH per epoch)\n`);
+}
+console.log('Testing [4/5] Partial sell not yet indexed (on-chain = half): pays on half, basis preserved...');
+{
+  const r = applyOnChainBalanceCap(holder, holder.token_balance / 2);
+  assert.equal(r.capped, true);
+  assert.ok(Math.abs(r.balance - holder.token_balance / 2) < 1e-6);
+  assert.ok(Math.abs(r.invested - 0.02) < 1e-12, `invested must halve (got ${r.invested})`);
+  assert.ok(Math.abs(basis(r) - holder.avg_cost_basis_eth) / holder.avg_cost_basis_eth < 1e-9, 'average cost basis must be unchanged by the cap');
+  console.log(`  ✓ balance halved, invested halved, basis ${basis(r).toExponential(6)} == ${holder.avg_cost_basis_eth.toExponential(6)}\n`);
+}
+console.log('Testing [5/5] Garbage on-chain value is rejected (fail closed)...');
+{
+  assert.throws(() => applyOnChainBalanceCap(holder, NaN), /BALANCE GUARD/);
+  assert.throws(() => applyOnChainBalanceCap(holder, -1), /BALANCE GUARD/);
+  console.log('  ✓ NaN / negative throw\n');
+}
+console.log('======================================================');
+console.log('  ALL 5/5 BALANCE GUARD TESTS PASSED');
+console.log('======================================================');
+process.exit(0);

--- a/test/hardhat/phantom-balance-fork.test.ts
+++ b/test/hardhat/phantom-balance-fork.test.ts
@@ -1,0 +1,179 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { network } from 'hardhat';
+import { parseEther, getAddress } from 'viem';
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+import http from 'node:http';
+import { createSupabaseRestMock } from './support/supabase-rest-mock.mjs';
+
+/**
+ * PHANTOM-BALANCE FORK TEST — the 2026-09-07 incident, reproduced and closed.
+ *
+ * What happened in production: a holder sold their ENTIRE position on-chain, the indexer missed
+ * the sell (V4 discovery had silently died), holder_cost_basis kept saying 18.7M tokens, and the
+ * REAL worker published 15 epochs of rewards against a position that no longer existed.
+ *
+ * What this test does, all on a mainnet fork with real contracts (production source), real
+ * trades, the REAL unmodified executeEpochForToken(), and Supabase mocked in-memory:
+ *   1. two holders (A, B) buy into a pump; the pump dumps; both are genuinely underwater;
+ *   2. their holder_cost_basis rows are seeded from the REAL post-buy on-chain numbers (as the
+ *      indexer would have written them);
+ *   3. THEN, without touching the DB: A sells 100% on-chain, B sells exactly 50% — the stale-DB
+ *      situation the incident was made of;
+ *   4. the real worker runs an epoch. Required: A gets NOTHING; B is paid on exactly half of the
+ *      recorded position (balance AND invested halved → basis preserved), strictly less than what
+ *      the uncapped formula would have paid; the epoch publishes on-chain only B's amount; B's
+ *      real claim lands exactly that amount net of gas.
+ *
+ * Run (isolated): npx hardhat test nodejs --network robinhoodFork -- test/hardhat/phantom-balance-fork.test.ts
+ */
+
+const WETH = getAddress('0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73');
+const UNISWAP_V3_FACTORY = getAddress('0x1f7d7550B1b028f7571E69A784071F0205FD2EfA');
+const UNISWAP_POSITION_MANAGER = getAddress('0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3');
+const SWAP_ROUTER02 = getAddress('0xcaf681a66D020601342297493863e78C959e5Cb2');
+const ZERO32 = '0x0000000000000000000000000000000000000000000000000000000000000000' as const;
+
+async function startRpcProxy(provider: { request: (args: { method: string; params?: unknown[] }) => Promise<unknown> }) {
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (chunk) => (body += chunk));
+    req.on('end', async () => {
+      try {
+        const payload = JSON.parse(body);
+        const handleOne = async (item: any) => {
+          try { return { jsonrpc: '2.0', id: item.id, result: await provider.request({ method: item.method, params: item.params }) }; }
+          catch (err: any) { return { jsonrpc: '2.0', id: item.id, error: { code: err?.code ?? -32000, message: err?.shortMessage || err?.message || String(err) } }; }
+        };
+        const out = Array.isArray(payload) ? await Promise.all(payload.map(handleOne)) : await handleOne(payload);
+        res.writeHead(200, { 'Content-Type': 'application/json' }); res.end(JSON.stringify(out));
+      } catch (err: any) { res.writeHead(500, { 'Content-Type': 'application/json' }); res.end(JSON.stringify({ error: String(err) })); }
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  return { server, url: `http://127.0.0.1:${typeof address === 'object' && address ? address.port : 0}` };
+}
+
+describe('Phantom-balance guard (real worker, real contracts on a mainnet fork, stale DB vs on-chain truth)', () => {
+  it('pays nothing to a fully-sold holder, pays a half-sold holder on exactly half, and publishes/claims exactly that', async () => {
+    const { viem, networkHelpers, provider } = await network.create('robinhoodFork');
+    const publicClient = await viem.getPublicClient();
+    const [, creator, holderA, holderB, pumpDump] = await viem.getWalletClients();
+    for (const w of [creator, holderA, holderB, pumpDump]) await networkHelpers.setBalance(w.account.address, parseEther('1000'));
+    await networkHelpers.mine(1);
+    console.log('--- Fork setup ---');
+    console.log('Forked at block:', await publicClient.getBlockNumber());
+
+    const rpcProxy = await startRpcProxy(provider);
+    try {
+      const operatorPrivateKey = generatePrivateKey();
+      const operatorAccount = privateKeyToAccount(operatorPrivateKey);
+      await networkHelpers.setBalance(operatorAccount.address, parseEther('1000'));
+
+      // Fresh, throwaway pool/factory/router/token — production source, never the real pool.
+      const pool = await viem.deployContract('LossRewardPool', [operatorAccount.address]);
+      const factory = await viem.deployContract('IncentifiBondingCurveFactory', [pool.address, WETH, UNISWAP_POSITION_MANAGER, UNISWAP_V3_FACTORY]);
+      const router = await viem.deployContract('IncentifiSwapRouter', [SWAP_ROUTER02, WETH, pool.address, factory.address]);
+      const totalSupply = 1_000_000_000n * 10n ** 18n;
+      const token = await viem.deployContract('IncentifiLaunchToken', ['Phantom Balance Test', 'PHNT', totalSupply], { client: { wallet: creator } });
+      await publicClient.waitForTransactionReceipt({ hash: await token.write.approve([factory.address, totalSupply], { account: creator.account }) });
+      await publicClient.waitForTransactionReceipt({ hash: await factory.write.registerExistingToken([token.address, creator.account.address], { account: creator.account }) });
+      const curve = await viem.getContractAt('IncentifiBondingCurve', getAddress(await factory.read.getBondingCurve([token.address])));
+      const deadline = () => BigInt(Math.floor(Date.now() / 1000) + 600);
+      console.log('Token:', token.address, '| Curve:', curve.address, '| Pool (fresh):', pool.address);
+
+      // 1. pump, two real buys, dump → A and B genuinely underwater
+      await publicClient.waitForTransactionReceipt({ hash: await router.write.buyToken([token.address, 0n, deadline()], { account: pumpDump.account, value: parseEther('3') }) });
+      await publicClient.waitForTransactionReceipt({ hash: await router.write.buyToken([token.address, 0n, deadline()], { account: holderA.account, value: parseEther('1') }) });
+      await publicClient.waitForTransactionReceipt({ hash: await router.write.buyToken([token.address, 0n, deadline()], { account: holderB.account, value: parseEther('1') }) });
+      const pumpBal = await token.read.balanceOf([pumpDump.account.address]);
+      await publicClient.waitForTransactionReceipt({ hash: await token.write.approve([router.address, pumpBal], { account: pumpDump.account }) });
+      await publicClient.waitForTransactionReceipt({ hash: await router.write.sellToken([token.address, pumpBal, 0n, deadline()], { account: pumpDump.account }) });
+
+      // 2. DB rows exactly as the indexer would have written them after the buys
+      const balA = await token.read.balanceOf([holderA.account.address]);
+      const balB = await token.read.balanceOf([holderB.account.address]);
+      const dbBalanceA = Number(balA) / 1e18, dbBalanceB = Number(balB) / 1e18;
+      const investedA = 1, investedB = 1;
+      const priceAfterDump = Number(await curve.read.getCurrentPrice()) / 1e18;
+      assert.ok(priceAfterDump < investedA / dbBalanceA && priceAfterDump < investedB / dbBalanceB, 'both holders must be genuinely underwater');
+      console.log(`A: ${dbBalanceA.toFixed(2)} tokens for 1 ETH | B: ${dbBalanceB.toFixed(2)} tokens for 1 ETH | curve price after dump ${priceAfterDump.toExponential(6)} ETH`);
+
+      // 3. THE INCIDENT: A sells 100%, B sells 50% — on-chain only; the DB rows below stay stale.
+      await publicClient.waitForTransactionReceipt({ hash: await token.write.approve([router.address, balA], { account: holderA.account }) });
+      await publicClient.waitForTransactionReceipt({ hash: await router.write.sellToken([token.address, balA, 0n, deadline()], { account: holderA.account }) });
+      const halfB = balB / 2n;
+      await publicClient.waitForTransactionReceipt({ hash: await token.write.approve([router.address, halfB], { account: holderB.account }) });
+      await publicClient.waitForTransactionReceipt({ hash: await router.write.sellToken([token.address, halfB, 0n, deadline()], { account: holderB.account }) });
+      assert.equal(await token.read.balanceOf([holderA.account.address]), 0n, 'A holds nothing on-chain');
+      const onChainB = await token.read.balanceOf([holderB.account.address]);
+      assert.equal(onChainB, balB - halfB, 'B holds exactly half on-chain');
+      console.log(`On-chain now: A = 0 tokens, B = ${(Number(onChainB) / 1e18).toFixed(2)} tokens. DB will still say A=${dbBalanceA.toFixed(2)}, B=${dbBalanceB.toFixed(2)}.`);
+
+      // fund the pool generously so funding never masks the cap
+      await publicClient.waitForTransactionReceipt({ hash: await pool.write.depositReward([token.address], { account: creator.account, value: parseEther('0.5') }) });
+
+      // 4. the REAL worker against the stale DB
+      const supaMock = createSupabaseRestMock('https://phantom-balance-fork-test.supabase.co');
+      globalThis.fetch = supaMock.fetchImpl as unknown as typeof fetch;
+      process.env.SUPABASE_URL = 'https://phantom-balance-fork-test.supabase.co';
+      process.env.SUPABASE_SERVICE_ROLE_KEY = 'dummy-service-role-key-fork-test';
+      process.env.VITE_EVM_RPC_URL = rpcProxy.url;
+      process.env.VITE_LOSS_REWARD_POOL = pool.address;
+      process.env.VITE_INCENTIFI_BONDING_CURVE_FACTORY = factory.address;
+      process.env.OPERATOR_PRIVATE_KEY = operatorPrivateKey;
+      const worker = await import('../../scripts/loss-reward-worker.mjs');
+
+      const rowA = { token_address: token.address.toLowerCase(), wallet_address: holderA.account.address.toLowerCase(), token_balance: dbBalanceA, avg_cost_basis_eth: investedA / dbBalanceA, total_invested_eth: investedA, is_eligible: true, is_underwater_seller: false };
+      const rowB = { token_address: token.address.toLowerCase(), wallet_address: holderB.account.address.toLowerCase(), token_balance: dbBalanceB, avg_cost_basis_eth: investedB / dbBalanceB, total_invested_eth: investedB, is_eligible: true, is_underwater_seller: false };
+      supaMock.seed('holder_cost_basis', [rowA, rowB]);
+
+      console.log('\n=== Real executeEpochForToken() against the stale DB ===');
+      const res = await worker.executeEpochForToken(token.address, { skipFreshnessCheck: true });
+      console.log('Epoch result:', JSON.stringify({ ...res, payouts: res.payouts?.map((p: any) => ({ wallet: p.wallet, finalRewardEth: p.finalRewardEth, balance: p.balance, invested: p.invested })) }, null, 2));
+
+      const price = res.benchmarkPriceEth as number;
+      const payouts: any[] = res.payouts || [];
+      const payoutA = payouts.find((p) => p.wallet === rowA.wallet_address);
+      const payoutB = payouts.find((p) => p.wallet === rowB.wallet_address);
+
+      // A: phantom → nothing. (Uncapped code would have paid 10% of (1 ETH − 0) = 0.1 ETH.)
+      assert.equal(payoutA, undefined, 'the fully-sold holder must receive NO payout');
+      console.log(`PASS: A (sold 100% on-chain, DB says ${dbBalanceA.toFixed(2)}) → no payout. Uncapped formula would have paid ${(0.1 * investedA).toFixed(4)} ETH.`);
+
+      // B: paid on exactly half — balance AND invested halved, basis preserved.
+      assert.ok(payoutB, 'the half-sold holder must still be paid');
+      const cappedBalance = Number(onChainB) / 1e18;
+      const expectedB = 0.1 * Math.max(0, investedB * 0.5 - cappedBalance * price);
+      const uncappedB = 0.1 * Math.max(0, investedB - dbBalanceB * price);
+      assert.ok(Math.abs(payoutB.balance - cappedBalance) < 1e-6, 'payout balance must be the ON-CHAIN balance');
+      assert.ok(Math.abs(payoutB.invested - investedB * 0.5) < 1e-12, 'invested must be scaled by the same ratio (half)');
+      assert.ok(Math.abs(payoutB.finalRewardEth - expectedB) / expectedB < 1e-9, `B payout ${payoutB.finalRewardEth} must equal 10% of the loss on the HALF position (${expectedB})`);
+      assert.ok(payoutB.finalRewardEth < uncappedB, 'capped payout must be strictly less than the stale-DB payout');
+      console.log(`PASS: B paid ${payoutB.finalRewardEth.toExponential(6)} ETH == 10% × (0.5 ETH − ${cappedBalance.toFixed(2)} × ${price.toExponential(4)}); uncapped would have been ${uncappedB.toExponential(6)} ETH.`);
+      assert.equal(res.eligibleHolders, 1);
+      assert.ok(Math.abs(res.totalDistributedEth - payoutB.finalRewardEth) < 1e-15, 'epoch total must be exactly B alone');
+
+      // Published on-chain with exactly B's amount; B's real claim lands exactly that.
+      const root = await pool.read.epochMerkleRoots([token.address, BigInt(res.epochNumber)]);
+      assert.notEqual(root, ZERO32, 'epoch must be published (B is a real underwater holder)');
+      assert.equal(root, res.merkleRoot);
+      const allocated = await pool.read.epochAllocatedAmounts([token.address, BigInt(res.epochNumber)]);
+      assert.equal(allocated, payoutB.finalRewardWei, 'on-chain allocation must be exactly B\'s capped reward');
+      const proofB = supaMock.table('epoch_holder_rewards').find((r: any) => r.wallet_address === rowB.wallet_address)?.merkle_proof;
+      assert.ok(proofB);
+      const before = await publicClient.getBalance({ address: holderB.account.address });
+      const claimRc = await publicClient.waitForTransactionReceipt({ hash: await pool.write.claimReward([token.address, BigInt(res.epochNumber), payoutB.finalRewardWei, proofB], { account: holderB.account }) });
+      const after = await publicClient.getBalance({ address: holderB.account.address });
+      assert.equal(after - before + claimRc.gasUsed * claimRc.effectiveGasPrice, payoutB.finalRewardWei, 'B claims exactly the capped amount, net of gas');
+      console.log(`PASS: root ${root.slice(0, 10)}… on-chain, allocated ${allocated} wei == B's reward; B claimed it, exact delta.`);
+      assert.equal(supaMock.table('epoch_holder_rewards').some((r: any) => r.wallet_address === rowA.wallet_address), false, 'no proof row may exist for A');
+
+      console.log('\n=== RESULT: phantom position paid 0; half-sold position paid on exactly half; published and claimed exactly ===');
+    } finally {
+      rpcProxy.server.close();
+      rpcProxy.server.closeAllConnections?.();
+    }
+  });
+});

--- a/test/indexer-v4-discovery-retry.test.mjs
+++ b/test/indexer-v4-discovery-retry.test.mjs
@@ -1,0 +1,124 @@
+/**
+ * INDEXER V4 DISCOVERY RETRY TEST — scripts/evm-indexer.mjs createIndexer().tick()
+ *
+ * Reproduces the 2026-09-07 failure mode and proves the fix:
+ *   BEFORE: the V4 TokenLaunched catch-up ran ONCE at startup; if it threw (RPC rate limit),
+ *           V4 trade indexing was silently disabled for the process lifetime while V3 indexing
+ *           continued and the heartbeat stayed "ok" — so the loss-reward worker's freshness gate
+ *           kept passing and it paid a wallet that had fully sold.
+ *   AFTER:  V4 discovery is a hard precondition of every tick, resumable per 5,000-block chunk.
+ *           While it is not ready the tick fails loudly: heartbeat status "error" (the gate treats
+ *           that as stale → epochs blocked) and the cursor does NOT advance; once the RPC recovers
+ *           the next tick completes and reports "ok". An empty `tokens` registry no longer
+ *           suppresses the heartbeat either.
+ *
+ * Offline: a tiny local JSON-RPC server stands in for the chain (eth_blockNumber / eth_getLogs),
+ * failing eth_getLogs while `phase = 'failing'`; Supabase REST is the in-memory mock used by the
+ * fork tests. The indexer module itself is real and unmodified.
+ *
+ * Run: node test/indexer-v4-discovery-retry.test.mjs   (part of `npm test`)
+ */
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import fs from 'node:fs';
+import { createSupabaseRestMock } from './hardhat/support/supabase-rest-mock.mjs';
+
+console.log('======================================================');
+console.log('  INDEXER V4 DISCOVERY RETRY TEST');
+console.log('======================================================\n');
+
+// ---- fake chain -----------------------------------------------------------------------------
+const FLOOR = 54_600_000n; // must equal V4_DISCOVERY_FLOOR_BLOCK in scripts/evm-indexer.mjs
+const HEAD = FLOOR + 12_000n; // 3 discovery chunks (5000/5000/2000) — exercises resumability
+const rpcState = { phase: 'failing', getLogsCalls: 0, failAtChunk: 2, chunkSeen: 0 };
+const hex = (n) => '0x' + BigInt(n).toString(16);
+const rpcServer = http.createServer((req, res) => {
+  let body = '';
+  req.on('data', (c) => (body += c));
+  req.on('end', () => {
+    const payload = JSON.parse(body);
+    const one = (item) => {
+      switch (item.method) {
+        case 'eth_chainId': return { jsonrpc: '2.0', id: item.id, result: hex(4663) };
+        case 'eth_blockNumber': return { jsonrpc: '2.0', id: item.id, result: hex(HEAD) };
+        case 'eth_getLogs': {
+          rpcState.getLogsCalls += 1;
+          rpcState.chunkSeen += 1;
+          // Fail from the Nth chunk on while "failing" — chunk 1 succeeds so progress is committed.
+          if (rpcState.phase === 'failing' && rpcState.chunkSeen >= rpcState.failAtChunk) {
+            return { jsonrpc: '2.0', id: item.id, error: { code: -32000, message: 'rate limited (test)' } };
+          }
+          return { jsonrpc: '2.0', id: item.id, result: [] };
+        }
+        default: return { jsonrpc: '2.0', id: item.id, error: { code: -32601, message: `unsupported in fake rpc: ${item.method}` } };
+      }
+    };
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(Array.isArray(payload) ? payload.map(one) : one(payload)));
+  });
+});
+await new Promise((r) => rpcServer.listen(0, '127.0.0.1', r));
+const RPC_URL = `http://127.0.0.1:${rpcServer.address().port}`;
+process.env.VITE_EVM_RPC_URL = RPC_URL; // .env.local does not define this key, so it survives the indexer's loader
+
+// ---- Supabase mock (installed BEFORE the indexer is imported) ---------------------------------
+function readEnvLocal(key) {
+  if (!fs.existsSync('.env.local')) return undefined;
+  let v;
+  for (const line of fs.readFileSync('.env.local', 'utf8').split(/\r?\n/)) { const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/); if (m && m[1] === key) v = m[2].replace(/^['"]|['"]$/g, ''); }
+  return v;
+}
+const supabaseUrl = readEnvLocal('VITE_SUPABASE_URL') || readEnvLocal('SUPABASE_URL') || 'https://indexer-retry-test.supabase.co';
+process.env.VITE_SUPABASE_URL ||= supabaseUrl;
+process.env.SUPABASE_SERVICE_ROLE_KEY ||= 'indexer-retry-test-key';
+const mock = createSupabaseRestMock(supabaseUrl, globalThis.fetch, { upsertKeys: { indexer_heartbeats: ['worker_name'] } });
+globalThis.fetch = mock.fetchImpl;
+// tokens registry EMPTY on purpose (see "no early return" fix); no prior trades → INIT path (head - 50)
+
+const indexer = await import('../scripts/evm-indexer.mjs');
+const idx = indexer.createIndexer();
+const heartbeat = () => mock.table('indexer_heartbeats').find((r) => r.worker_name === 'evm-indexer');
+
+// ---- Tick 1: RPC failing mid-catch-up -----------------------------------------------------------
+console.log('Testing [1/4] Tick while V4 discovery cannot complete: heartbeat=error, cursor frozen...');
+const r1 = await idx.tick();
+assert.equal(r1.ok, false, 'tick must report failure');
+assert.match(r1.error, /V4 discovery not ready/, 'failure must name V4 discovery as the cause');
+const hb1 = heartbeat();
+assert.ok(hb1, 'a heartbeat row must still be written on failure');
+assert.equal(hb1.status, 'error', 'heartbeat status must be "error" so the freshness gate blocks the worker');
+assert.match(hb1.message, /V4 discovery not ready/);
+const cursorAfterFail = idx.lastPolledBlock; // INIT set it to HEAD-50; the failed tick must not advance past it
+assert.equal(cursorAfterFail, HEAD - 50n, 'cursor must stay at its initial value after a failed tick');
+console.log(`  ✓ tick.ok=false; heartbeat status=${hb1.status} "${hb1.message.slice(0, 70)}…"; cursor=${cursorAfterFail}\n`);
+
+console.log('Testing [2/4] Resumability: progress from the chunk that DID succeed is kept...');
+assert.equal(indexer.isV4DiscoveryReadyThrough(FLOOR + 5000n), true, 'first 5,000-block chunk must be committed');
+assert.equal(indexer.isV4DiscoveryReadyThrough(FLOOR + 5001n), false, 'nothing beyond the failed chunk may be marked scanned');
+assert.equal(indexer.isV4DiscoveryReadyThrough(HEAD), false);
+console.log(`  ✓ scanned through ${FLOOR + 5000n}, not beyond (getLogs calls so far: ${rpcState.getLogsCalls})\n`);
+
+// ---- Tick 2: RPC recovered ------------------------------------------------------------------------
+console.log('Testing [3/4] Next tick after the RPC recovers: discovery completes, heartbeat=ok, cursor advances...');
+rpcState.phase = 'healthy';
+const callsBefore = rpcState.getLogsCalls;
+const r2 = await idx.tick();
+assert.equal(r2.ok, true, `tick must succeed once the RPC is healthy (got ${r2.error})`);
+assert.equal(r2.indexedThrough, HEAD);
+assert.equal(indexer.isV4DiscoveryReadyThrough(HEAD), true, 'discovery must now cover the head');
+const hb2 = heartbeat();
+assert.equal(hb2.status, 'ok');
+assert.match(hb2.message, new RegExp(`Indexed through block ${HEAD}`));
+assert.equal(idx.lastPolledBlock, HEAD, 'cursor must advance to the tick window end');
+console.log(`  ✓ heartbeat ok "${hb2.message}"; cursor=${idx.lastPolledBlock}; resumed with only ${rpcState.getLogsCalls - callsBefore} more getLogs call(s) (remaining chunks, not a restart from the floor)\n`);
+
+console.log('Testing [4/4] Empty `tokens` registry no longer suppresses the heartbeat (tick 2 above ran with zero V3 tokens)...');
+assert.equal(mock.table('tokens').length, 0);
+assert.equal(hb2.status, 'ok');
+console.log('  ✓ heartbeat written with zero registered V3 tokens\n');
+
+rpcServer.close();
+console.log('======================================================');
+console.log('  ALL 4/4 INDEXER V4 DISCOVERY RETRY TESTS PASSED');
+console.log('======================================================');
+process.exit(0);


### PR DESCRIPTION
## Incident this closes

2026-09-07 ~01:08–02:54Z: the daemon restarted during RPC rate-limiting, the indexer's **one-shot** V4 catch-up threw, and from then on the process indexed **no V4 trades** while V3 kept working and the heartbeat kept saying `ok`. A holder's full sell (tx `0xa648ea14…`, 01:18:23Z) was never indexed, `holder_cost_basis` kept 18.7M tokens, and the worker published **15 epochs (~0.0012 ETH)** to a wallet holding nothing. The freshness gate — built for exactly this — never fired because the signal it trusts was wrong.

## Part 1 — indexer: V4 discovery is fail-loud and resumable (`scripts/evm-indexer.mjs`)

- `advanceV4Discovery(toBlock)` commits progress per 5,000-block chunk and is a **hard precondition of every tick**. If it can't cover the window: heartbeat `status="error"` (→ the worker's gate blocks epochs), cursor frozen, retried next tick from the last committed chunk. Startup scan becomes a best-effort warm-up.
- V4 snapshots remain warn-only (display) and no longer sit behind discovery success.
- Empty `tokens` registry no longer suppresses the heartbeat.
- `createIndexer().tick()` exposed for tests; `runIndexer()` behaviour otherwise unchanged.

## Part 2 — worker: payouts capped at the chain (`scripts/loss-reward-worker.mjs`)

- `applyOnChainBalanceCap()`: payout computed on `min(dbBalance, balanceOf)`, with `invested` scaled by the **same ratio** — the loss formula is `invested − balance × price`, so capping balance alone would *inflate* it (a zero balance would pay 10% of everything invested). Basis preserved; phantom position pays **0**.
- The `balanceOf` read **fails closed**: RPC error ⇒ that token's epoch is skipped this cycle.
- `runEpochWorker` gets a per-token `try/catch` — one token's failure no longer aborts the rest of the cycle (the coupling seen with the unfunded operator wallet).

## Verification

| Test | Result |
|---|---|
| `test/indexer-v4-discovery-retry.test.mjs` (offline; fake JSON-RPC + REST mock, real indexer module) | tick with failing discovery → `ok=false`, heartbeat `error` "V4 discovery not ready…", cursor frozen at init; chunk 1 kept (scanned through floor+5000, not beyond); next tick → `ok`, cursor at head, only 2 more `getLogs` (remaining chunks); empty registry still heartbeats — **4/4** |
| `test/balance-guard.test.mjs` (offline) | equal/higher/zero/half/garbage — incl. 18.7M→0 pays 0 and basis preserved on a half sell — **5/5** |
| **`test/hardhat/phantom-balance-fork.test.ts`** (mainnet fork, real contracts, REAL `executeEpochForToken`) | A sold 100% on-chain, DB says 73.6M → **no payout** (old formula: 0.1 ETH); B sold 50% → **0.04441 ETH = 10% of loss on the half position** (uncapped 0.08883); root on-chain, allocated exactly B's wei, B claims with **exact delta** — **1 passing** |
| `test/hardhat/loss-reward-fork.test.ts` (regression, original 7-item suite) | passing |
| `test/v4-trade-replay.test.mjs` (regression, Fix 1 replay) | 7/7 |
| `npm test` | 13/14 (only the pre-existing `integration-layer` stale-factory assertion) |

## Operational note

After deploy, a failed V4 catch-up will show as heartbeat `status=error` with message `V4 discovery not ready (scanned through block N, need M)` and epochs will pause — that is the intended behaviour, not a new bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
