### PR TITLE
LossRewardPoolV2: creator-selected stock payout (AAPL/TSLA/NVDA) with ETH fallback — design + implementation (supersedes #18)

### DIFF
--- a/contracts/loss-reward/LossRewardPoolV2.sol
+++ b/contracts/loss-reward/LossRewardPoolV2.sol
@@ -1,0 +1,452 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {ILossRewardPoolV2} from "./interfaces/ILossRewardPoolV2.sol";
+import {IRewardSwapper} from "./interfaces/IRewardSwapper.sol";
+import {IRobinhoodStock, IRobinhoodStockFactory, IRobinhoodAccessControlsRegistry} from "./interfaces/IRobinhoodStock.sol";
+
+/**
+ * @dev Cryptographic Merkle proof verification matching OpenZeppelin standard. Identical to V1.
+ */
+library MerkleProof {
+    function verify(bytes32[] calldata proof, bytes32 root, bytes32 leaf) internal pure returns (bool) {
+        bytes32 computedHash = leaf;
+        for (uint256 i = 0; i < proof.length; i++) {
+            bytes32 proofElement = proof[i];
+            if (computedHash <= proofElement) {
+                computedHash = _efficientHash(computedHash, proofElement);
+            } else {
+                computedHash = _efficientHash(proofElement, computedHash);
+            }
+        }
+        return computedHash == root;
+    }
+
+    function _efficientHash(bytes32 a, bytes32 b) private pure returns (bytes32 value) {
+        assembly {
+            mstore(0x00, a)
+            mstore(0x20, b)
+            value := keccak256(0x00, 0x40)
+        }
+    }
+}
+
+/**
+ * @title LossRewardPoolV2
+ * @notice Holds native ETH loss-reward funds for Incentifi launch tokens and pays claims in ETH
+ *         (exactly as V1) or, when the token's creator selected one at launch, in a Robinhood
+ *         stock token bought at claim time.
+ *
+ *         Economics of a stock payout, stated once: the claimant's ETH allocation is spent buying
+ *         the selected stock at the moment of the claim, and the claimant receives whatever it
+ *         buys. There is no dollar-value promise, no oracle price, no shortfall liability. If the
+ *         stock cannot be delivered, the claimant receives the ETH allocation instead.
+ *
+ * @dev    Custody invariant: THIS CONTRACT NEVER HOLDS STOCK. The swap adapter delivers the
+ *         stock from the Uniswap pool straight to the claimant; this contract only ever custodies
+ *         ETH. Stock tokens are pausable, block-listable and admin-burnable by their issuer, so
+ *         any custody here would be a liability.
+ *
+ *         V1 compatibility: depositReward, setEpochMerkleRoot, claimReward, claimBatch, the leaf
+ *         format keccak256(bytes.concat(keccak256(abi.encode(token, epochId, claimant, amount)))),
+ *         the operator model and every V1 event/error are unchanged, so the worker changes are
+ *         address-only.
+ *
+ *         V2 fixes: receive() reverts (bare ETH is unattributable), and a per-epoch claimed cap
+ *         makes per-token accounting strict: claims <= sum(allocations) <= deposits per token, so
+ *         address(this).balance == sum over tokens of (totalDeposited - totalClaimed), exactly.
+ */
+contract LossRewardPoolV2 is ILossRewardPoolV2 {
+    // ------------------------------------------------------------------ V1 state (same names)
+    address public owner;
+    address public operator;
+
+    mapping(address => uint256) public totalDeposited;
+    mapping(address => uint256) public totalAllocated;
+    mapping(address => uint256) public totalClaimed;
+
+    mapping(address => mapping(uint256 => bytes32)) public epochMerkleRoots;
+    mapping(address => mapping(uint256 => uint256)) public epochAllocatedAmounts;
+    mapping(address => mapping(uint256 => mapping(address => bool))) public hasClaimed;
+
+    uint256 private _status;
+    uint256 private constant _NOT_ENTERED = 1;
+    uint256 private constant _ENTERED = 2;
+
+    // ------------------------------------------------------------------ V2 state
+    IRobinhoodStockFactory public immutable stockFactory;
+    IRobinhoodAccessControlsRegistry public immutable accessRegistry;
+
+    /// @notice Strict accounting: ETH claimed against each epoch, capped at its allocation.
+    mapping(address => mapping(uint256 => uint256)) public epochClaimedAmounts;
+
+    struct TokenAsset {
+        address asset;   // address(0) = ETH
+        bool assetSet;   // written exactly once, at launch
+        bool forcedEth;  // owner override, one-way
+    }
+
+    mapping(address => TokenAsset) private _tokenAssets;
+    mapping(address => AssetRoute) private _routes;
+    mapping(address => bool) public assetSetters;
+    /// @notice Applies to the BATCH TOTAL of a claim, not per epoch.
+    uint256 public minStockRewardWei;
+
+    uint16 public constant MAX_DEVIATION_BPS_CAP = 2_000; // a route may never tolerate more than 20%
+    uint32 public constant MIN_TWAP_WINDOW = 300;         // seconds
+
+    // ------------------------------------------------------------------ modifiers
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert Unauthorized();
+        _;
+    }
+
+    modifier onlyOperator() {
+        if (msg.sender != operator && msg.sender != owner) revert Unauthorized();
+        _;
+    }
+
+    modifier nonReentrant() {
+        if (_status == _ENTERED) revert ReentrancyGuardReentrantCall();
+        _status = _ENTERED;
+        _;
+        _status = _NOT_ENTERED;
+    }
+
+    constructor(address _operator, address _stockFactory, address _accessRegistry) {
+        if (_stockFactory == address(0) || _accessRegistry == address(0)) revert ZeroAddress();
+        owner = msg.sender;
+        operator = _operator == address(0) ? msg.sender : _operator;
+        stockFactory = IRobinhoodStockFactory(_stockFactory);
+        accessRegistry = IRobinhoodAccessControlsRegistry(_accessRegistry);
+        _status = _NOT_ENTERED;
+        emit OwnershipTransferred(address(0), msg.sender);
+        emit OperatorUpdated(address(0), operator);
+    }
+
+    /// @dev Bare ETH is unattributable to any token, and a labelled sink would need a privileged
+    ///      "attribute this" lever. Rejecting keeps the accounting invariant exact and loses nothing.
+    receive() external payable {
+        revert BareEthRejected();
+    }
+
+    // ================================================================== V1 surface (unchanged)
+    function depositReward(address token) external payable {
+        if (token == address(0)) revert ZeroAddress();
+        if (msg.value == 0) revert ZeroAmount();
+        totalDeposited[token] += msg.value;
+        emit RewardDeposited(token, msg.sender, msg.value);
+    }
+
+    function getUnallocatedBalance(address token) external view returns (uint256) {
+        uint256 deposited = totalDeposited[token];
+        uint256 allocated = totalAllocated[token];
+        return deposited > allocated ? deposited - allocated : 0;
+    }
+
+    function setEpochMerkleRoot(address token, uint256 epochId, bytes32 merkleRoot, uint256 allocatedAmount)
+        external
+        onlyOperator
+    {
+        if (token == address(0)) revert ZeroAddress();
+        if (merkleRoot == bytes32(0)) revert InvalidMerkleRoot();
+        if (epochMerkleRoots[token][epochId] != bytes32(0)) revert EpochAlreadyPublished();
+
+        uint256 unallocated = totalDeposited[token] - totalAllocated[token];
+        if (allocatedAmount > unallocated) revert InsufficientUnallocatedPool();
+
+        totalAllocated[token] += allocatedAmount;
+        epochMerkleRoots[token][epochId] = merkleRoot;
+        epochAllocatedAmounts[token][epochId] = allocatedAmount;
+
+        emit EpochRootPublished(token, epochId, merkleRoot, allocatedAmount);
+    }
+
+    /// @notice V1 signature. Reverts UseClaimAs when the effective payout is a stock (unless the
+    ///         amount is below minStockRewardWei, in which case ETH is paid anyway).
+    function claimReward(address token, uint256 epochId, uint256 amount, bytes32[] calldata merkleProof)
+        external
+        nonReentrant
+    {
+        _claimEpoch(token, epochId, amount, merkleProof, msg.sender);
+        _settle(token, msg.sender, amount, 0, type(uint256).max, true);
+    }
+
+    /// @notice V1 signature. See claimReward.
+    function claimBatch(address token, uint256[] calldata epochIds, uint256[] calldata amounts, bytes32[][] calldata merkleProofs)
+        external
+        nonReentrant
+    {
+        uint256 total = _claimMany(token, epochIds, amounts, merkleProofs);
+        _settle(token, msg.sender, total, 0, type(uint256).max, true);
+    }
+
+    // ================================================================== V2 claims
+    function claimRewardAs(address token, uint256 epochId, uint256 amount, bytes32[] calldata merkleProof, uint256 minAssetOut, uint256 deadline)
+        external
+        nonReentrant
+    {
+        if (block.timestamp > deadline) revert DeadlineExpired();
+        _claimEpoch(token, epochId, amount, merkleProof, msg.sender);
+        _settle(token, msg.sender, amount, minAssetOut, deadline, false);
+    }
+
+    function claimBatchAs(address token, uint256[] calldata epochIds, uint256[] calldata amounts, bytes32[][] calldata merkleProofs, uint256 minAssetOut, uint256 deadline)
+        external
+        nonReentrant
+    {
+        if (block.timestamp > deadline) revert DeadlineExpired();
+        uint256 total = _claimMany(token, epochIds, amounts, merkleProofs);
+        _settle(token, msg.sender, total, minAssetOut, deadline, false);
+    }
+
+    function _claimMany(address token, uint256[] calldata epochIds, uint256[] calldata amounts, bytes32[][] calldata merkleProofs)
+        internal
+        returns (uint256 total)
+    {
+        if (epochIds.length != amounts.length || epochIds.length != merkleProofs.length) revert ArrayLengthMismatch();
+        for (uint256 i = 0; i < epochIds.length; i++) {
+            _claimEpoch(token, epochIds[i], amounts[i], merkleProofs[i], msg.sender);
+            total += amounts[i];
+        }
+    }
+
+    /// @dev Effects first: hasClaimed and the per-epoch cap are written BEFORE any external call.
+    function _claimEpoch(address token, uint256 epochId, uint256 amount, bytes32[] calldata merkleProof, address claimant) internal {
+        bytes32 root = epochMerkleRoots[token][epochId];
+        if (root == bytes32(0)) revert EpochNotPublished();
+        if (hasClaimed[token][epochId][claimant]) revert AlreadyClaimed();
+
+        bytes32 leaf = keccak256(bytes.concat(keccak256(abi.encode(token, epochId, claimant, amount))));
+        if (!MerkleProof.verify(merkleProof, root, leaf)) revert InvalidProof();
+
+        uint256 claimedSoFar = epochClaimedAmounts[token][epochId] + amount;
+        if (claimedSoFar > epochAllocatedAmounts[token][epochId]) revert EpochOverClaimed();
+        epochClaimedAmounts[token][epochId] = claimedSoFar;
+        hasClaimed[token][epochId][claimant] = true;
+
+        emit RewardClaimed(token, epochId, claimant, amount);
+    }
+
+    // ================================================================== payout
+    /**
+     * @dev Decides ETH vs stock and pays. `legacy` marks the V1 signatures.
+     *      Order: effects (totalClaimed) -> cheap pre-checks (each failure = ETH fallback, no swap)
+     *      -> reference -> swap with amountOutMinimum = max(userMin, protocolFloor) -> on revert,
+     *      decide by which bound was binding. No post-swap outcome check can trigger a fallback:
+     *      once the adapter returns, stock has already moved.
+     */
+    function _settle(address token, address claimant, uint256 total, uint256 userMin, uint256 deadline, bool legacy) internal {
+        totalClaimed[token] += total;
+
+        TokenAsset memory ta = _tokenAssets[token];
+        if (ta.asset == address(0)) {
+            _payEth(claimant, total);
+            emit RewardPaid(token, claimant, total, address(0), 0);
+            return;
+        }
+        if (ta.forcedEth) {
+            _fallback(token, claimant, total, ta.asset, FallbackReason.ForcedEth, "");
+            return;
+        }
+        if (total < minStockRewardWei) {
+            _fallback(token, claimant, total, ta.asset, FallbackReason.BelowMinimum, "");
+            return;
+        }
+        // From here the effective payout is the stock: a V1-signature claim cannot carry the
+        // user's minAssetOut/deadline, so it must use claimRewardAs / claimBatchAs.
+        if (legacy) revert UseClaimAs();
+
+        address asset = ta.asset;
+        AssetRoute memory r = _routes[asset];
+        if (!r.enabled || r.swapper == address(0)) {
+            _fallback(token, claimant, total, asset, FallbackReason.AssetDisabled, "");
+            return;
+        }
+        if (!_isCanonicalStock(asset)) {
+            _fallback(token, claimant, total, asset, FallbackReason.RegistryMismatch, "");
+            return;
+        }
+        if (_isPaused(asset)) {
+            _fallback(token, claimant, total, asset, FallbackReason.AssetPaused, "");
+            return;
+        }
+        if (_isBlocked(claimant)) {
+            _fallback(token, claimant, total, asset, FallbackReason.ClaimantBlocked, "");
+            return;
+        }
+        IRewardSwapper swapper = IRewardSwapper(r.swapper);
+        if (swapper.poolLiquidity(r.pool) == 0) {
+            _fallback(token, claimant, total, asset, FallbackReason.NoLiquidity, "");
+            return;
+        }
+        (uint256 refOut, bool available) = swapper.referenceOut(r.pool, r.twapWindow, total);
+        if (!available) {
+            _fallback(token, claimant, total, asset, FallbackReason.ReferenceUnavailable, "");
+            return;
+        }
+        if (refOut == 0) {
+            _fallback(token, claimant, total, asset, FallbackReason.NoLiquidity, "");
+            return;
+        }
+        uint256 protocolFloor = refOut * (10_000 - r.maxDeviationBps) / 10_000;
+        uint256 amountOutMinimum = userMin > protocolFloor ? userMin : protocolFloor;
+
+        // The ETH goes as msg.value in the SAME call that swaps: a caught revert returns it atomically.
+        try swapper.swap{value: total}(asset, r.pool, amountOutMinimum, claimant, deadline) returns (uint256 assetOut) {
+            emit RewardPaid(token, claimant, total, asset, assetOut);
+        } catch (bytes memory err) {
+            if (_selector(err) == IRewardSwapper.InsufficientOutput.selector) {
+                if (protocolFloor > userMin) {
+                    // the protocol's floor was the binding bound: the protocol's choice -> ETH
+                    _fallback(token, claimant, total, asset, FallbackReason.BelowProtocolBound, err);
+                } else {
+                    // the user's bound was binding: the user's choice -> revert the claim
+                    (uint256 amountOut,) = abi.decode(_slice4(err), (uint256, uint256));
+                    revert MinOutNotMet(amountOut, userMin);
+                }
+            } else {
+                _fallback(token, claimant, total, asset, FallbackReason.SwapFailed, err);
+            }
+        }
+    }
+
+    function _fallback(address token, address claimant, uint256 total, address asset, FallbackReason reason, bytes memory data) internal {
+        _payEth(claimant, total);
+        emit RewardPaidInEthFallback(claimant, token, asset, reason, data);
+        emit RewardPaid(token, claimant, total, address(0), 0);
+    }
+
+    function _payEth(address to, uint256 amount) internal {
+        (bool success,) = to.call{value: amount}("");
+        if (!success) revert EthTransferFailed();
+    }
+
+    // ================================================================== per-token asset
+    function setRewardAsset(address token, address asset) external {
+        if (!assetSetters[msg.sender]) revert NotAssetSetter();
+        if (token == address(0)) revert ZeroAddress();
+        if (_tokenAssets[token].assetSet) revert RewardAssetAlreadySet(token);
+        if (asset != address(0) && !isSelectableAsset(asset)) revert AssetNotSelectable(asset);
+        _tokenAssets[token] = TokenAsset({asset: asset, assetSet: true, forcedEth: false});
+        emit RewardAssetSet(token, asset, msg.sender);
+    }
+
+    /// @notice One-way: once forced, the token pays ETH forever. For assets that became
+    ///         undeliverable (paused, delisted, no liquidity). Cannot move value, only change form.
+    function forceEthPayout(address token) external onlyOwner {
+        TokenAsset storage ta = _tokenAssets[token];
+        if (ta.forcedEth) return;
+        ta.forcedEth = true;
+        emit EthPayoutForced(token, ta.asset);
+    }
+
+    function rewardAsset(address token) external view returns (address asset, bool assetSet, bool forcedEth) {
+        TokenAsset memory ta = _tokenAssets[token];
+        return (ta.asset, ta.assetSet, ta.forcedEth);
+    }
+
+    function effectivePayoutAsset(address token) public view returns (address) {
+        TokenAsset memory ta = _tokenAssets[token];
+        return ta.forcedEth ? address(0) : ta.asset;
+    }
+
+    // ================================================================== allow-list / routes / config
+    function setAssetRoute(address asset, AssetRoute calldata route) external onlyOwner {
+        if (asset == address(0) || route.swapper == address(0) || route.pool == address(0)) revert ZeroAddress();
+        if (route.swapper.code.length == 0) revert InvalidRoute();
+        if (route.twapWindow < MIN_TWAP_WINDOW) revert InvalidRoute();
+        if (route.maxDeviationBps == 0 || route.maxDeviationBps > MAX_DEVIATION_BPS_CAP) revert InvalidRoute();
+        if (!_isCanonicalStock(asset)) revert AssetNotSelectable(asset);
+        if (!IRewardSwapper(route.swapper).validateRoute(asset, route.pool, route.fee)) revert InvalidRoute();
+        _routes[asset] = route;
+        emit AssetRouteSet(asset, route.swapper, route.pool, route.fee, route.twapWindow, route.maxDeviationBps, route.enabled);
+    }
+
+    function setAssetEnabled(address asset, bool enabled) external onlyOwner {
+        AssetRoute storage r = _routes[asset];
+        if (r.swapper == address(0)) revert RouteNotConfigured(asset);
+        r.enabled = enabled;
+        emit AssetRouteSet(asset, r.swapper, r.pool, r.fee, r.twapWindow, r.maxDeviationBps, enabled);
+    }
+
+    function assetRoute(address asset) external view returns (AssetRoute memory) {
+        return _routes[asset];
+    }
+
+    /// @notice Selectable = enabled route AND registry round-trip AND not paused. The contract
+    ///         trusts only the StockFactory round-trip, never a stored list of names.
+    function isSelectableAsset(address asset) public view returns (bool) {
+        AssetRoute memory r = _routes[asset];
+        if (!r.enabled || r.swapper == address(0)) return false;
+        if (!_isCanonicalStock(asset)) return false;
+        if (_isPaused(asset)) return false;
+        return true;
+    }
+
+    function setAssetSetter(address setter, bool allowed) external onlyOwner {
+        if (setter == address(0)) revert ZeroAddress();
+        assetSetters[setter] = allowed;
+        emit AssetSetterUpdated(setter, allowed);
+    }
+
+    function setMinStockReward(uint256 minStockRewardWei_) external onlyOwner {
+        minStockRewardWei = minStockRewardWei_;
+        emit MinStockRewardUpdated(minStockRewardWei_);
+    }
+
+    // ================================================================== accounting views
+    function tokenVault(address token) external view returns (uint256) {
+        return totalDeposited[token] - totalClaimed[token];
+    }
+
+    // ================================================================== admin (V1)
+    function setOperator(address _operator) external onlyOwner {
+        if (_operator == address(0)) revert ZeroAddress();
+        emit OperatorUpdated(operator, _operator);
+        operator = _operator;
+    }
+
+    function transferOwnership(address newOwner) external onlyOwner {
+        if (newOwner == address(0)) revert ZeroAddress();
+        emit OwnershipTransferred(owner, newOwner);
+        owner = newOwner;
+    }
+
+    // ================================================================== registry helpers
+    /// @dev `uid()` on an arbitrary contract may revert or return garbage; the factory mapping is
+    ///      the authority. A counterfeit returning AAPL's uid maps to AAPL's address, not its own.
+    function _isCanonicalStock(address asset) internal view returns (bool) {
+        if (asset.code.length == 0) return false;
+        (bool ok, bytes memory ret) = asset.staticcall(abi.encodeCall(IRobinhoodStock.uid, ()));
+        if (!ok || ret.length != 32) return false;
+        bytes32 uid = abi.decode(ret, (bytes32));
+        return stockFactory.tokenAddress(uid) == asset;
+    }
+
+    function _isPaused(address asset) internal view returns (bool) {
+        (bool ok, bytes memory ret) = asset.staticcall(abi.encodeCall(IRobinhoodStock.paused, ()));
+        if (!ok || ret.length != 32) return true; // unreadable = treat as undeliverable
+        return abi.decode(ret, (bool));
+    }
+
+    function _isBlocked(address account) internal view returns (bool) {
+        (bool ok, bytes memory ret) = address(accessRegistry).staticcall(abi.encodeCall(IRobinhoodAccessControlsRegistry.isBlocked, (account)));
+        if (!ok || ret.length != 32) return true;
+        return abi.decode(ret, (bool));
+    }
+
+    function _selector(bytes memory err) internal pure returns (bytes4 sel) {
+        if (err.length < 4) return bytes4(0);
+        assembly ("memory-safe") {
+            sel := mload(add(err, 32))
+        }
+    }
+
+    function _slice4(bytes memory err) internal pure returns (bytes memory out) {
+        out = new bytes(err.length - 4);
+        for (uint256 i = 0; i < out.length; i++) {
+            out[i] = err[i + 4];
+        }
+    }
+}

--- a/contracts/loss-reward/RewardSwapperUniswapV3.sol
+++ b/contracts/loss-reward/RewardSwapperUniswapV3.sol
@@ -61,13 +61,17 @@ contract RewardSwapperUniswapV3 is IRewardSwapper {
         }
     }
 
+    /// @dev The reference is net of the pool's fee tier, so the pool's `maxDeviationBps` measures
+    ///      price impact + drift only and means what it says (a 0.30% pool with a 3% tolerance
+    ///      tolerates 3% of impact, not 2.7%).
     function referenceOut(address pool, uint32 twapWindow, uint256 ethIn) external view returns (uint256 refOut, bool available) {
         (int24 tick, bool ok) = _meanTick(pool, twapWindow);
         if (!ok && twapWindow > FALLBACK_TWAP_WINDOW) (tick, ok) = _meanTick(pool, FALLBACK_TWAP_WINDOW);
         if (!ok) return (0, false);
         // token1 per token0 = (sqrtP / 2^96)^2 ; WETH is token0, asset is token1.
         uint160 sqrtP = TickMath.getSqrtPriceAtTick(tick);
-        refOut = FullMath.mulDiv(FullMath.mulDiv(ethIn, sqrtP, Q96), sqrtP, Q96);
+        uint256 ethInNetOfFee = ethIn - FullMath.mulDiv(ethIn, IUniswapV3PoolMinimal(pool).fee(), 1_000_000);
+        refOut = FullMath.mulDiv(FullMath.mulDiv(ethInNetOfFee, sqrtP, Q96), sqrtP, Q96);
         available = true;
     }
 

--- a/contracts/loss-reward/RewardSwapperUniswapV3.sol
+++ b/contracts/loss-reward/RewardSwapperUniswapV3.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {TickMath} from "@uniswap/v4-periphery/lib/v4-core/src/libraries/TickMath.sol";
+import {FullMath} from "@uniswap/v4-periphery/lib/v4-core/src/libraries/FullMath.sol";
+
+import {IRewardSwapper} from "./interfaces/IRewardSwapper.sol";
+import {IUniswapV3PoolMinimal, IUniswapV3FactoryMinimal, IWETH9} from "./interfaces/IUniswapV3Minimal.sol";
+
+/**
+ * @title RewardSwapperUniswapV3
+ * @notice Stateless adapter for LossRewardPoolV2: wraps the ETH it is sent, swaps WETH -> asset on
+ *         the canonical Uniswap V3 pool with `recipient = claimant`, and pays the pool's WETH in
+ *         the callback. The stock flows from the Uniswap pool straight to the claimant; this
+ *         contract never holds it. It holds ETH/WETH only inside one `swap` frame and asserts a
+ *         zero residual before returning.
+ * @dev    `amountOutMinimum` is enforced inside the frame: if the delivered amount is short the
+ *         whole frame (delivery included) reverts with `InsufficientOutput`, which is what lets
+ *         the pool fall back to ETH safely - nothing has moved.
+ *         Only the loss-reward pool may call `swap` (the ETH is its own custody).
+ */
+contract RewardSwapperUniswapV3 is IRewardSwapper {
+    address public immutable lossRewardPool;
+    IWETH9 public immutable weth;
+    IUniswapV3FactoryMinimal public immutable v3Factory;
+
+    /// @dev TickMath.MIN_SQRT_PRICE + 1: "sell WETH for as much asset as the pool will give".
+    uint160 internal constant SQRT_PRICE_LIMIT_ZERO_FOR_ONE = 4295128740;
+    /// @notice Secondary TWAP window when the primary one reaches past the observation ring.
+    uint32 public constant FALLBACK_TWAP_WINDOW = 600;
+    uint256 internal constant Q96 = 2 ** 96;
+
+    address private _expectedPool;
+
+    error OnlyLossRewardPool();
+    error DeadlineExpired();
+    error UnexpectedCallback();
+    error ResidualBalance();
+    error ZeroAddress();
+
+    constructor(address _lossRewardPool, address _weth, address _v3Factory) {
+        if (_lossRewardPool == address(0) || _weth == address(0) || _v3Factory == address(0)) revert ZeroAddress();
+        lossRewardPool = _lossRewardPool;
+        weth = IWETH9(_weth);
+        v3Factory = IUniswapV3FactoryMinimal(_v3Factory);
+    }
+
+    // ------------------------------------------------------------------ views
+    function validateRoute(address asset, address pool, uint24 fee) external view returns (bool) {
+        if (asset == address(0) || pool == address(0) || pool.code.length == 0) return false;
+        if (v3Factory.getPool(address(weth), asset, fee) != pool) return false;
+        // WETH must be token0 so the swap direction (zeroForOne) and the price maths below hold.
+        return IUniswapV3PoolMinimal(pool).token0() == address(weth) && IUniswapV3PoolMinimal(pool).token1() == asset;
+    }
+
+    function poolLiquidity(address pool) external view returns (uint128) {
+        try IUniswapV3PoolMinimal(pool).liquidity() returns (uint128 l) {
+            return l;
+        } catch {
+            return 0;
+        }
+    }
+
+    function referenceOut(address pool, uint32 twapWindow, uint256 ethIn) external view returns (uint256 refOut, bool available) {
+        (int24 tick, bool ok) = _meanTick(pool, twapWindow);
+        if (!ok && twapWindow > FALLBACK_TWAP_WINDOW) (tick, ok) = _meanTick(pool, FALLBACK_TWAP_WINDOW);
+        if (!ok) return (0, false);
+        // token1 per token0 = (sqrtP / 2^96)^2 ; WETH is token0, asset is token1.
+        uint160 sqrtP = TickMath.getSqrtPriceAtTick(tick);
+        refOut = FullMath.mulDiv(FullMath.mulDiv(ethIn, sqrtP, Q96), sqrtP, Q96);
+        available = true;
+    }
+
+    /// @dev Arithmetic-mean tick over `window`, V3 rounding (toward negative infinity).
+    function _meanTick(address pool, uint32 window) internal view returns (int24 tick, bool ok) {
+        uint32[] memory ago = new uint32[](2);
+        ago[0] = window;
+        ago[1] = 0;
+        try IUniswapV3PoolMinimal(pool).observe(ago) returns (int56[] memory tickCumulatives, uint160[] memory) {
+            int56 delta = tickCumulatives[1] - tickCumulatives[0];
+            int56 w = int56(uint56(window));
+            int24 t = int24(delta / w);
+            if (delta < 0 && (delta % w != 0)) t--;
+            return (t, true);
+        } catch {
+            return (0, false);
+        }
+    }
+
+    // ------------------------------------------------------------------ swap
+    function swap(address asset, address pool, uint256 amountOutMinimum, address recipient, uint256 deadline)
+        external
+        payable
+        returns (uint256 assetOut)
+    {
+        if (msg.sender != lossRewardPool) revert OnlyLossRewardPool();
+        if (block.timestamp > deadline) revert DeadlineExpired();
+        asset; // the route was validated against the factory when it was set; token1 is the asset
+
+        weth.deposit{value: msg.value}();
+        _expectedPool = pool;
+        (, int256 amount1) = IUniswapV3PoolMinimal(pool).swap(
+            recipient, true, int256(msg.value), SQRT_PRICE_LIMIT_ZERO_FOR_ONE, ""
+        );
+        _expectedPool = address(0);
+        assetOut = uint256(-amount1);
+        if (assetOut < amountOutMinimum) revert InsufficientOutput(assetOut, amountOutMinimum);
+        // Post-swap checks may only assert invariants (stock has already moved): no residual custody.
+        if (weth.balanceOf(address(this)) != 0 || address(this).balance != 0) revert ResidualBalance();
+    }
+
+    /// @dev Pays the pool its WETH. Only the pool named in the in-flight swap may call this.
+    function uniswapV3SwapCallback(int256 amount0Delta, int256, bytes calldata) external {
+        if (msg.sender != _expectedPool || _expectedPool == address(0)) revert UnexpectedCallback();
+        if (amount0Delta <= 0) revert UnexpectedCallback();
+        if (!weth.transfer(msg.sender, uint256(amount0Delta))) revert ResidualBalance();
+    }
+}

--- a/contracts/loss-reward/interfaces/ILossRewardPoolV2.sol
+++ b/contracts/loss-reward/interfaces/ILossRewardPoolV2.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+/**
+ * @title ILossRewardPoolV2
+ * @notice V1 surface preserved verbatim (same names, semantics, leaf format, operator model) plus
+ *         a creator-selected payout asset with an ETH fallback. See docs/LOSS_REWARD_ASSET_DESIGN.md.
+ */
+interface ILossRewardPoolV2 {
+    // ------------------------------------------------------------------ types
+    struct AssetRoute {
+        address swapper;        // IRewardSwapper
+        address pool;           // canonical Uniswap V3 WETH/asset pool
+        uint24 fee;             // pool fee tier
+        uint32 twapWindow;      // seconds, protocol reference
+        uint16 maxDeviationBps; // executed output must be >= TWAP-implied * (1 - this)
+        bool enabled;
+    }
+
+    enum FallbackReason {
+        ForcedEth,            // owner forced this token to ETH
+        AssetDisabled,        // no enabled route for the asset
+        RegistryMismatch,     // uid()/tokenAddress() round-trip failed at claim time
+        AssetPaused,          // asset.paused() (token or global)
+        ClaimantBlocked,      // registry.isBlocked(claimant): a transfer to them would revert
+        NoLiquidity,          // pool has no in-range liquidity / reference is zero
+        ReferenceUnavailable, // TWAP could not be read
+        BelowMinimum,         // batch total below minStockRewardWei
+        BelowProtocolBound,   // swap reverted InsufficientOutput and the protocol floor was binding
+        SwapFailed            // any other revert from the adapter / pool / token
+    }
+
+    // ------------------------------------------------------------------ V1 events
+    event RewardDeposited(address indexed token, address indexed sender, uint256 amount);
+    event EpochRootPublished(address indexed token, uint256 indexed epochId, bytes32 merkleRoot, uint256 allocatedAmount);
+    event RewardClaimed(address indexed token, uint256 indexed epochId, address indexed claimant, uint256 amount);
+    event OperatorUpdated(address indexed previousOperator, address indexed newOperator);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    // ------------------------------------------------------------------ V2 events
+    event RewardAssetSet(address indexed token, address indexed asset, address indexed setter);
+    event EthPayoutForced(address indexed token, address indexed previousAsset);
+    event AssetRouteSet(address indexed asset, address swapper, address pool, uint24 fee, uint32 twapWindow, uint16 maxDeviationBps, bool enabled);
+    event AssetSetterUpdated(address indexed setter, bool allowed);
+    event MinStockRewardUpdated(uint256 minStockRewardWei);
+    /// @dev asset == address(0) and assetAmount == 0 for an ETH payout (including every fallback).
+    event RewardPaid(address indexed token, address indexed claimant, uint256 ethAmount, address indexed asset, uint256 assetAmount);
+    event RewardPaidInEthFallback(address indexed claimant, address indexed token, address indexed asset, FallbackReason reason, bytes data);
+
+    // ------------------------------------------------------------------ V1 errors
+    error Unauthorized();
+    error ZeroAddress();
+    error ZeroAmount();
+    error EpochAlreadyPublished();
+    error InsufficientUnallocatedPool();
+    error InvalidMerkleRoot();
+    error EpochNotPublished();
+    error AlreadyClaimed();
+    error InvalidProof();
+    error EthTransferFailed();
+    error ArrayLengthMismatch();
+    error ReentrancyGuardReentrantCall();
+
+    // ------------------------------------------------------------------ V2 errors
+    /// @dev V1-signature claim on a token whose effective payout is a stock: use claimRewardAs / claimBatchAs.
+    error UseClaimAs();
+    error DeadlineExpired();
+    /// @dev The user's own minAssetOut was the binding bound and was not met; the claim reverts.
+    error MinOutNotMet(uint256 amountOut, uint256 minAssetOut);
+    error AssetNotSelectable(address asset);
+    error RewardAssetAlreadySet(address token);
+    error NotAssetSetter();
+    error EpochOverClaimed();
+    error BareEthRejected();
+    error InvalidRoute();
+    error RouteNotConfigured(address asset);
+
+    // ------------------------------------------------------------------ V1 functions (unchanged)
+    function depositReward(address token) external payable;
+    function getUnallocatedBalance(address token) external view returns (uint256);
+    function setEpochMerkleRoot(address token, uint256 epochId, bytes32 merkleRoot, uint256 allocatedAmount) external;
+    function claimReward(address token, uint256 epochId, uint256 amount, bytes32[] calldata merkleProof) external;
+    function claimBatch(address token, uint256[] calldata epochIds, uint256[] calldata amounts, bytes32[][] calldata merkleProofs) external;
+    function totalDeposited(address token) external view returns (uint256);
+    function totalAllocated(address token) external view returns (uint256);
+    function totalClaimed(address token) external view returns (uint256);
+    function epochMerkleRoots(address token, uint256 epochId) external view returns (bytes32);
+    function epochAllocatedAmounts(address token, uint256 epochId) external view returns (uint256);
+    function hasClaimed(address token, uint256 epochId, address account) external view returns (bool);
+    function owner() external view returns (address);
+    function operator() external view returns (address);
+    function setOperator(address newOperator) external;
+    function transferOwnership(address newOwner) external;
+
+    // ------------------------------------------------------------------ V2: claims that may pay in stock
+    /// @notice Works for ETH tokens too (minAssetOut is ignored; deadline is still enforced).
+    ///         minStockRewardWei applies to the BATCH TOTAL, so small epochs can be combined.
+    function claimRewardAs(address token, uint256 epochId, uint256 amount, bytes32[] calldata merkleProof, uint256 minAssetOut, uint256 deadline) external;
+    function claimBatchAs(address token, uint256[] calldata epochIds, uint256[] calldata amounts, bytes32[][] calldata merkleProofs, uint256 minAssetOut, uint256 deadline) external;
+
+    // ------------------------------------------------------------------ V2: per-token asset
+    function setRewardAsset(address token, address asset) external;
+    function forceEthPayout(address token) external;
+    function rewardAsset(address token) external view returns (address asset, bool assetSet, bool forcedEth);
+    function effectivePayoutAsset(address token) external view returns (address);
+
+    // ------------------------------------------------------------------ V2: allow-list / routes / config
+    function setAssetRoute(address asset, AssetRoute calldata route) external;
+    function setAssetEnabled(address asset, bool enabled) external;
+    function assetRoute(address asset) external view returns (AssetRoute memory);
+    function isSelectableAsset(address asset) external view returns (bool);
+    function setAssetSetter(address setter, bool allowed) external;
+    function assetSetters(address setter) external view returns (bool);
+    function setMinStockReward(uint256 minStockRewardWei_) external;
+    function minStockRewardWei() external view returns (uint256);
+
+    // ------------------------------------------------------------------ V2: strict accounting
+    function epochClaimedAmounts(address token, uint256 epochId) external view returns (uint256);
+    function tokenVault(address token) external view returns (uint256);
+}

--- a/contracts/loss-reward/interfaces/ILossRewardPoolV2.sol
+++ b/contracts/loss-reward/interfaces/ILossRewardPoolV2.sol
@@ -23,7 +23,8 @@ interface ILossRewardPoolV2 {
         RegistryMismatch,     // uid()/tokenAddress() round-trip failed at claim time
         AssetPaused,          // asset.paused() (token or global)
         ClaimantBlocked,      // registry.isBlocked(claimant): a transfer to them would revert
-        NoLiquidity,          // pool has no in-range liquidity / reference is zero
+        NoLiquidity,          // EMPTY pool: zero in-range liquidity, or a zero reference. Thin (but nonzero)
+                              // liquidity is not caught here; it surfaces in-swap as BelowProtocolBound.
         ReferenceUnavailable, // TWAP could not be read
         BelowMinimum,         // batch total below minStockRewardWei
         BelowProtocolBound,   // swap reverted InsufficientOutput and the protocol floor was binding

--- a/contracts/loss-reward/interfaces/IRewardSwapper.sol
+++ b/contracts/loss-reward/interfaces/IRewardSwapper.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+/**
+ * @title IRewardSwapper
+ * @notice A stateless adapter that turns a claimant's ETH allocation into the selected stock and
+ *         delivers it STRAIGHT to the claimant. It never holds stock, and holds ETH/WETH only
+ *         inside a single `swap` call frame.
+ * @dev    The ETH for the swap is passed as msg.value in the same call that swaps, so a caught
+ *         revert returns it to the pool atomically; nothing is ever transferred to the adapter
+ *         beforehand. `amountOutMinimum` is enforced INSIDE the swap frame (the pool's transfer to
+ *         the claimant is unwound by the revert), which is what makes fallback-on-revert safe:
+ *         nothing has moved when the pool catches `InsufficientOutput`.
+ */
+interface IRewardSwapper {
+    /// @dev The swap executed but delivered less than `amountOutMinimum`; the whole frame reverted.
+    error InsufficientOutput(uint256 amountOut, uint256 amountOutMinimum);
+
+    /// @notice True iff (pool, fee) is the canonical Uniswap V3 WETH/asset pool for `asset`.
+    function validateRoute(address asset, address pool, uint24 fee) external view returns (bool);
+
+    /// @notice Current in-range liquidity of the pool (0 if the call fails).
+    function poolLiquidity(address pool) external view returns (uint128);
+
+    /// @notice TWAP-implied output for `ethIn` over `twapWindow` seconds (falls back to a shorter
+    ///         window if the ring buffer does not reach back that far). `available == false` when
+    ///         no reference could be read at all.
+    function referenceOut(address pool, uint32 twapWindow, uint256 ethIn)
+        external
+        view
+        returns (uint256 refOut, bool available);
+
+    /// @notice Wrap msg.value, swap WETH -> asset on `pool`, deliver to `recipient`. Reverts
+    ///         `InsufficientOutput` if the delivered amount is below `amountOutMinimum`.
+    ///         Callable only by the loss-reward pool.
+    function swap(address asset, address pool, uint256 amountOutMinimum, address recipient, uint256 deadline)
+        external
+        payable
+        returns (uint256 assetOut);
+}

--- a/contracts/loss-reward/interfaces/IRobinhoodStock.sol
+++ b/contracts/loss-reward/interfaces/IRobinhoodStock.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+/// @dev Minimal view of a Robinhood Stock token (BeaconProxy -> verified `Stock`, ERC-20 + ERC-8056).
+///      Balances are RAW; `uiMultiplier()` (1e18-scaled) is display-only. `paused()` is true when
+///      the token OR the shared access-controls registry is paused; transfers then revert.
+interface IRobinhoodStock {
+    function uid() external view returns (bytes32);
+    function paused() external view returns (bool);
+    function uiMultiplier() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+    function ACCESS_CONTROLLED_REGISTRY() external view returns (address);
+}
+
+/// @dev The on-chain asset registry: Robinhood's StockFactory (ERC1967 proxy, verified `StockFactory`).
+///      `tokenAddress(uid)` is written exactly once per uid by `deploy()` and never cleared, so the
+///      canonical check is `tokenAddress(IRobinhoodStock(x).uid()) == x`.
+///      Robinhood Chain mainnet: 0x4783C67b63dE2B358Ac5951a7D41F47A38F3C046.
+interface IRobinhoodStockFactory {
+    function tokenAddress(bytes32 uid) external view returns (address);
+    function beacon() external view returns (address);
+}
+
+/// @dev Shared access-controls registry (also the beacon for every Stock). A blocked address cannot
+///      send or receive any stock token. Robinhood Chain mainnet: 0xe10b6f6B275de231345c20D14Ab812db62151b00.
+interface IRobinhoodAccessControlsRegistry {
+    function isBlocked(address account) external view returns (bool);
+    function paused() external view returns (bool);
+}

--- a/contracts/loss-reward/interfaces/IUniswapV3Minimal.sol
+++ b/contracts/loss-reward/interfaces/IUniswapV3Minimal.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+interface IUniswapV3PoolMinimal {
+    function token0() external view returns (address);
+    function token1() external view returns (address);
+    function fee() external view returns (uint24);
+    function liquidity() external view returns (uint128);
+    function slot0()
+        external
+        view
+        returns (
+            uint160 sqrtPriceX96,
+            int24 tick,
+            uint16 observationIndex,
+            uint16 observationCardinality,
+            uint16 observationCardinalityNext,
+            uint8 feeProtocol,
+            bool unlocked
+        );
+    function observe(uint32[] calldata secondsAgos)
+        external
+        view
+        returns (int56[] memory tickCumulatives, uint160[] memory secondsPerLiquidityCumulativeX128s);
+    function swap(address recipient, bool zeroForOne, int256 amountSpecified, uint160 sqrtPriceLimitX96, bytes calldata data)
+        external
+        returns (int256 amount0, int256 amount1);
+}
+
+interface IUniswapV3FactoryMinimal {
+    function getPool(address tokenA, address tokenB, uint24 fee) external view returns (address pool);
+}
+
+interface IWETH9 {
+    function deposit() external payable;
+    function transfer(address to, uint256 value) external returns (bool);
+    function balanceOf(address account) external view returns (uint256);
+}

--- a/docs/LOSS_REWARD_ASSET_DESIGN.md
+++ b/docs/LOSS_REWARD_ASSET_DESIGN.md
@@ -190,12 +190,12 @@ Incentives first: at claim time **the caller is the beneficiary**. A user-suppli
 - **The ETH for the swap is passed as `msg.value` in the same adapter call that swaps.** Nothing is transferred to the adapter in a prior call, so a caught revert returns the ETH to the pool atomically and the fallback pays it out. The adapter has no `receive()`; bare ETH to it reverts.
 
 1. **Required `minAssetOut` and `deadline`.** The frontend derives `minAssetOut` from a fresh QuoterV2 quote on the configured route × (1 − user slippage, default 1%), `deadline = now + 10 min`. Failure of *this* bound reverts the whole claim (`MinOutNotMet`) — the user's choice; nothing is consumed and they retry.
-2. **Protocol sanity bound: the V3 pool's own TWAP.** `refOut = ethIn × price(meanTick over twapWindow)` from `pool.observe([window, 0])` (V3 rounding); enforced through `amountOutMinimum` as above. **Defaults: window 1800 s, tolerance 300 bps, per asset, owner-tunable (window ≥ 300 s, tolerance ≤ 2 000 bps enforced by the contract).** Justification:
+2. **Protocol sanity bound: the V3 pool's own TWAP.** `refOut = (ethIn − ethIn × feeTier) × price(meanTick over twapWindow)` from `pool.observe([window, 0])` (V3 rounding) — **net of the pool's fee tier** (review note 1), so `maxDeviationBps` measures impact + drift only and means what it says: a 3% tolerance on the 0.30% TSLA pool tolerates 3% of impact, not 2.7%. Enforced through `amountOutMinimum` as above. **Defaults: window 1800 s, tolerance 300 bps, per asset, owner-tunable (window ≥ 300 s, tolerance ≤ 2 000 bps enforced by the contract).** Justification:
    - *Why the pool's TWAP and not Chainlink:* the stock feeds go 65 h stale over weekends (measured) while the pools trade 24/7; a hard Chainlink bound would fall back to ETH every weekend. The pool's TWAP tracks the venue the claim actually executes on.
    - *Why 30 min:* Robinhood Chain has a single sequencer, no MEV auction and ~10 blocks/s, so a spot or 1-block reference is trivially manipulable in one transaction. Moving a 30-min TWAP by 3% requires holding the pool ≥ 3% off for a large fraction of 1800 s against arbitrage from the far deeper USDG pools ($1.6M AAPL, $1.5M TSLA, $6.3M NVDA) — capital ≈ pool depth × deviation, exposed for 30 min, to skim ≤ 3% of one user's reward. All three pools carry ≥ 6 h of observations today (TSLA 13 h at cardinality 300), so 1800 s is available with > 10× margin; if `observe` reverts `OLD`, the adapter retries a 600 s window and, failing that, reports `available = false` → ETH fallback (`ReferenceUnavailable`). The fork test that pushes the AAPL pool with a 60 ETH buy inside one block confirms the TWAP does not move within that block.
    - *Why 3%:* it must exceed LP fee (0.05–0.30%) + measured impact (≤ 0.05% at 0.5 ETH) + the drift a legitimate claim can see over the window. Regular-session 30-min moves for AAPL/NVDA are typically well under 1%; TSLA can exceed 3% on news days, in which case the claim pays ETH — a safe outcome, not a loss. Tighter bounds cost users stock payouts on ordinary volatility; looser bounds shift more of the manipulation budget to the attacker.
    - *Chainlink as an extra check only when fresh:* deferred to a later adapter version. The interface allows it (`referenceOut` is the adapter's), and it would apply only when `updatedAt` is within 3600 s and the L2 sequencer feed reports up; never a hard block.
-3. **Liquidity check before attempting:** `swapper.poolLiquidity(pool) > 0` and `refOut > 0`; otherwise ETH fallback (`NoLiquidity`) with no swap attempted.
+3. **Empty-pool check before attempting:** `swapper.poolLiquidity(pool) > 0` and `refOut > 0`; otherwise ETH fallback (`NoLiquidity`) with no swap attempted. This is an *empty-pool* check, not a depth check (review note 2): in-range liquidity of 1 wei passes it. **Thin liquidity is caught inside the swap** — the executed output falls under the TWAP floor and the claim falls back as `BelowProtocolBound`. A pre-swap depth check would cost a full quote simulation (≈ the swap's own gas) for a case the in-swap bound already handles, so it is deliberately not done.
 4. **Cheap pre-checks before the swap** (~15k gas): registry round-trip, `asset.paused()` (covers token *and* global pause), `registry.isBlocked(claimant)`. Any failure → ETH fallback without a wasted swap.
 5. **Minimum reward size for stock payout.** Measured on the fork (§C5): a one-epoch AAPL claim costs 352,223 gas against 120,144 for the same ETH claim — **≈ 232k gas of stock-path overhead**, ≈ 0.00007 ETH at today's 0.305 gwei. Rule: *the marginal cost must not exceed 5% of the reward* ⇒ `minStockRewardWei = 20 × 232 000 × gasPrice` ≈ 0.0014 ETH today. **Default 0.002 ETH (≈ $5)**, owner-tunable with `MinStockRewardUpdated`; applies to the batch total (Amendment C). Below it the claim pays ETH directly (`BelowMinimum`). Stated plainly: with the current reward magnitudes on this launchpad (the last TESTINGG claim was 0.00012 ETH) most claims will land under this threshold and pay ETH; the stock path is for positions where the reward is worth the swap.
 6. **`nonReentrant`, checks-effects-interactions, `hasClaimed` before any external call** (§B3). The adapter has no storage beyond the in-flight pool address; the only re-entrant surfaces are the claimant's `receive()` on the ETH path (blocked by the guard, tested both propagated and swallowed) and the V3 callback (adapter checks `msg.sender == pool` and pays WETH only).
@@ -212,7 +212,7 @@ Every stock-path failure pays the ETH allocation instead and emits `RewardPaidIn
 | `RegistryMismatch` | `uid()` reverted or `tokenAddress(uid) != asset` at claim time | no |
 | `AssetPaused` | `asset.paused()` (token or global) | no |
 | `ClaimantBlocked` | `registry.isBlocked(claimant)` — a transfer to them would revert | no |
-| `NoLiquidity` | `liquidity() == 0` or `refOut == 0` | no |
+| `NoLiquidity` | **empty pool**: `liquidity() == 0` or `refOut == 0` (thin-but-nonzero liquidity surfaces as `BelowProtocolBound` instead) | no |
 | `ReferenceUnavailable` | TWAP `observe` reverted at both windows | no |
 | `BelowProtocolBound` | `InsufficientOutput` with the protocol floor binding (swap reverted and unwound) | yes |
 | `SwapFailed` | any other revert from the adapter/pool/token (`data` = revert bytes) | yes |
@@ -282,7 +282,7 @@ Foundry, Robinhood mainnet fork, real StockFactory / access registry / stock tok
 | Registry-valid at launch, invalid at claim → ETH fallback + event | `test_RegistryInvalidAtClaim_FallsBackToEth` | pass |
 | Below user minOut → revert; below protocol bound → fallback; distinguishable | `test_UserBoundBinding_RevertsMinOutNotMet`, `test_ProtocolBoundBinding_FallsBack_and_UserBoundStillReverts` (60 ETH push inside the block) | pass |
 | Paused stock → fallback (and not selectable) | `test_PausedAtClaim_FallsBackToEth` | pass |
-| Empty / thin liquidity → fallback, no swap | `test_ThinLiquidity_FallsBackWithoutSwapping` | pass |
+| Empty pool → fallback, no swap; thin pool → in-swap `BelowProtocolBound` | `test_ThinLiquidity_FallsBackWithoutSwapping`, `test_ProtocolBoundBinding_FallsBack_and_UserBoundStillReverts` | pass |
 | Claimant blocked → fallback | `test_ClaimantBlocked_FallsBackToEth` | pass |
 | Route disabled → fallback | `test_AssetDisabled_FallsBack` | pass |
 | Batch below min → ETH; batch above min → stock; mixed epochs | `test_MinimumReward_BatchTotal` | pass |
@@ -310,10 +310,27 @@ Foundry, Robinhood mainnet fork, real StockFactory / access registry / stock tok
 
 Slippage observed per asset in the suite (0.05–0.07 ETH claims, quiet pool): AAPL, TSLA, NVDA deliveries all above 99% of the TWAP-implied output (the user `minOut` used in `test_StockClaim_AAPL` is 99% of the reference and is met).
 
+## C6. Runbook (things that bite silently if missed)
+
+1. **Authorise the launch factory before opening launches.** After `DeployLossRewardPoolV2`, the pool must have `setAssetSetter(<legible factory>, true)` — via the script's `ASSET_SETTER` env or a separate call. Without it **every stock-asset launch reverts `NotAssetSetter`** (ETH launches still work, so the failure is easy to misread as a frontend bug). The script prints a WARNING when `ASSET_SETTER` is unset. Verify with `pool.assetSetters(factory) == true` before announcing stock rewards.
+2. **Monitor `RewardPaidInEthFallback` in production.** An adapter bug, a route pointing at a drained pool, or a paused stock degrades every stock claim to ETH **without any transaction failing** — the event is the only signal. The worker now polls the event on every run (`monitorFallbackEvents` in `scripts/loss-reward-worker.mjs`, enabled by `LOSS_REWARD_POOL_V2_ADDRESS`) and raises `sendAlert` with a per-reason breakdown whenever new fallbacks appear; `ForcedEth` and `BelowMinimum` are reported but not alerted (they are expected). Treat any `SwapFailed` / `BelowProtocolBound` / `ReferenceUnavailable` burst as an incident.
+3. **Order of operations:** deploy V2 → verify on Blockscout → `setAssetSetter` → DB migration → worker dual-pool env → frontend env → `RepointHookLossRewardPool` last (§B6).
+4. **Do not send bare ETH** to V2 or the adapter: both revert. Funding is `depositReward(token)` only.
+
+## C7. Review log (PR #18 @ ebc920f, PR #17 @ 62f8f32 — approved with five non-blocking notes)
+
+| # | Note | Resolution |
+|---|---|---|
+| 1 | `referenceOut()` ignored the pool fee, so the effective tolerance on TSLA was ~2.7% | **Fixed in code:** the reference is now net of the pool's fee tier (§B4.2); `maxDeviationBps` means what it says |
+| 2 | `poolLiquidity() == 0` is an empty-pool check, not a depth check | **Relabelled** (§B4.3, §B5, interface comment); thin liquidity is handled in-swap as `BelowProtocolBound` — a pre-swap quote would cost as much as the swap |
+| 3 | Same-block manipulation test compared against a parallel recomputation with a 1-wei tolerance | **Fixed in test:** it now asserts the contract's own `referenceOut()` before and after the push are equal to the wei |
+| 4 | Confirm `setAssetRoute()` calls `validateRoute()` and rejects on `false` | **Confirmed and stated** (§B11); tested by the wrong-pool / wrong-fee cases |
+| 5 | Runbook: `setAssetSetter` before any stock launch; monitor the fallback event rate | **Done:** §C6, deploy-script WARNING, worker `monitorFallbackEvents` + alert |
+
 ## B11. Risks and what is not verified
 
 - **Upgradeable counterparties.** StockFactory (UUPS) and every Stock (shared beacon) are upgradeable by Robinhood roles; the registry round-trip and the pause/blocklist semantics are trusted as of today's verified source. The fallback design means an adverse upgrade degrades to ETH payouts, not to stuck rewards.
-- **Owner route power** is bounded to canonical V3 pools by `validateRoute`, but a shallow canonical pool would push claims to the fallback via the TWAP bound; route changes are evented.
+- **Owner route power** is bounded to canonical V3 pools: `setAssetRoute()` calls `IRewardSwapper(route.swapper).validateRoute(asset, pool, fee)` and reverts `InvalidRoute` on `false` (canonical-factory `getPool(WETH, asset, fee) == pool`, `token0 == WETH`, `token1 == asset`), and separately requires the asset to pass the StockFactory round-trip (`AssetNotSelectable`), `twapWindow ≥ 300 s`, `0 < maxDeviationBps ≤ 2 000`, and a deployed swapper. The adapter's `swap()` trusts the stored route on the strength of that check (review note 4; tested by the wrong-pool and wrong-fee cases in `test_NonRegistryAssetRejected`). A shallow canonical pool would push claims to the fallback via the in-swap bound; route changes are evented.
 - **TWAP manipulation** is bounded, not eliminated (§B4). The user's `minAssetOut` is the primary guard.
 - **Not audited:** the `FablesRampETH` hook on the USDG/ETH pool (irrelevant while MSFT is deferred).
 - **Not measured yet:** gas of the full V2 claim with adapter overhead (C5), and behaviour of `observe()` under a burst that fills TSLA's 300-slot ring inside 30 minutes (handled by the 600 s retry and ETH fallback).

--- a/docs/LOSS_REWARD_ASSET_DESIGN.md
+++ b/docs/LOSS_REWARD_ASSET_DESIGN.md
@@ -1,6 +1,6 @@
 # Creator-selected Loss-Reward payout asset — Design Doc (Phase B, pre-Solidity)
 
-**Status:** architecture proposal. Nothing implemented, nothing deployed. Phase C starts only after this doc is approved.
+**Status:** Phase B approved with three amendments (A, B, C below); **Phase C implemented in this PR**: `LossRewardPoolV2`, `RewardSwapperUniswapV3`, deploy + re-point scripts, 24 fork tests green. **Nothing deployed.** Measured numbers in §C5.
 **Scope:** a new `LossRewardPoolV2` at a new address that pays claims in ETH (as today) or in a creator-selected Robinhood stock token (AAPL, TSLA, NVDA at launch). The loss calculation, epoch/Merkle mechanism, eligibility, leaf format and operator model are **unchanged**. Only what the claimant receives changes.
 **Not in scope:** creator fees (they live in the hook's `creatorBalances`, never touch the pool, and stay ETH — there is no coupling to design), MSFT (deferred: no deep direct WETH pool; the two-hop needs an unaudited third-party hook), any change to PR #17's curve or fee mechanics.
 
@@ -45,7 +45,7 @@ A full stock claim is therefore ≈ **350–360k gas** (baseline + overhead + ad
 | File | Role |
 |---|---|
 | `LossRewardPoolV2.sol` | The pool. V1 surface preserved verbatim + asset config + stock payout with ETH fallback. **Holds only ETH, ever.** |
-| `RewardSwapperUniswapV3.sol` | Stateless swap adapter: wrap → direct `IUniswapV3Pool.swap` with `recipient = claimant` → callback pays WETH. Computes the TWAP reference and enforces the protocol bound. Never holds stock; holds ETH/WETH only inside one call frame. |
+| `RewardSwapperUniswapV3.sol` | Stateless swap adapter: wrap → direct `IUniswapV3Pool.swap` with `recipient = claimant` → callback pays WETH. Computes the TWAP reference; enforces `amountOutMinimum` **inside the swap frame**. Never holds stock; holds ETH/WETH only inside one call frame and asserts a zero residual before returning. **`swap` is callable only by the pool** (`OnlyLossRewardPool`); it has no `receive()`. |
 | `interfaces/ILossRewardPoolV2.sol` | Full ABI (below). |
 | `interfaces/IRewardSwapper.sol` | Adapter ABI (below). |
 | `interfaces/IRobinhoodStock.sol` | Minimal `IStock` (`uid`, `paused`), `IStockFactory` (`tokenAddress`), `IAccessControlsRegistry` (`isBlocked`, `paused`). |
@@ -162,10 +162,14 @@ function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes c
 Order inside `claimBatchAs` (also `claimRewardAs`):
 
 1. `nonReentrant`; `deadline` check (reverts `DeadlineExpired` — the user's own parameter).
-2. For each epoch: `_claimEpoch` exactly as V1 (root exists, not claimed, proof verifies for `msg.sender`), **`hasClaimed = true` here, before any external call**, plus the new per-epoch cap (§B9). Sum → `total`.
+2. For each epoch: `_claimEpoch` exactly as V1 (root exists, not claimed, proof verifies for `msg.sender`), **`hasClaimed = true` and the per-epoch cap are written here, before any external call**. Sum → `total`.
 3. Effects: `totalClaimed[token] += total`.
 4. Decide payout (§B4 pre-checks). ETH path: `call{value: total}` to `msg.sender`, `RewardPaid(token, claimant, total, address(0), 0)`.
-5. Stock path: `swapper.swap{value: total}(asset, pool, minAssetOut, refFloor, msg.sender, deadline)` inside `try/catch`. The adapter wraps `total` to WETH and calls `IUniswapV3Pool.swap(recipient = claimant, zeroForOne = true, amountSpecified = total, sqrtPriceLimit = MIN+1)`. The stock goes **from the Uniswap pool straight to the claimant**; neither the pool nor the adapter ever holds it. On success: `RewardPaid(token, claimant, total, asset, assetOut)`.
+5. Stock path: `swapper.swap{value: total}(asset, pool, amountOutMinimum, msg.sender, deadline)` inside `try/catch`, with `amountOutMinimum = max(userMin, protocolFloor)` (§B4). The adapter wraps `total` to WETH and calls `IUniswapV3Pool.swap(recipient = claimant, zeroForOne = true, amountSpecified = total, sqrtPriceLimit = MIN+1)`. The stock goes **from the Uniswap pool straight to the claimant**; neither the pool nor the adapter ever holds it. On success: `RewardPaid(token, claimant, total, asset, assetOut)`.
+
+**Amendment C — the minimum applies to the batch total.** `minStockRewardWei` is compared against the summed `total` of the claim, never per epoch, so a user can combine several small epochs in one `claimBatchAs` to reach a stock payout (tested: three 0.001 ETH epochs — one alone pays ETH as `BelowMinimum`, two together pay AAPL).
+
+**Amendment B — V1 signatures on a stock token.** `claimReward` / `claimBatch` (no `minAssetOut`, no `deadline`) **revert `UseClaimAs()`** when the effective payout is a stock. They still work, and pay ETH, when the effective payout is ETH anyway: the token is ETH, `forceEthPayout` was applied, or the batch total is below `minStockRewardWei`. Stated in `ILossRewardPoolV2` and tested. The legacy relayer path in the gateway now encodes `claimBatchAs` (it remains deprecated: the pool binds `claimant = msg.sender`).
 
 **Economics, stated in the contract NatSpec, the design doc and the UI:** *your ETH allocation is spent buying the selected stock at the moment you claim; you receive whatever it buys.* There is no dollar-value promise, no oracle price, no shortfall liability, no top-up. The reward amount in the Merkle leaf is and stays ETH-denominated. If the stock cannot be delivered you receive the ETH instead.
 
@@ -176,35 +180,44 @@ Order inside `claimBatchAs` (also `claimRewardAs`):
 
 Incentives first: at claim time **the caller is the beneficiary**. A user-supplied `minAssetOut` is aligned (unlike `convert()` in PR #17, where the caller was not the beneficiary), so it is the primary protection. The protocol bound exists only to stop a buggy or hostile frontend from passing `minAssetOut = 0`.
 
+**Amendment A — bound enforcement is inside the swap, because delivery to the claimant is irreversible.** Exactly:
+
+- Before the swap the pool reads `refOut = swapper.referenceOut(pool, twapWindow, total)` and derives `protocolFloor = refOut × (1 − maxDeviationBps / 10 000)`.
+- The swap is called with **`amountOutMinimum = max(userMin, protocolFloor)`**. The adapter checks the delivered amount against it *inside the swap frame*: a shortfall reverts the frame with `InsufficientOutput(out, min)`, which unwinds the Uniswap transfer to the claimant. Nothing has moved when the pool catches it.
+- If the adapter reverts with `InsufficientOutput`: **if `protocolFloor > userMin` the protocol was the binding bound → ETH fallback (`BelowProtocolBound`); otherwise the user's bound was binding → the claim reverts (`MinOutNotMet(out, userMin)`)**. The two are distinguishable by construction and both are tested on the same manipulated pool state.
+- Any *other* revert from the adapter/pool/token (paused mid-flight, blocked pool, callback failure) → ETH fallback (`SwapFailed`, revert data attached). This is the one refinement to the amendment as written: a non-output failure is never turned into a claim revert on the user, because "a reward must never be stuck".
+- **No post-swap outcome check can trigger a fallback**: once the adapter returns, stock has moved. Post-swap checks only assert invariants — the adapter reverts `ResidualBalance` if it holds any WETH or ETH after the swap (an impossible state, hence a revert not a fallback).
+- **The ETH for the swap is passed as `msg.value` in the same adapter call that swaps.** Nothing is transferred to the adapter in a prior call, so a caught revert returns the ETH to the pool atomically and the fallback pays it out. The adapter has no `receive()`; bare ETH to it reverts.
+
 1. **Required `minAssetOut` and `deadline`.** The frontend derives `minAssetOut` from a fresh QuoterV2 quote on the configured route × (1 − user slippage, default 1%), `deadline = now + 10 min`. Failure of *this* bound reverts the whole claim (`MinOutNotMet`) — the user's choice; nothing is consumed and they retry.
-2. **Protocol sanity bound: the V3 pool's own TWAP.** `refOut = ethIn × price(meanTick over twapWindow)` from `pool.observe([window, 0])`; the executed output must satisfy `assetOut ≥ refOut × (1 − maxDeviationBps/10 000)`. Failure is *the protocol's* choice and goes to the ETH fallback (`BelowProtocolBound`), not a revert. **Proposed defaults: window 1800 s, tolerance 300 bps, per asset, owner-tunable.** Justification:
+2. **Protocol sanity bound: the V3 pool's own TWAP.** `refOut = ethIn × price(meanTick over twapWindow)` from `pool.observe([window, 0])` (V3 rounding); enforced through `amountOutMinimum` as above. **Defaults: window 1800 s, tolerance 300 bps, per asset, owner-tunable (window ≥ 300 s, tolerance ≤ 2 000 bps enforced by the contract).** Justification:
    - *Why the pool's TWAP and not Chainlink:* the stock feeds go 65 h stale over weekends (measured) while the pools trade 24/7; a hard Chainlink bound would fall back to ETH every weekend. The pool's TWAP tracks the venue the claim actually executes on.
-   - *Why 30 min:* Robinhood Chain has a single sequencer, no MEV auction and ~10 blocks/s, so a spot or 1-block reference is trivially manipulable in one transaction. Moving a 30-min TWAP by 3% requires holding the pool ≥ 3% off for a large fraction of 1800 s against arbitrage from the far deeper USDG pools ($1.6M AAPL, $1.5M TSLA, $6.3M NVDA) — capital ≈ pool depth × deviation, exposed for 30 min, to skim ≤ 3% of one user's reward. All three pools carry ≥ 6 h of observations today (TSLA 13 h at cardinality 300), so 1800 s is available with > 10× margin; if `observe` ever reverts `OLD`, the adapter retries a 600 s window and, failing that, reports `available = false` → ETH fallback (`ReferenceUnavailable`).
-   - *Why 3%:* it must exceed LP fee (0.05–0.30%) + measured impact (≤ 0.05% at 0.5 ETH) + the drift a legitimate claim can see over the window. Regular-session 30-min moves for AAPL/NVDA are typically well under 1%; TSLA can exceed 3% on news days, in which case the claim pays ETH — a safe outcome, not a loss. Tighter bounds cost users stock payouts on ordinary volatility; looser bounds shift more of the manipulation budget to the attacker. 3% is the point where the attacker's edge is smaller than a one-block sandwich would already be *without* any TWAP on a 5-block-lag arb.
-   - *Chainlink as an extra check only when fresh:* if `updatedAt` is within 3600 s and the L2 sequencer-uptime feed reports up, the adapter additionally requires the TWAP-implied USD price to be within 500 bps of the feed (USD via the ETH/USD feed, same freshness rule). Stale → skipped, never a hard block.
-3. **Liquidity check before attempting:** `pool.liquidity() > 0` and `refOut > 0`; otherwise ETH fallback (`NoLiquidity`) with no swap attempted.
+   - *Why 30 min:* Robinhood Chain has a single sequencer, no MEV auction and ~10 blocks/s, so a spot or 1-block reference is trivially manipulable in one transaction. Moving a 30-min TWAP by 3% requires holding the pool ≥ 3% off for a large fraction of 1800 s against arbitrage from the far deeper USDG pools ($1.6M AAPL, $1.5M TSLA, $6.3M NVDA) — capital ≈ pool depth × deviation, exposed for 30 min, to skim ≤ 3% of one user's reward. All three pools carry ≥ 6 h of observations today (TSLA 13 h at cardinality 300), so 1800 s is available with > 10× margin; if `observe` reverts `OLD`, the adapter retries a 600 s window and, failing that, reports `available = false` → ETH fallback (`ReferenceUnavailable`). The fork test that pushes the AAPL pool with a 60 ETH buy inside one block confirms the TWAP does not move within that block.
+   - *Why 3%:* it must exceed LP fee (0.05–0.30%) + measured impact (≤ 0.05% at 0.5 ETH) + the drift a legitimate claim can see over the window. Regular-session 30-min moves for AAPL/NVDA are typically well under 1%; TSLA can exceed 3% on news days, in which case the claim pays ETH — a safe outcome, not a loss. Tighter bounds cost users stock payouts on ordinary volatility; looser bounds shift more of the manipulation budget to the attacker.
+   - *Chainlink as an extra check only when fresh:* deferred to a later adapter version. The interface allows it (`referenceOut` is the adapter's), and it would apply only when `updatedAt` is within 3600 s and the L2 sequencer feed reports up; never a hard block.
+3. **Liquidity check before attempting:** `swapper.poolLiquidity(pool) > 0` and `refOut > 0`; otherwise ETH fallback (`NoLiquidity`) with no swap attempted.
 4. **Cheap pre-checks before the swap** (~15k gas): registry round-trip, `asset.paused()` (covers token *and* global pause), `registry.isBlocked(claimant)`. Any failure → ETH fallback without a wasted swap.
-5. **Minimum reward size for stock payout.** Marginal cost of the stock path ≈ 275k gas ≈ 0.000085 ETH at today's 0.305 gwei. Rule: *the marginal cost must not exceed 5% of the reward* ⇒ `minStockRewardWei = 20 × 275 000 × gasPrice`. **Default 0.002 ETH (≈ $5 at $2,493/ETH)**, owner-tunable with `MinStockRewardUpdated`; batches are summed first, so the threshold applies to the whole claim. Below it the claim pays ETH directly (`BelowMinimum`). Stated plainly: with the current reward magnitudes on this launchpad (the last TESTINGG claim was 0.00012 ETH) most claims will land under this threshold and pay ETH; the stock path is for positions where the reward is worth the swap.
-6. **`nonReentrant`, checks-effects-interactions, `hasClaimed` before any external call** (§B3). The adapter has no storage; the only re-entrant surfaces are the claimant's `receive()` on the ETH path (blocked by the guard) and the V3 callback (adapter checks `msg.sender == pool` and pays WETH only).
+5. **Minimum reward size for stock payout.** Measured on the fork (§C5): a one-epoch AAPL claim costs 352,223 gas against 120,144 for the same ETH claim — **≈ 232k gas of stock-path overhead**, ≈ 0.00007 ETH at today's 0.305 gwei. Rule: *the marginal cost must not exceed 5% of the reward* ⇒ `minStockRewardWei = 20 × 232 000 × gasPrice` ≈ 0.0014 ETH today. **Default 0.002 ETH (≈ $5)**, owner-tunable with `MinStockRewardUpdated`; applies to the batch total (Amendment C). Below it the claim pays ETH directly (`BelowMinimum`). Stated plainly: with the current reward magnitudes on this launchpad (the last TESTINGG claim was 0.00012 ETH) most claims will land under this threshold and pay ETH; the stock path is for positions where the reward is worth the swap.
+6. **`nonReentrant`, checks-effects-interactions, `hasClaimed` before any external call** (§B3). The adapter has no storage beyond the in-flight pool address; the only re-entrant surfaces are the claimant's `receive()` on the ETH path (blocked by the guard, tested both propagated and swallowed) and the V3 callback (adapter checks `msg.sender == pool` and pays WETH only).
 
 ## B5. Fallback — a reward must never be stuck
 
-Every stock-path failure pays the ETH allocation instead and emits `RewardPaidInEthFallback(claimant, token, asset, reason, data)`:
+Every stock-path failure pays the ETH allocation instead and emits `RewardPaidInEthFallback(claimant, token, asset, reason, data)` followed by `RewardPaid(token, claimant, total, address(0), 0)`:
 
 | Reason | When | Swap attempted? |
 |---|---|---|
 | `ForcedEth` | owner used `forceEthPayout(token)` | no |
+| `BelowMinimum` | batch `total < minStockRewardWei` (V1 signatures allowed here) | no |
 | `AssetDisabled` | route disabled/missing | no |
 | `RegistryMismatch` | `uid()` reverted or `tokenAddress(uid) != asset` at claim time | no |
-| `AssetPaused` | `asset.paused()` | no |
+| `AssetPaused` | `asset.paused()` (token or global) | no |
 | `ClaimantBlocked` | `registry.isBlocked(claimant)` — a transfer to them would revert | no |
 | `NoLiquidity` | `liquidity() == 0` or `refOut == 0` | no |
 | `ReferenceUnavailable` | TWAP `observe` reverted at both windows | no |
-| `BelowMinimum` | `total < minStockRewardWei` | no |
-| `BelowProtocolBound` | executed output under the TWAP floor (swap reverted and unwound) | yes |
+| `BelowProtocolBound` | `InsufficientOutput` with the protocol floor binding (swap reverted and unwound) | yes |
 | `SwapFailed` | any other revert from the adapter/pool/token (`data` = revert bytes) | yes |
 
-Two deliberate exceptions bubble up instead of falling back: `MinOutNotMet` (the user's own bound) and `DeadlineExpired`. The `try/catch` distinguishes them by revert selector. Because the whole swap runs in the adapter's frame, a revert unwinds the WETH wrap too; the pool's ETH is untouched and is then paid out directly.
+Three things bubble up instead of falling back, all the user's own: `MinOutNotMet` (their bound was binding), `DeadlineExpired`, and `UseClaimAs` (wrong signature for a stock token). Because the whole swap runs in the adapter's frame, a revert unwinds the WETH wrap too; the pool's ETH is untouched and is then paid out directly.
 
 ## B6. Migration
 
@@ -256,24 +269,46 @@ V1 keeps its ETH (0.0222 ETH today) and its published epochs; **no funds move be
 
 ## B10. Test plan (Phase C, Foundry, Robinhood mainnet fork, real registry/factory/pools)
 
-| Case | Setup / assertion |
+Foundry, Robinhood mainnet fork, real StockFactory / access registry / stock tokens / Uniswap V3 pools. `test/foundry/LossRewardPoolV2.t.sol` (21) + `test/foundry/LossRewardPoolV2Hook.t.sol` (3, wired to the PR #17 hook/factory/converter). **24/24 passing.**
+
+| Case | Test | Result |
+|---|---|---|
+| ETH reward byte-for-byte unchanged | `test_EthClaim_ParityWithV1` — V1 and V2 side by side, identical `RewardClaimed` topics+data, balances, counters; V1 signatures | pass |
+| AAPL reward: claim receives AAPL, ETH consumed | `test_StockClaim_AAPL` | pass |
+| TSLA on another token, same block, no cross-contamination | `test_TwoAssets_SameBlock_NoCrossContamination` | pass |
+| Creator ETH unaffected | `test_HookFeesFundV2_StockClaim_CreatorEthUntouched` (hook `creatorBalances` before/after, then pulled) | pass |
+| Non-setter / non-creator cannot set; A's creator cannot set B's | `test_SetRewardAsset_Authorisation`, `test_FactoryLaunchWithRewardAsset_AgainstV2_SetsIt` | pass |
+| Arbitrary / non-registry address rejected (asset and route) | `test_NonRegistryAssetRejected` | pass |
+| Registry-valid at launch, invalid at claim → ETH fallback + event | `test_RegistryInvalidAtClaim_FallsBackToEth` | pass |
+| Below user minOut → revert; below protocol bound → fallback; distinguishable | `test_UserBoundBinding_RevertsMinOutNotMet`, `test_ProtocolBoundBinding_FallsBack_and_UserBoundStillReverts` (60 ETH push inside the block) | pass |
+| Paused stock → fallback (and not selectable) | `test_PausedAtClaim_FallsBackToEth` | pass |
+| Empty / thin liquidity → fallback, no swap | `test_ThinLiquidity_FallsBackWithoutSwapping` | pass |
+| Claimant blocked → fallback | `test_ClaimantBlocked_FallsBackToEth` | pass |
+| Route disabled → fallback | `test_AssetDisabled_FallsBack` | pass |
+| Batch below min → ETH; batch above min → stock; mixed epochs | `test_MinimumReward_BatchTotal` | pass |
+| V1 signature on stock token reverts; on ETH / forced / below-min pays ETH | `test_V1Signatures_OnStockToken`, `test_EthClaim_ParityWithV1` | pass |
+| Reentrancy: propagated → claim reverts; swallowed → paid once | `test_Reentrancy_RevertsAndNeverDoublePays` | pass |
+| `forceEthPayout`: works, emits, owner-only, irreversible | `test_ForceEthPayout` | pass |
+| Accounting: paid + swapped + remaining == deposited, per token, mixed batch | `test_Accounting_MixedBatch` (6 claims, 3 tokens, 2 users, one fallback) | pass |
+| Adapter holds zero after every path | `assertNoCustody()` in every stock-path test (success, fallback, revert) | pass |
+| Per-epoch cap: a root over-committing an epoch cannot drain | `test_EpochOverClaimed_PerTokenAccountingIsEnforced` | pass |
+| Bare ETH rejected (pool and adapter); deadline; adapter entrypoint pool-only | `test_BareEthRejected`, `test_DeadlineExpired`, `test_AdapterSwapOnlyByPool` | pass |
+| Factory launch with rewardAsset: against V2 sets it (and surfaces V2's rejection); against V1 reverts | `test_FactoryLaunchWithRewardAsset_AgainstV2_SetsIt`, `…_AgainstV1_Reverts` | pass |
+| Deploy script runs with an EOA sender | `forge script script/DeployLossRewardPoolV2.s.sol --sender 0x1111…` dry run (no broadcast): routes validated against the live V3 factory, all three assets selectable | pass |
+
+## C5. Measured numbers (Phase C, Robinhood fork, block ≈ 56.87M)
+
+| Measurement | Value |
 |---|---|
-| ETH reward unchanged | V1 and V2 side by side, identical roots/leaves/proofs; identical events, `hasClaimed`, counters, balance deltas |
-| AAPL reward | claim receives AAPL in the claimant's wallet, ETH allocation consumed, pool/adapter hold 0 AAPL, `RewardPaid` fields |
-| TSLA on another token, same block | two tokens, two assets, claims in one block: no cross-contamination of counters or assets |
-| Creator ETH unaffected | hook `creatorBalances` identical before/after every claim |
-| Authorisation | non-setter `setRewardAsset` reverts; second write reverts; factory-level: only the launcher can pick, creator of A cannot touch B |
-| Non-registry address | counterfeit AAPL and an EOA rejected at selection (`AssetNotSelectable`) |
-| Valid at launch, invalid at claim | `vm.mockCall` on `paused()` / `tokenAddress()` → ETH fallback + event with reason |
-| Below `minAssetOut` | reverts `MinOutNotMet`, `hasClaimed` unchanged |
-| Below protocol bound | same-block price move so output < TWAP floor while `minOut = 0` → ETH fallback `BelowProtocolBound` |
-| Paused stock | mocked `paused()` true → fallback |
-| Empty / thin liquidity | mocked `liquidity()` 0 → fallback `NoLiquidity`, no swap |
-| Below minimum reward | `total < minStockRewardWei` → direct ETH, `BelowMinimum` |
-| Reentrancy | claimant contract re-enters on `receive()` and via a hostile callback → reverts, single payment |
-| `forceEthPayout` | works, emits, owner-only, irreversible |
-| Accounting | mixed batch of ETH and stock claims across tokens: Σ ETH paid + Σ ETH spent on swaps + remaining == Σ deposited per token; contract balance invariant |
-| Gas | measured per claim type, written back into this doc (C5) |
+| `claimBatchAs`, 1 epoch, empty proof, **AAPL** payout (pre-checks + TWAP + wrap + swap + delivery) | **352,223 gas** |
+| `claimBatchAs`, 1 epoch, empty proof, **ETH** payout | **120,144 gas** |
+| Stock-path overhead | **≈ 232k gas** ≈ 0.00007 ETH at 0.305 gwei (L1 data component 0) |
+| V1 `claimReward`, 1 epoch, empty proof (baseline) | 82,421 gas |
+| 0.05 ETH → AAPL via the 0.05% pool (probe, direct swap) | 0.38881 AAPL raw (× uiMultiplier 1.000566 for display) |
+| Same-block 60 ETH push on the AAPL/WETH pool | 30-min TWAP reference unchanged to the wei; spot output fell below the 3% floor → `BelowProtocolBound` fallback |
+| `minStockRewardWei` default | 0.002 ETH (5%-rule value today ≈ 0.0014 ETH) |
+
+Slippage observed per asset in the suite (0.05–0.07 ETH claims, quiet pool): AAPL, TSLA, NVDA deliveries all above 99% of the TWAP-implied output (the user `minOut` used in `test_StockClaim_AAPL` is 99% of the reference and is met).
 
 ## B11. Risks and what is not verified
 

--- a/docs/LOSS_REWARD_ASSET_DESIGN.md
+++ b/docs/LOSS_REWARD_ASSET_DESIGN.md
@@ -1,0 +1,284 @@
+# Creator-selected Loss-Reward payout asset — Design Doc (Phase B, pre-Solidity)
+
+**Status:** architecture proposal. Nothing implemented, nothing deployed. Phase C starts only after this doc is approved.
+**Scope:** a new `LossRewardPoolV2` at a new address that pays claims in ETH (as today) or in a creator-selected Robinhood stock token (AAPL, TSLA, NVDA at launch). The loss calculation, epoch/Merkle mechanism, eligibility, leaf format and operator model are **unchanged**. Only what the claimant receives changes.
+**Not in scope:** creator fees (they live in the hook's `creatorBalances`, never touch the pool, and stay ETH — there is no coupling to design), MSFT (deferred: no deep direct WETH pool; the two-hop needs an unaudited third-party hook), any change to PR #17's curve or fee mechanics.
+
+---
+
+## 0. What Phase A established (the facts this design rests on)
+
+| Fact | Value | Verified how |
+|---|---|---|
+| Live pool is not upgradeable | `0x697BDA9db5a297a9Cd9ED969BBF2549d0527DcdF`, plain contract, no proxy, no `DELEGATECALL` | bytecode + EIP-1967 slots |
+| On-chain asset registry | **StockFactory** `0x4783C67b63dE2B358Ac5951a7D41F47A38F3C046` (ERC1967/UUPS proxy, logic `0xee351e53…6ee0e`, verified) | verified source, 203 `Deployed` events, 0 duplicate uids |
+| Membership check | `IStock(candidate).uid()` → `StockFactory.tokenAddress(uid) == candidate` | round-trips for AAPL/TSLA/NVDA/MSFT; random uid → 0; counterfeit "AAPL" has no `uid()` |
+| Access-controls registry (also the beacon) | `0xe10b6f6B275de231345c20D14Ab812db62151b00` — `isBlocked(addr)`, `paused()` | verified source |
+| Stock implementation | `0xb35490d6f9163DE4F80d88dc75c3516eb64C5aE2` (`Stock`, BeaconProxy behind it). `transfer`/`transferFrom` revert if token paused, registry paused, or sender/recipient/caller blocked. `adminBurn` exists. Balances are raw; `uiMultiplier()` is display-only. | verified source |
+| The docs table is NOT an on-chain read | `AssetsTable` fetches `https://api.robinhood.com/rhj/assets` (194 assets, off-chain `ASSET_STATUS_ACTIVE`) | docs-site JS bundle |
+| Venues (WETH V3, same factory the app already uses) | AAPL `0x8bb3514e2204E1cDF3Ac149EFEe7Ff04D91B719f` 0.05% · TSLA `0xA953CA88ff430e9487c60cA34d757414f4efdA07` 0.30% · NVDA `0x62AB521f71431f78ac374CdbadC6cda3c8916b6C` 0.05%; WETH is `token0` in all three | on-chain `factory()`, `fee()`, `token0()` |
+| Price impact (V3, QuoterV2) | 0.05 ETH: ≤ 0.007% · 0.5 ETH: ≤ 0.046% | quotes |
+| V4 native-ETH pools for these three | 5% fee — quote ~6% worse. **Not used.** | `Initialize` logs |
+| TWAP availability | oldest observation: AAPL 6.0 h, NVDA 7.0 h, TSLA 13.1 h (cardinality 1400/1400/300) | fork read |
+| Chainlink | "Robinhood AAPL / USD" `0x6B22A786bAa607d76728168703a39Ea9C99f2cD0`, TSLA `0x4A1166a659A55625345e9515b32adECea5547C38`, NVDA `0x379EC4f7C378F34a1B47E4F3cbeBCbAC3E8E9F15` (8 dp, 24 h heartbeat) — **65 h stale over the weekend** | feed directory + `latestRoundData` |
+| Gas price | L2 ≈ 0.305 gwei; L1 data component `ArbGasInfo.getL1BaseFeeEstimate() == 0` | RPC |
+
+### Measured cost of the stock path (Robinhood fork, block ≈ 56.8M, 0.05 ETH, recipient = claimant, direct `IUniswapV3Pool.swap` + callback)
+
+| Step | AAPL | TSLA | NVDA |
+|---|---|---|---|
+| `observe([1800, 0])` (30-min TWAP) | 69,180 | 50,574 | 65,897 |
+| registry round-trip + `paused()` + `isBlocked(claimant)` + `liquidity()` | 32,370 | 32,370 | 32,370 |
+| `WETH.deposit` | 46,233 | 46,233 | 46,233 |
+| `pool.swap` (stock lands in the claimant's wallet) | 116,339 | 118,760 | 118,521 |
+| **stock-path overhead** | **264,394** | **248,209** | **263,293** |
+| V1 `claimReward`, 1 epoch, empty proof (baseline) | 82,421 | | |
+
+A full stock claim is therefore ≈ **350–360k gas** (baseline + overhead + adapter call), an ETH claim ≈ 82k for one epoch and ≈ 110–130k for a realistic 3-epoch batch. At today's 0.305 gwei: stock claim ≈ 0.00011 ETH (≈ $0.27), ETH claim ≈ 0.000025 ETH, **marginal cost of choosing stock ≈ 0.000085 ETH (≈ $0.21)**. The probe that produced these numbers is kept out of the repo (scratchpad `GasProbeStockClaim.t.sol`) and will be folded into the Phase C suite.
+
+---
+
+## B1. Contracts, files, interfaces
+
+### New contracts (`contracts/loss-reward/`)
+
+| File | Role |
+|---|---|
+| `LossRewardPoolV2.sol` | The pool. V1 surface preserved verbatim + asset config + stock payout with ETH fallback. **Holds only ETH, ever.** |
+| `RewardSwapperUniswapV3.sol` | Stateless swap adapter: wrap → direct `IUniswapV3Pool.swap` with `recipient = claimant` → callback pays WETH. Computes the TWAP reference and enforces the protocol bound. Never holds stock; holds ETH/WETH only inside one call frame. |
+| `interfaces/ILossRewardPoolV2.sol` | Full ABI (below). |
+| `interfaces/IRewardSwapper.sol` | Adapter ABI (below). |
+| `interfaces/IRobinhoodStock.sol` | Minimal `IStock` (`uid`, `paused`), `IStockFactory` (`tokenAddress`), `IAccessControlsRegistry` (`isBlocked`, `paused`). |
+| `interfaces/IUniswapV3PoolMinimal.sol`, `interfaces/IWETH9.sol` | Minimal external ABIs (`swap`, `observe`, `liquidity`, `token0/1`, `factory`; `deposit`, `transfer`). |
+
+Why an adapter instead of swap code inside the pool: the pool's job is accounting and custody of ETH; the adapter is the only thing that knows Uniswap. Adding MSFT later through a V3 WETH pool is then a `setAssetRoute` call (config); adding it through a two-hop would be a second adapter contract plus config, with **no change to the pool**. The adapter is owner-chosen but cannot be pointed at an arbitrary sink: it validates every route against the canonical V3 factory (`IUniswapV3Factory.getPool(WETH, asset, fee) == pool`) at `setAssetRoute` time, so the owner's power is "pick a canonical Uniswap pool", not "pick where the ETH goes".
+
+### Modified contracts
+
+| File | Change | Depends on |
+|---|---|---|
+| `contracts/v4/legible/IncentifiV4LegibleFactory.sol` | `launchToken(address token, address rewardAsset)`; existing `launchToken(token)` = ETH. After registering with the hook it calls `pool.setRewardAsset(token, rewardAsset)`. `msg.sender` (the creator) is the only party who can make that call for that token, because the factory is the only authorised setter and the call happens inside the creator's own launch transaction. | PR #17 merged |
+| `contracts/v4/legible/IncentifiV4LegibleHook.sol` | `setLossRewardPool(address)` (owner) with `LossRewardPoolUpdated(old, new)`. **Today `lossRewardPool` is `immutable` on this branch and on the live GenericSell hook.** Either PR #17 gains this setter before merge, or the legible hook is deployed with V2 as its constructor argument (V2 must then exist first). This doc assumes the setter. | PR #17 |
+
+### Scripts, tests, off-chain, frontend
+
+| File | Change |
+|---|---|
+| `script/DeployLossRewardPoolV2.s.sol` | Deploy V2 + swapper; `setAssetRoute` × 3 (validated on-chain); `setAssetSetter(legibleFactory, true)`; `setMinStockReward`; `setOperator(0x78a4E4BC…)`. Owner = `--sender` (hardware EOA). Prints everything. |
+| `script/RepointHookLossRewardPool.s.sol` | **Separate, deliberate second action:** reads `hook.lossRewardPool()`, requires V2 has code and `V2.operator()` is set, calls `hook.setLossRewardPool(V2)`, prints before/after. Never run by the deploy script. |
+| `test/foundry/LossRewardPoolV2.t.sol` (+ `LossRewardPoolV2Fallbacks.t.sol`) | Fork suite, §B10. |
+| `scripts/loss-reward-worker.mjs` | Address from env; **dual-pool mode** during migration (§B6). |
+| `scripts/evm-indexer.mjs` | `loss_pool_tvl_eth` = sum of both pools' unallocated balance for a token. |
+| `supabase/functions/loss-reward-gateway/index.ts` | `pool_address` per epoch in `/query`; legacy `/claim` relayer path stays deprecated. |
+| `supabase/loss_reward_asset_migration.sql` | `reward_epochs.pool_address` (default = V1), `tokens.reward_asset`, `tokens.reward_asset_symbol`. |
+| `src/lib/uniswapAddresses.ts` | `LOSS_REWARD_POOL` → V2, new `LOSS_REWARD_POOL_LEGACY` → V1. |
+| `src/lib/lossReward.ts` | claims grouped by pool; `claimBatchAs` with quote-derived `minOut` + deadline for V2; V1 path unchanged. |
+| `src/lib/rewardAssets.ts` (new) | Allow-list = on-chain `assetRoute(asset).enabled` ∩ API `ASSET_STATUS_ACTIVE`; `uiMultiplier()` display helper; `previewStockOut()`. |
+| `src/lib/createEvmToken.ts`, `src/pages/launch/page.tsx` | Reward-asset dropdown; passes the address to `launchToken(token, asset)`. |
+| `src/pages/token-preview/page.tsx` | "Loss Reward: AAPL" badge, claim copy, "you will receive ≈ X AAPL", legacy-pool claims section. |
+| `scripts/claim-loss-rewards.mjs`, `scripts/check-live-deployment.mjs` | V2 + `minOut`/deadline flags; both addresses. |
+
+### Interfaces
+
+```solidity
+// ---------- ILossRewardPoolV2 ----------
+// V1 surface, byte-for-byte semantics (worker/CLI/gateway changes are address-only):
+function depositReward(address token) external payable;
+function getUnallocatedBalance(address token) external view returns (uint256);
+function setEpochMerkleRoot(address token, uint256 epochId, bytes32 merkleRoot, uint256 allocatedAmount) external; // onlyOperator
+function claimReward(address token, uint256 epochId, uint256 amount, bytes32[] calldata proof) external;            // ETH tokens only
+function claimBatch(address token, uint256[] calldata epochIds, uint256[] calldata amounts, bytes32[][] calldata proofs) external; // ETH tokens only
+function totalDeposited(address) external view returns (uint256);
+function totalAllocated(address) external view returns (uint256);
+function totalClaimed(address) external view returns (uint256);
+function epochMerkleRoots(address, uint256) external view returns (bytes32);
+function epochAllocatedAmounts(address, uint256) external view returns (uint256);
+function hasClaimed(address, uint256, address) external view returns (bool);
+function owner() external view returns (address);
+function operator() external view returns (address);
+function setOperator(address) external;          // onlyOwner
+function transferOwnership(address) external;    // onlyOwner
+// leaf: keccak256(bytes.concat(keccak256(abi.encode(token, epochId, claimant, amount))))  — unchanged
+
+// New: claims that may pay in stock (work for ETH tokens too; minAssetOut/deadline ignored there)
+function claimRewardAs(address token, uint256 epochId, uint256 amount, bytes32[] calldata proof,
+                       uint256 minAssetOut, uint256 deadline) external;
+function claimBatchAs(address token, uint256[] calldata epochIds, uint256[] calldata amounts, bytes32[][] calldata proofs,
+                      uint256 minAssetOut, uint256 deadline) external;
+
+// Per-token asset (set once, at launch, by an authorised setter = the launch factory)
+function setRewardAsset(address token, address asset) external;      // onlyAssetSetter, reverts if already set
+function forceEthPayout(address token) external;                     // onlyOwner, one-way
+function rewardAsset(address token) external view returns (address asset, bool assetSet, bool forcedEth);
+function effectivePayoutAsset(address token) external view returns (address); // address(0) = ETH
+
+// Allow-list / routes (owner). Adding an asset later is a call, not code.
+struct AssetRoute { address swapper; address pool; uint24 fee; uint32 twapWindow; uint16 maxDeviationBps; bool enabled; }
+function setAssetRoute(address asset, AssetRoute calldata route) external;   // validates via swapper.validateRoute()
+function setAssetEnabled(address asset, bool enabled) external;
+function assetRoute(address asset) external view returns (AssetRoute memory);
+function isSelectableAsset(address asset) external view returns (bool);      // enabled && registry round-trip && !paused()
+function setAssetSetter(address setter, bool allowed) external;             // onlyOwner (factories)
+function setMinStockReward(uint256 wei_) external;                          // onlyOwner
+function minStockRewardWei() external view returns (uint256);
+
+// Strict per-token accounting
+function epochClaimedAmounts(address token, uint256 epochId) external view returns (uint256);
+function tokenVault(address token) external view returns (uint256);         // totalDeposited - totalClaimed
+
+// Events (V1 events kept: RewardDeposited, EpochRootPublished, RewardClaimed, OperatorUpdated, OwnershipTransferred)
+event RewardAssetSet(address indexed token, address indexed asset, address indexed setter);
+event EthPayoutForced(address indexed token, address indexed previousAsset);
+event AssetRouteSet(address indexed asset, address swapper, address pool, uint24 fee, uint32 twapWindow, uint16 maxDeviationBps, bool enabled);
+event AssetSetterUpdated(address indexed setter, bool allowed);
+event MinStockRewardUpdated(uint256 wei_);
+event RewardPaid(address indexed token, address indexed claimant, uint256 ethAmount, address indexed asset, uint256 assetAmount); // asset = 0 for ETH
+event RewardPaidInEthFallback(address indexed claimant, address indexed token, address indexed asset, FallbackReason reason, bytes data);
+enum FallbackReason { ForcedEth, AssetDisabled, RegistryMismatch, AssetPaused, ClaimantBlocked, NoLiquidity, ReferenceUnavailable, BelowMinimum, BelowProtocolBound, SwapFailed }
+
+// Errors (V1 errors kept) + SwapParamsRequired(), DeadlineExpired(), MinOutNotMet(uint256 out, uint256 minOut),
+//   AssetNotSelectable(address), RewardAssetAlreadySet(address), NotAssetSetter(), EpochOverClaimed(), BareEthRejected(), InvalidRoute()
+
+// ---------- IRewardSwapper ----------
+function validateRoute(address asset, address pool, uint24 fee) external view returns (bool);        // canonical factory check, token1 == asset, token0 == WETH
+function referenceOut(address asset, address pool, uint32 twapWindow, uint256 ethIn) external view
+        returns (uint256 refOut, bool available);                                                      // TWAP-implied output; available=false if observe() reverts
+function swap(address asset, address pool, uint256 minOut, uint256 refFloor, address recipient, uint256 deadline)
+        external payable returns (uint256 assetOut);                                                   // reverts MinOutNotMet | BelowProtocolBound | pool errors
+function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes calldata data) external;
+```
+
+---
+
+## B2. Per-token asset config
+
+- **Chosen once, at launch, via the factory; immutable.** `launchToken(token, asset)` → `pool.setRewardAsset(token, asset)`. `asset == address(0)` means ETH and is also recorded (`assetSet = true`), so *every* launched token is pinned. A token with no record (pre-V2 tokens, V3-curve tokens) is ETH by default.
+- **Validated against the registry at selection time** (`isSelectableAsset`): route enabled, `IStock(asset).uid()` in `try/catch`, `StockFactory.tokenAddress(uid) == asset`, `!IStock(asset).paused()`. The frontend's dropdown comes from the API filtered to `ACTIVE`, intersected with `assetRoute(asset).enabled`; the contract trusts only the factory round-trip.
+- **Who can set:** only addresses in `assetSetters` (the legible factory; any future factory is one `setAssetSetter` call). The factory only calls it inside the creator's launch transaction, so "non-creator cannot set an asset" and "creator of A cannot set B's" hold at both layers: the pool refuses non-setters and refuses second writes; the factory refuses non-launchers.
+- **Owner override: `forceEthPayout(token)`**, one-way, emits `EthPayoutForced`. **For:** stock tokens are pausable, block-listable and admin-burnable by Robinhood, and pools can drain — without the override every claim on a dead asset still ends in the ETH fallback, but only after each user pays for a doomed attempt (~100k gas of pre-checks and a reverted swap) and sees a confusing "fallback" event. The override makes the state explicit, cheap and honest in the UI. It cannot extract value: the only thing the owner can do is pay the base asset the pool already holds. **Against:** it is owner discretion over a creator's promise. Mitigations that make it acceptable: it is irreversible (cannot be flipped back to stock, so it cannot be used to time markets), it is evented, and the fallback path exists regardless, so the override never changes *whether* users get paid, only *how cheaply*. **Recommendation: keep it.**
+
+## B3. Claim-time conversion
+
+Order inside `claimBatchAs` (also `claimRewardAs`):
+
+1. `nonReentrant`; `deadline` check (reverts `DeadlineExpired` — the user's own parameter).
+2. For each epoch: `_claimEpoch` exactly as V1 (root exists, not claimed, proof verifies for `msg.sender`), **`hasClaimed = true` here, before any external call**, plus the new per-epoch cap (§B9). Sum → `total`.
+3. Effects: `totalClaimed[token] += total`.
+4. Decide payout (§B4 pre-checks). ETH path: `call{value: total}` to `msg.sender`, `RewardPaid(token, claimant, total, address(0), 0)`.
+5. Stock path: `swapper.swap{value: total}(asset, pool, minAssetOut, refFloor, msg.sender, deadline)` inside `try/catch`. The adapter wraps `total` to WETH and calls `IUniswapV3Pool.swap(recipient = claimant, zeroForOne = true, amountSpecified = total, sqrtPriceLimit = MIN+1)`. The stock goes **from the Uniswap pool straight to the claimant**; neither the pool nor the adapter ever holds it. On success: `RewardPaid(token, claimant, total, asset, assetOut)`.
+
+**Economics, stated in the contract NatSpec, the design doc and the UI:** *your ETH allocation is spent buying the selected stock at the moment you claim; you receive whatever it buys.* There is no dollar-value promise, no oracle price, no shortfall liability, no top-up. The reward amount in the Merkle leaf is and stays ETH-denominated. If the stock cannot be delivered you receive the ETH instead.
+
+**UI copy (token page, claim panel, for a stock token):**
+> Loss rewards for this token are paid in **AAPL**. When you claim, your ETH reward (≈ 0.0123 ETH) is used to buy AAPL on Uniswap and sent to your wallet — you receive whatever it buys at that moment (≈ 0.0956 AAPL now; this is an estimate, not a guarantee). If AAPL can't be delivered, you receive the ETH instead.
+
+## B4. Swap protection
+
+Incentives first: at claim time **the caller is the beneficiary**. A user-supplied `minAssetOut` is aligned (unlike `convert()` in PR #17, where the caller was not the beneficiary), so it is the primary protection. The protocol bound exists only to stop a buggy or hostile frontend from passing `minAssetOut = 0`.
+
+1. **Required `minAssetOut` and `deadline`.** The frontend derives `minAssetOut` from a fresh QuoterV2 quote on the configured route × (1 − user slippage, default 1%), `deadline = now + 10 min`. Failure of *this* bound reverts the whole claim (`MinOutNotMet`) — the user's choice; nothing is consumed and they retry.
+2. **Protocol sanity bound: the V3 pool's own TWAP.** `refOut = ethIn × price(meanTick over twapWindow)` from `pool.observe([window, 0])`; the executed output must satisfy `assetOut ≥ refOut × (1 − maxDeviationBps/10 000)`. Failure is *the protocol's* choice and goes to the ETH fallback (`BelowProtocolBound`), not a revert. **Proposed defaults: window 1800 s, tolerance 300 bps, per asset, owner-tunable.** Justification:
+   - *Why the pool's TWAP and not Chainlink:* the stock feeds go 65 h stale over weekends (measured) while the pools trade 24/7; a hard Chainlink bound would fall back to ETH every weekend. The pool's TWAP tracks the venue the claim actually executes on.
+   - *Why 30 min:* Robinhood Chain has a single sequencer, no MEV auction and ~10 blocks/s, so a spot or 1-block reference is trivially manipulable in one transaction. Moving a 30-min TWAP by 3% requires holding the pool ≥ 3% off for a large fraction of 1800 s against arbitrage from the far deeper USDG pools ($1.6M AAPL, $1.5M TSLA, $6.3M NVDA) — capital ≈ pool depth × deviation, exposed for 30 min, to skim ≤ 3% of one user's reward. All three pools carry ≥ 6 h of observations today (TSLA 13 h at cardinality 300), so 1800 s is available with > 10× margin; if `observe` ever reverts `OLD`, the adapter retries a 600 s window and, failing that, reports `available = false` → ETH fallback (`ReferenceUnavailable`).
+   - *Why 3%:* it must exceed LP fee (0.05–0.30%) + measured impact (≤ 0.05% at 0.5 ETH) + the drift a legitimate claim can see over the window. Regular-session 30-min moves for AAPL/NVDA are typically well under 1%; TSLA can exceed 3% on news days, in which case the claim pays ETH — a safe outcome, not a loss. Tighter bounds cost users stock payouts on ordinary volatility; looser bounds shift more of the manipulation budget to the attacker. 3% is the point where the attacker's edge is smaller than a one-block sandwich would already be *without* any TWAP on a 5-block-lag arb.
+   - *Chainlink as an extra check only when fresh:* if `updatedAt` is within 3600 s and the L2 sequencer-uptime feed reports up, the adapter additionally requires the TWAP-implied USD price to be within 500 bps of the feed (USD via the ETH/USD feed, same freshness rule). Stale → skipped, never a hard block.
+3. **Liquidity check before attempting:** `pool.liquidity() > 0` and `refOut > 0`; otherwise ETH fallback (`NoLiquidity`) with no swap attempted.
+4. **Cheap pre-checks before the swap** (~15k gas): registry round-trip, `asset.paused()` (covers token *and* global pause), `registry.isBlocked(claimant)`. Any failure → ETH fallback without a wasted swap.
+5. **Minimum reward size for stock payout.** Marginal cost of the stock path ≈ 275k gas ≈ 0.000085 ETH at today's 0.305 gwei. Rule: *the marginal cost must not exceed 5% of the reward* ⇒ `minStockRewardWei = 20 × 275 000 × gasPrice`. **Default 0.002 ETH (≈ $5 at $2,493/ETH)**, owner-tunable with `MinStockRewardUpdated`; batches are summed first, so the threshold applies to the whole claim. Below it the claim pays ETH directly (`BelowMinimum`). Stated plainly: with the current reward magnitudes on this launchpad (the last TESTINGG claim was 0.00012 ETH) most claims will land under this threshold and pay ETH; the stock path is for positions where the reward is worth the swap.
+6. **`nonReentrant`, checks-effects-interactions, `hasClaimed` before any external call** (§B3). The adapter has no storage; the only re-entrant surfaces are the claimant's `receive()` on the ETH path (blocked by the guard) and the V3 callback (adapter checks `msg.sender == pool` and pays WETH only).
+
+## B5. Fallback — a reward must never be stuck
+
+Every stock-path failure pays the ETH allocation instead and emits `RewardPaidInEthFallback(claimant, token, asset, reason, data)`:
+
+| Reason | When | Swap attempted? |
+|---|---|---|
+| `ForcedEth` | owner used `forceEthPayout(token)` | no |
+| `AssetDisabled` | route disabled/missing | no |
+| `RegistryMismatch` | `uid()` reverted or `tokenAddress(uid) != asset` at claim time | no |
+| `AssetPaused` | `asset.paused()` | no |
+| `ClaimantBlocked` | `registry.isBlocked(claimant)` — a transfer to them would revert | no |
+| `NoLiquidity` | `liquidity() == 0` or `refOut == 0` | no |
+| `ReferenceUnavailable` | TWAP `observe` reverted at both windows | no |
+| `BelowMinimum` | `total < minStockRewardWei` | no |
+| `BelowProtocolBound` | executed output under the TWAP floor (swap reverted and unwound) | yes |
+| `SwapFailed` | any other revert from the adapter/pool/token (`data` = revert bytes) | yes |
+
+Two deliberate exceptions bubble up instead of falling back: `MinOutNotMet` (the user's own bound) and `DeadlineExpired`. The `try/catch` distinguishes them by revert selector. Because the whole swap runs in the adapter's frame, a revert unwinds the WETH wrap too; the pool's ETH is untouched and is then paid out directly.
+
+## B6. Migration
+
+V1 keeps its ETH (0.0222 ETH today) and its published epochs; **no funds move between pools**. V1 has no sweep, so any ETH left unallocated there can only ever leave via epochs published *there*. The cutover is therefore a per-token drain-then-switch, not a flag flip.
+
+1. **Deploy V2** with the deploy script (owner = hardware EOA, operator = `0x78a4E4BCC8ab559B6d3B1Cb9eab0A04a2411c726`, routes AAPL/TSLA/NVDA validated on-chain, `assetSetters = {legible factory}`, `minStockRewardWei = 0.002 ETH`). Verify on Blockscout. Fork-test against the deployed address.
+2. **DB migration:** `reward_epochs.pool_address` (default V1 for existing rows), `tokens.reward_asset` / `reward_asset_symbol`.
+3. **Worker, dual-pool mode, from block N:** per token and per run, if `V1.getUnallocatedBalance(token) ≥ MIN_EPOCH_PAYOUT_WEI` publish this epoch **on V1** (draining it), else publish **on V2**. Each `reward_epochs` row records its `pool_address`. Pending-funding FIFO resolution runs per pool. Once V1's unallocated balance for a token is under the dust guard, that token is V2-only forever. No epoch is ever split across pools.
+4. **Gateway `/query`** returns `poolAddress` with each unclaimed epoch; **frontend** groups epochs by pool and sends one transaction per pool: V1 → `claimBatch` (unchanged), V2 → `claimBatchAs`. The panel shows a "Legacy pool" sub-section while any V1 epochs remain; when none remain it disappears. Old-pool claims are always ETH.
+5. **Hook re-point**, only after 1–4 are live and verified: `RepointHookLossRewardPool.s.sol` calls `legibleHook.setLossRewardPool(V2)`. From that transaction every `collect()` and converter deposit for every token on that hook lands in V2. The live GenericSell hook cannot be re-pointed (immutable); its single token (TESTINGG) keeps feeding V1, which the dual-pool worker keeps draining — no special case.
+6. **Indexer** sums both pools for `loss_pool_tvl_eth`.
+
+**Every place the V1 address is hardcoded** (from `grep`), and what to do:
+
+| Site | Action |
+|---|---|
+| `src/lib/uniswapAddresses.ts:32` | `LOSS_REWARD_POOL` → V2 via `VITE_LOSS_REWARD_POOL`; add `LOSS_REWARD_POOL_LEGACY` via `VITE_LOSS_REWARD_POOL_LEGACY` (default V1) |
+| `src/lib/integration/index.ts:26` | same two exports |
+| `scripts/loss-reward-worker.mjs:98` | `LOSS_REWARD_POOL_ADDRESS` (V2) + `LOSS_REWARD_POOL_LEGACY_ADDRESS` (V1) |
+| `scripts/evm-indexer.mjs:111` | both, summed |
+| `supabase/functions/loss-reward-gateway/index.ts:42` | both, `pool_address` per epoch |
+| `scripts/claim-loss-rewards.mjs:43` | `--pool` flag, default V2, `--min-out`/`--deadline` |
+| `scripts/check-live-deployment.mjs:21` | check both |
+| `src/lib/incentifiBondingCurveFactoryBytecode.ts:269`, `src/lib/incentifiSwapRouterBytecode.ts:303`, `scripts/generate-deploy-bytecode.mjs:42`, `scripts/verify-factory.mjs:20`, `scripts/verify-router.mjs:25`, `scripts/verify-v3-fix-mainnet.ts:73`, `scripts/deploy-v3-fixed-factory-and-router.ts:60` | V3-curve deploy/verify artefacts: leave as-is (they describe the deployed V3 contracts, which point at V1 immutably) |
+| `scripts/deploy-v4-hook-*.ts`, `scripts/verify-v4-hook-production-mainnet.ts`, `scripts/.v*-deployment-result.json` | historical deploy records: leave as-is |
+
+**Env vars to set:** Vercel `VITE_LOSS_REWARD_POOL`, `VITE_LOSS_REWARD_POOL_LEGACY`; Railway (worker + indexer) `LOSS_REWARD_POOL_ADDRESS`, `LOSS_REWARD_POOL_LEGACY_ADDRESS` (the worker currently reads `VITE_LOSS_REWARD_POOL` — normalise); Supabase function secrets `LOSS_REWARD_POOL_ADDRESS`, `LOSS_REWARD_POOL_LEGACY_ADDRESS`. The hardcoded V1 fallbacks in the four runtime sites are replaced by a fail-loud "address not configured" so a stale deploy cannot silently publish epochs to the wrong pool.
+
+## B7. Off-chain changes
+
+- **Worker:** dual-pool selection (§B6), `pool_address` on every `reward_epochs` insert, ABI additions (`rewardAsset`, `epochClaimedAmounts` for reconciliation). No change to epoch maths, leaves, dust guard, freshness gate, balance cap.
+- **Indexer:** TVL from both pools. Nothing else — `Bought`/`Sold` are untouched.
+- **Gateway:** `poolAddress` and `rewardAsset` in `/query`; `/claim` (relayer) stays deprecated and returns the "use your wallet" message.
+- **Frontend**
+  - *Launch page:* "Loss-reward payout asset" dropdown: ETH (default) + assets where `assetRoute(asset).enabled` on-chain **and** the API lists `ASSET_STATUS_ACTIVE`, showing name/logo from the API. Below it, the B3 sentence. `createEvmToken` passes the address to `launchToken(token, asset)`.
+  - *Token page:* badge "Loss Reward: AAPL" (or "ETH", or "ETH (forced)" after an override) from `pool.rewardAsset(token)`, mirrored into `tokens.reward_asset` by the launch flow for lists. Claim panel: claimable ETH (unchanged), "you will receive ≈ X AAPL" from a QuoterV2 quote on the configured route, slippage control (default 1%), the B3 copy, and the legacy-pool sub-section.
+  - **`uiMultiplier` — required for every stock number shown.** Balances and swap outputs are raw ERC-20 amounts; Robinhood's app displays `raw × uiMultiplier() / 1e18` (AAPL is at 1.000566 today after a corporate action; TSLA/NVDA at 1.0). The estimate, the post-claim receipt and any wallet-balance display must apply the multiplier or users will see numbers that disagree with Robinhood by the multiplier. `rewardAssets.ts` exposes `toDisplayShares(raw, asset)` reading `uiMultiplier()`, and shows a note when `newUIMultiplier()`/`effectiveAt()` announce a pending change.
+- **Docs/whitepaper pages:** one paragraph on the payout-asset option and the "you receive whatever it buys" rule.
+
+## B8. Open question: should V2 accept deposits denominated in the stock?
+
+**Recommendation: ETH-only, forever.** Reasons: (1) the custody constraint — the pool must never hold stock, and a stock deposit would have to be sold to ETH inside the deposit, adding a sell route, price risk and a second swap surface for a feature nobody has asked for; (2) the whole epoch machine (leaves, allocations, dust guard, `getUnallocatedBalance`) is ETH-denominated and the worker's budgeting would need a valuation oracle for stock sitting in the pool; (3) a creator who wants to fund rewards with AAPL can sell it and call `depositReward{value}` today, with no protocol change. If sponsor deposits are ever wanted, build them as a separate "sponsor converter" contract (same pattern as PR #17's `FeeConverter`) that sells to ETH and calls `depositReward`; the pool's code never changes and never touches stock.
+
+## B9. V2 pool fixes
+
+- **Bare ETH is rejected: `receive()` reverts `BareEthRejected()`.** Why revert rather than a labelled sink: bare ETH is unattributable, and a sink would need an owner-only "attribute this to token X" lever — a new privileged action that can move value between tokens' budgets. Reverting is loss-free (the sender keeps their ETH, the transaction simply fails) and keeps the invariant below exact. The hook, converter and worker never send bare ETH; the only path in is `depositReward(token)`.
+- **Strict per-token accounting, enforced.** V1 only checks `allocated ≤ deposited` at allocation; a Merkle root whose leaves sum to more than the epoch's allocation could drain other tokens' ETH. V2 adds `epochClaimedAmounts[token][epochId] += amount; require(≤ epochAllocatedAmounts[token][epochId])` (`EpochOverClaimed`). With that, claims ≤ Σ allocations ≤ deposits per token, and because bare ETH is rejected and swaps consume exactly `amount`, the invariant **`address(this).balance == Σ_token (totalDeposited − totalClaimed)`** holds exactly and is asserted in tests. `tokenVault(token)` exposes it.
+- **Unchanged on purpose:** `depositReward`, `setEpochMerkleRoot`, `claimReward`, `claimBatch`, the leaf format, `onlyOperator` (= operator or owner), `setOperator`, `transferOwnership`, all V1 events and errors.
+
+## B10. Test plan (Phase C, Foundry, Robinhood mainnet fork, real registry/factory/pools)
+
+| Case | Setup / assertion |
+|---|---|
+| ETH reward unchanged | V1 and V2 side by side, identical roots/leaves/proofs; identical events, `hasClaimed`, counters, balance deltas |
+| AAPL reward | claim receives AAPL in the claimant's wallet, ETH allocation consumed, pool/adapter hold 0 AAPL, `RewardPaid` fields |
+| TSLA on another token, same block | two tokens, two assets, claims in one block: no cross-contamination of counters or assets |
+| Creator ETH unaffected | hook `creatorBalances` identical before/after every claim |
+| Authorisation | non-setter `setRewardAsset` reverts; second write reverts; factory-level: only the launcher can pick, creator of A cannot touch B |
+| Non-registry address | counterfeit AAPL and an EOA rejected at selection (`AssetNotSelectable`) |
+| Valid at launch, invalid at claim | `vm.mockCall` on `paused()` / `tokenAddress()` → ETH fallback + event with reason |
+| Below `minAssetOut` | reverts `MinOutNotMet`, `hasClaimed` unchanged |
+| Below protocol bound | same-block price move so output < TWAP floor while `minOut = 0` → ETH fallback `BelowProtocolBound` |
+| Paused stock | mocked `paused()` true → fallback |
+| Empty / thin liquidity | mocked `liquidity()` 0 → fallback `NoLiquidity`, no swap |
+| Below minimum reward | `total < minStockRewardWei` → direct ETH, `BelowMinimum` |
+| Reentrancy | claimant contract re-enters on `receive()` and via a hostile callback → reverts, single payment |
+| `forceEthPayout` | works, emits, owner-only, irreversible |
+| Accounting | mixed batch of ETH and stock claims across tokens: Σ ETH paid + Σ ETH spent on swaps + remaining == Σ deposited per token; contract balance invariant |
+| Gas | measured per claim type, written back into this doc (C5) |
+
+## B11. Risks and what is not verified
+
+- **Upgradeable counterparties.** StockFactory (UUPS) and every Stock (shared beacon) are upgradeable by Robinhood roles; the registry round-trip and the pause/blocklist semantics are trusted as of today's verified source. The fallback design means an adverse upgrade degrades to ETH payouts, not to stuck rewards.
+- **Owner route power** is bounded to canonical V3 pools by `validateRoute`, but a shallow canonical pool would push claims to the fallback via the TWAP bound; route changes are evented.
+- **TWAP manipulation** is bounded, not eliminated (§B4). The user's `minAssetOut` is the primary guard.
+- **Not audited:** the `FablesRampETH` hook on the USDG/ETH pool (irrelevant while MSFT is deferred).
+- **Not measured yet:** gas of the full V2 claim with adapter overhead (C5), and behaviour of `observe()` under a burst that fills TSLA's 300-slot ring inside 30 minutes (handled by the 600 s retry and ETH fallback).

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "node test/loss-reward-audit.test.mjs && node test/worker-hardening.test.mjs && node test/session-daemon.test.mjs && node test/symbol-registry.test.mjs && node test/bonding-curve-v3-harness.test.mjs && node test/comprehensive-bonding-curve.test.mjs && node test/fee-on-transfer-accounting.test.mjs && node test/graduation-price-continuity.test.mjs && node test/creator-pull-payment.test.mjs && node test/indexer-freshness-gate.test.mjs && node test/underwater-requalification.test.mjs && node test/indexer-v4-discovery-retry.test.mjs && node test/balance-guard.test.mjs && node test/integration-layer.test.mjs && node test/indexer-dual-hook.test.mjs && node test/worker-mixed-hooks.test.mjs",
+    "test": "node test/loss-reward-audit.test.mjs && node test/worker-hardening.test.mjs && node test/session-daemon.test.mjs && node test/symbol-registry.test.mjs && node test/bonding-curve-v3-harness.test.mjs && node test/comprehensive-bonding-curve.test.mjs && node test/fee-on-transfer-accounting.test.mjs && node test/graduation-price-continuity.test.mjs && node test/creator-pull-payment.test.mjs && node test/indexer-freshness-gate.test.mjs && node test/underwater-requalification.test.mjs && node test/indexer-v4-discovery-retry.test.mjs && node test/balance-guard.test.mjs && node test/integration-layer.test.mjs && node test/indexer-dual-hook.test.mjs && node test/worker-mixed-hooks.test.mjs && node test/fallback-monitor.test.mjs",
     "test:legible-parity": "node test/legible-parity.test.mjs",
     "daemon": "node scripts/daemon.mjs",
     "test:v4-replay": "node test/v4-trade-replay.test.mjs",

--- a/script/DeployLossRewardPoolV2.s.sol
+++ b/script/DeployLossRewardPoolV2.s.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Script, console2} from "forge-std/Script.sol";
+
+import {LossRewardPoolV2} from "../contracts/loss-reward/LossRewardPoolV2.sol";
+import {RewardSwapperUniswapV3} from "../contracts/loss-reward/RewardSwapperUniswapV3.sol";
+import {ILossRewardPoolV2} from "../contracts/loss-reward/interfaces/ILossRewardPoolV2.sol";
+
+/**
+ * Deploys LossRewardPoolV2 + its Uniswap V3 swap adapter and configures the launch allow-list
+ * (AAPL, TSLA, NVDA). NOT run as part of this PR. Does NOT touch the hook: re-pointing the hook is
+ * a deliberate second action (script/RepointHookLossRewardPool.s.sol).
+ *
+ * Owner = --sender (hardware-wallet EOA). Operator = OPERATOR (defaults to the live worker key).
+ *
+ * Usage (dry run first, then broadcast; the operator supplies their own key — never share it):
+ *   [OPERATOR=0x...] [ASSET_SETTER=<legible factory>] [MIN_STOCK_REWARD_WEI=2000000000000000] \
+ *   forge script script/DeployLossRewardPoolV2.s.sol --rpc-url robinhood --sender <hardware-wallet> [--broadcast --ledger]
+ */
+contract DeployLossRewardPoolV2 is Script {
+    // Robinhood Chain mainnet (chain id 4663) — every address below was verified on-chain in Phase A.
+    address constant STOCK_FACTORY = 0x4783C67b63dE2B358Ac5951a7D41F47A38F3C046;
+    address constant ACCESS_REGISTRY = 0xe10b6f6B275de231345c20D14Ab812db62151b00;
+    address constant WETH = 0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73;
+    address constant UNISWAP_V3_FACTORY = 0x1f7d7550B1b028f7571E69A784071F0205FD2EfA;
+    address constant DEFAULT_OPERATOR = 0x78a4E4BCC8ab559B6d3B1Cb9eab0A04a2411c726;
+
+    address constant AAPL = 0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9;
+    address constant TSLA = 0x322F0929c4625eD5bAd873c95208D54E1c003b2d;
+    address constant NVDA = 0xd0601CE157Db5bdC3162BbaC2a2C8aF5320D9EEC;
+    address constant AAPL_WETH_POOL = 0x8bb3514e2204E1cDF3Ac149EFEe7Ff04D91B719f; // 0.05%
+    address constant TSLA_WETH_POOL = 0xA953CA88ff430e9487c60cA34d757414f4efdA07; // 0.30%
+    address constant NVDA_WETH_POOL = 0x62AB521f71431f78ac374CdbadC6cda3c8916b6C; // 0.05%
+
+    uint32 constant TWAP_WINDOW = 1800;
+    uint16 constant MAX_DEVIATION_BPS = 300;
+
+    function run() external {
+        address operator = vm.envOr("OPERATOR", DEFAULT_OPERATOR);
+        address assetSetter = vm.envOr("ASSET_SETTER", address(0));
+        uint256 minStockRewardWei = vm.envOr("MIN_STOCK_REWARD_WEI", uint256(0.002 ether));
+
+        vm.startBroadcast();
+        LossRewardPoolV2 pool = new LossRewardPoolV2(operator, STOCK_FACTORY, ACCESS_REGISTRY);
+        RewardSwapperUniswapV3 swapper = new RewardSwapperUniswapV3(address(pool), WETH, UNISWAP_V3_FACTORY);
+        _route(pool, address(swapper), AAPL, AAPL_WETH_POOL, 500);
+        _route(pool, address(swapper), TSLA, TSLA_WETH_POOL, 3000);
+        _route(pool, address(swapper), NVDA, NVDA_WETH_POOL, 500);
+        if (assetSetter != address(0)) pool.setAssetSetter(assetSetter, true);
+        pool.setMinStockReward(minStockRewardWei);
+        vm.stopBroadcast();
+
+        require(pool.owner() == msg.sender, "owner mismatch");
+        require(pool.operator() == operator, "operator mismatch");
+        require(pool.isSelectableAsset(AAPL) && pool.isSelectableAsset(TSLA) && pool.isSelectableAsset(NVDA), "assets not selectable");
+        console2.log("LossRewardPoolV2", address(pool));
+        console2.log("RewardSwapperUniswapV3", address(swapper));
+        console2.log("owner (EOA)", pool.owner());
+        console2.log("operator", pool.operator());
+        console2.log("assetSetter", assetSetter);
+        console2.log("minStockRewardWei", minStockRewardWei);
+        console2.log("NEXT (separate, deliberate): script/RepointHookLossRewardPool.s.sol");
+    }
+
+    function _route(LossRewardPoolV2 pool, address swapper, address asset, address v3Pool, uint24 fee) internal {
+        pool.setAssetRoute(
+            asset,
+            ILossRewardPoolV2.AssetRoute({
+                swapper: swapper, pool: v3Pool, fee: fee, twapWindow: TWAP_WINDOW, maxDeviationBps: MAX_DEVIATION_BPS, enabled: true
+            })
+        );
+    }
+}

--- a/script/DeployLossRewardPoolV2.s.sol
+++ b/script/DeployLossRewardPoolV2.s.sol
@@ -47,7 +47,14 @@ contract DeployLossRewardPoolV2 is Script {
         _route(pool, address(swapper), AAPL, AAPL_WETH_POOL, 500);
         _route(pool, address(swapper), TSLA, TSLA_WETH_POOL, 3000);
         _route(pool, address(swapper), NVDA, NVDA_WETH_POOL, 500);
-        if (assetSetter != address(0)) pool.setAssetSetter(assetSetter, true);
+        if (assetSetter != address(0)) {
+            pool.setAssetSetter(assetSetter, true);
+        } else {
+            // RUNBOOK: without an authorised setter EVERY stock-asset launch reverts NotAssetSetter
+            // (ETH launches still work). Call pool.setAssetSetter(<legible factory>, true) before
+            // opening launches, or re-run with ASSET_SETTER set.
+            console2.log("WARNING: ASSET_SETTER unset - stock-asset launches will revert NotAssetSetter until setAssetSetter(<legible factory>, true) is called");
+        }
         pool.setMinStockReward(minStockRewardWei);
         vm.stopBroadcast();
 

--- a/script/RepointHookLossRewardPool.s.sol
+++ b/script/RepointHookLossRewardPool.s.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Script, console2} from "forge-std/Script.sol";
+
+import {IncentifiV4LegibleHook} from "../contracts/v4/legible/IncentifiV4LegibleHook.sol";
+import {LossRewardPoolV2} from "../contracts/loss-reward/LossRewardPoolV2.sol";
+
+/**
+ * The DELIBERATE SECOND ACTION of the LossRewardPoolV2 rollout: point the legible hook's
+ * loss-reward deposits at V2. Run only after V2 is deployed, verified on Blockscout, the worker
+ * is in dual-pool mode and the DB migration is applied (docs/LOSS_REWARD_ASSET_DESIGN.md §B6).
+ * Nothing already deposited moves; every deposit after this transaction lands in V2.
+ *
+ * Usage:
+ *   HOOK=0x... NEW_POOL=0x... forge script script/RepointHookLossRewardPool.s.sol --rpc-url robinhood --sender <hook owner> [--broadcast --ledger]
+ */
+contract RepointHookLossRewardPool is Script {
+    error NotHookOwner(address owner, address sender);
+    error NewPoolHasNoCode(address pool);
+    error NewPoolNotConfigured(address pool);
+
+    function run() external {
+        IncentifiV4LegibleHook hook = IncentifiV4LegibleHook(payable(vm.envAddress("HOOK")));
+        address newPool = vm.envAddress("NEW_POOL");
+
+        if (hook.owner() != msg.sender) revert NotHookOwner(hook.owner(), msg.sender);
+        if (newPool.code.length == 0) revert NewPoolHasNoCode(newPool);
+        LossRewardPoolV2 v2 = LossRewardPoolV2(payable(newPool));
+        if (v2.operator() == address(0) || v2.owner() == address(0)) revert NewPoolNotConfigured(newPool);
+
+        address before = hook.lossRewardPool();
+        console2.log("hook", address(hook));
+        console2.log("lossRewardPool BEFORE", before);
+        console2.log("lossRewardPool AFTER (requested)", newPool);
+
+        vm.startBroadcast();
+        hook.setLossRewardPool(newPool);
+        vm.stopBroadcast();
+
+        require(hook.lossRewardPool() == newPool, "re-point did not take");
+        console2.log("re-pointed; converter now deposits to", newPool);
+    }
+}

--- a/scripts/loss-reward-worker.mjs
+++ b/scripts/loss-reward-worker.mjs
@@ -1,6 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 import {
   createPublicClient,
+  parseAbiItem,
   createWalletClient,
   http,
   parseAbi,
@@ -99,6 +100,9 @@ const OPERATOR_PRIVATE_KEY = process.env.OPERATOR_PRIVATE_KEY || '';
 const LOSS_REWARD_POOL_ADDRESS = process.env.VITE_LOSS_REWARD_POOL || '0x697bda9db5a297a9cd9ed969bbf2549d0527dcdf';
 const INCENTIFI_FACTORY_ADDRESS = process.env.VITE_INCENTIFI_BONDING_CURVE_FACTORY || '0xa0143de84fba1753b887e4e32941e4fb342e473f';
 const ALERT_WEBHOOK_URL = process.env.ALERT_WEBHOOK_URL || '';
+// LossRewardPoolV2 (creator-selected stock payouts). Optional until V2 is deployed; when set, the
+// worker polls RewardPaidInEthFallback on every run — see monitorFallbackEvents() below.
+const LOSS_REWARD_POOL_V2_ADDRESS = process.env.LOSS_REWARD_POOL_V2_ADDRESS || '';
 const WORKER_NAME = 'loss-reward-worker';
 
 /**
@@ -1021,7 +1025,86 @@ export async function runEpochWorker(options = {}) {
       results.push({ tokenAddress: String(t.mint_address).toLowerCase(), skipped: true, reason: 'error', detail: err.message });
     }
   }
+  // V2 fallback-rate monitor (no-op until LOSS_REWARD_POOL_V2_ADDRESS is set). Runs after the
+  // epochs so a monitoring failure can never delay a payout.
+  if (!options.skipFallbackMonitor) await monitorFallbackEvents(options.fallbackMonitor || {});
   return results;
+}
+
+// ---------------------------------------------------------------------------------------------
+// LossRewardPoolV2 fallback monitor.
+//
+// A stock claim that cannot deliver the stock pays ETH instead and emits
+// RewardPaidInEthFallback(claimant, token, asset, reason, data). That is the ONLY signal of an
+// adapter bug, a drained route, or a paused asset: no transaction fails, every user simply gets
+// ETH. So the worker polls the event on every run and alerts on any reason that is not expected
+// in normal operation (ForcedEth = owner decision, BelowMinimum = small claim, by design).
+// ---------------------------------------------------------------------------------------------
+export const FALLBACK_REASONS = [
+  'ForcedEth', 'AssetDisabled', 'RegistryMismatch', 'AssetPaused', 'ClaimantBlocked',
+  'NoLiquidity', 'ReferenceUnavailable', 'BelowMinimum', 'BelowProtocolBound', 'SwapFailed',
+];
+export const EXPECTED_FALLBACK_REASONS = new Set(['ForcedEth', 'BelowMinimum']);
+const FALLBACK_EVENT = parseAbiItem(
+  'event RewardPaidInEthFallback(address indexed claimant, address indexed token, address indexed asset, uint8 reason, bytes data)'
+);
+/** Default look-back when there is no cursor yet: ~5 minutes at ~10 blocks/s, one worker cadence. */
+export const FALLBACK_LOOKBACK_BLOCKS = 3000n;
+let fallbackCursorBlock = null;
+
+/**
+ * Pure: folds RewardPaidInEthFallback logs into counts per reason. Exported for unit tests.
+ */
+export function summarizeFallbackEvents(logs) {
+  const byReason = {};
+  const tokens = new Set();
+  const claimants = new Set();
+  let alertable = 0;
+  for (const log of logs || []) {
+    const idx = Number(log.args?.reason ?? -1);
+    const name = FALLBACK_REASONS[idx] ?? `Unknown(${idx})`;
+    byReason[name] = (byReason[name] || 0) + 1;
+    if (log.args?.token) tokens.add(String(log.args.token).toLowerCase());
+    if (log.args?.claimant) claimants.add(String(log.args.claimant).toLowerCase());
+    if (!EXPECTED_FALLBACK_REASONS.has(name)) alertable++;
+  }
+  return { total: (logs || []).length, alertable, byReason, tokens: [...tokens], claimants: claimants.size };
+}
+
+/**
+ * Polls RewardPaidInEthFallback on LossRewardPoolV2 since the last run and alerts on unexpected
+ * reasons. No-op until LOSS_REWARD_POOL_V2_ADDRESS is configured. Never throws into the epoch
+ * loop: monitoring must not be able to stop payouts.
+ *   options.client  — viem public client (default: the worker's)
+ *   options.alert   — alert sink (default: sendAlert)
+ *   options.address — pool address (default: env)
+ *   options.fromBlock / options.toBlock — override the cursor (tests)
+ */
+export async function monitorFallbackEvents(options = {}) {
+  const address = options.address ?? LOSS_REWARD_POOL_V2_ADDRESS;
+  if (!address) return { skipped: true, reason: 'LOSS_REWARD_POOL_V2_ADDRESS not set' };
+  const client = options.client ?? publicClient;
+  const alert = options.alert ?? sendAlert;
+  try {
+    const latest = options.toBlock ?? (await client.getBlockNumber());
+    let fromBlock = options.fromBlock ?? fallbackCursorBlock;
+    if (fromBlock == null) fromBlock = latest > FALLBACK_LOOKBACK_BLOCKS ? latest - FALLBACK_LOOKBACK_BLOCKS : 0n;
+    if (fromBlock > latest) return { skipped: true, reason: 'cursor ahead of head', fromBlock, toBlock: latest };
+    const logs = await client.getLogs({ address: getAddress(address), event: FALLBACK_EVENT, fromBlock, toBlock: latest });
+    const summary = summarizeFallbackEvents(logs);
+    fallbackCursorBlock = latest + 1n;
+    if (summary.total > 0) {
+      const line = Object.entries(summary.byReason).map(([k, v]) => `${k}=${v}`).join(', ');
+      console.log(`[FALLBACK MONITOR] ${summary.total} RewardPaidInEthFallback in blocks ${fromBlock}-${latest} (${line}); tokens: ${summary.tokens.join(',')}`);
+      if (summary.alertable > 0) {
+        await alert(`LossRewardPoolV2 paid ${summary.alertable} stock claim(s) in ETH for an UNEXPECTED reason in blocks ${fromBlock}-${latest}: ${line}. Tokens: ${summary.tokens.join(',')}. Check the adapter/route/asset state before the next epoch.`);
+      }
+    }
+    return { ...summary, fromBlock, toBlock: latest };
+  } catch (err) {
+    console.warn(`[FALLBACK MONITOR] could not read RewardPaidInEthFallback logs: ${err.message}`);
+    return { skipped: true, reason: 'error', detail: err.message };
+  }
 }
 
 // Backward-compatible alias

--- a/supabase/functions/loss-reward-gateway/index.ts
+++ b/supabase/functions/loss-reward-gateway/index.ts
@@ -46,6 +46,12 @@ const POOL_ABI = parseAbi([
   'function hasClaimed(address token, uint256 epochId, address account) view returns (bool)',
   'function claimReward(address token, uint256 epochId, uint256 amount, bytes32[] calldata merkleProof)',
   'function claimBatch(address token, uint256[] calldata epochIds, uint256[] calldata amounts, bytes32[][] calldata merkleProofs)',
+  // LossRewardPoolV2: the V1 signatures revert UseClaimAs on a stock-configured token, so the
+  // (deprecated) relayer path encodes the V2 signatures. minAssetOut = 0 is safe here only because
+  // the pool enforces its own TWAP floor inside the swap; a wallet-signed claim from the frontend
+  // passes a real quote-derived minAssetOut.
+  'function claimRewardAs(address token, uint256 epochId, uint256 amount, bytes32[] calldata merkleProof, uint256 minAssetOut, uint256 deadline)',
+  'function claimBatchAs(address token, uint256[] calldata epochIds, uint256[] calldata amounts, bytes32[][] calldata merkleProofs, uint256 minAssetOut, uint256 deadline)',
 ]);
 
 const JWT_ISSUER = 'incentifi.finance';
@@ -833,12 +839,14 @@ export async function handleClaim(req: Request): Promise<Response> {
       txHash = await walletClient.writeContract({
         address: getAddress(LOSS_REWARD_POOL_ADDRESS),
         abi: POOL_ABI,
-        functionName: 'claimReward',
+        functionName: 'claimRewardAs',
         args: [
           getAddress(normalizedToken),
           BigInt(row.epochNumber),
           row.amountWei,
           row.merkle_proof as `0x${string}`[],
+          0n,
+          BigInt(Math.floor(Date.now() / 1000) + 600),
         ],
       });
     } else {
@@ -849,8 +857,8 @@ export async function handleClaim(req: Request): Promise<Response> {
       txHash = await walletClient.writeContract({
         address: getAddress(LOSS_REWARD_POOL_ADDRESS),
         abi: POOL_ABI,
-        functionName: 'claimBatch',
-        args: [getAddress(normalizedToken), epochIds, amounts, proofs],
+        functionName: 'claimBatchAs',
+        args: [getAddress(normalizedToken), epochIds, amounts, proofs, 0n, BigInt(Math.floor(Date.now() / 1000) + 600)],
       });
     }
 

--- a/test/fallback-monitor.test.mjs
+++ b/test/fallback-monitor.test.mjs
@@ -1,0 +1,97 @@
+// LossRewardPoolV2 fallback monitor: the RewardPaidInEthFallback event is the ONLY signal of an
+// adapter/route/asset failure (no transaction fails; users just get ETH). These tests pin down
+// (1) the pure summariser and (2) the poller's alerting and cursor behaviour with an injected
+// client and alert sink — no RPC, no Supabase.
+import assert from 'node:assert/strict';
+import {
+  summarizeFallbackEvents,
+  monitorFallbackEvents,
+  FALLBACK_REASONS,
+  EXPECTED_FALLBACK_REASONS,
+  FALLBACK_LOOKBACK_BLOCKS,
+} from '../scripts/loss-reward-worker.mjs';
+
+const V2 = '0x00000000000000000000000000000000000000A2';
+const log = (reason, token = '0xToKeN', claimant = '0xC1') => ({ args: { reason, token, claimant } });
+
+// --- 1. summariser -------------------------------------------------------------------------
+{
+  const s = summarizeFallbackEvents([]);
+  assert.equal(s.total, 0);
+  assert.equal(s.alertable, 0);
+  assert.deepEqual(s.byReason, {});
+}
+{
+  const idx = (name) => FALLBACK_REASONS.indexOf(name);
+  const s = summarizeFallbackEvents([
+    log(idx('BelowMinimum'), '0xAAA', '0xC1'),
+    log(idx('ForcedEth'), '0xAAA', '0xC2'),
+    log(idx('SwapFailed'), '0xBBB', '0xC1'),
+    log(idx('BelowProtocolBound'), '0xBBB', '0xC3'),
+    log(99, '0xBBB', '0xC3'),
+  ]);
+  assert.equal(s.total, 5);
+  assert.equal(s.byReason.BelowMinimum, 1);
+  assert.equal(s.byReason.ForcedEth, 1);
+  assert.equal(s.byReason.SwapFailed, 1);
+  assert.equal(s.byReason.BelowProtocolBound, 1);
+  assert.equal(s.byReason['Unknown(99)'], 1);
+  assert.equal(s.alertable, 3, 'ForcedEth and BelowMinimum are expected; everything else alerts');
+  assert.deepEqual(s.tokens.sort(), ['0xaaa', '0xbbb']);
+  assert.equal(s.claimants, 3);
+  assert.ok(EXPECTED_FALLBACK_REASONS.has('ForcedEth') && EXPECTED_FALLBACK_REASONS.has('BelowMinimum'));
+  assert.equal(FALLBACK_REASONS.length, 10, 'must match the Solidity enum order');
+}
+
+// --- 2. poller: no address -> no-op ---------------------------------------------------------
+{
+  const r = await monitorFallbackEvents({ address: '' });
+  assert.equal(r.skipped, true);
+}
+
+// --- 3. poller: alerts only on unexpected reasons, advances the cursor, never throws ----------
+{
+  const calls = [];
+  const alerts = [];
+  const client = {
+    getBlockNumber: async () => 10_000n,
+    getLogs: async (q) => {
+      calls.push(q);
+      return [log(FALLBACK_REASONS.indexOf('BelowMinimum')), log(FALLBACK_REASONS.indexOf('SwapFailed'), '0xDeAd')];
+    },
+  };
+  const alert = async (m) => alerts.push(m);
+
+  const r1 = await monitorFallbackEvents({ address: V2, client, alert });
+  assert.equal(r1.total, 2);
+  assert.equal(r1.alertable, 1);
+  assert.equal(calls[0].fromBlock, 10_000n - FALLBACK_LOOKBACK_BLOCKS, 'first run looks back one cadence');
+  assert.equal(calls[0].toBlock, 10_000n);
+  assert.equal(alerts.length, 1);
+  assert.match(alerts[0], /UNEXPECTED/);
+  assert.match(alerts[0], /SwapFailed=1/);
+  assert.match(alerts[0], /0xdead/);
+
+  // expected-only batch: logged, not alerted; cursor continues from the previous head + 1
+  client.getLogs = async (q) => { calls.push(q); return [log(FALLBACK_REASONS.indexOf('ForcedEth'))]; };
+  client.getBlockNumber = async () => 10_500n;
+  const r2 = await monitorFallbackEvents({ address: V2, client, alert });
+  assert.equal(r2.total, 1);
+  assert.equal(r2.alertable, 0);
+  assert.equal(alerts.length, 1, 'no new alert for an expected reason');
+  assert.equal(calls[1].fromBlock, 10_001n, 'cursor resumes right after the last head');
+  assert.equal(calls[1].toBlock, 10_500n);
+
+  // RPC failure: swallowed, reported, cursor untouched
+  client.getLogs = async () => { throw new Error('rpc down'); };
+  client.getBlockNumber = async () => 11_000n;
+  const r3 = await monitorFallbackEvents({ address: V2, client, alert });
+  assert.equal(r3.skipped, true);
+  assert.equal(r3.reason, 'error');
+  client.getLogs = async (q) => { calls.push(q); return []; };
+  const r4 = await monitorFallbackEvents({ address: V2, client, alert });
+  assert.equal(r4.total, 0);
+  assert.equal(calls[2].fromBlock, 10_501n, 'a failed poll does not move the cursor');
+}
+
+console.log('fallback-monitor tests passed');

--- a/test/foundry/LossRewardPoolV2.t.sol
+++ b/test/foundry/LossRewardPoolV2.t.sol
@@ -1,0 +1,735 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Test, Vm, console2} from "forge-std/Test.sol";
+
+import {LossRewardPool} from "../../contracts/LossRewardPool.sol";
+import {LossRewardPoolV2} from "../../contracts/loss-reward/LossRewardPoolV2.sol";
+import {RewardSwapperUniswapV3} from "../../contracts/loss-reward/RewardSwapperUniswapV3.sol";
+import {ILossRewardPoolV2} from "../../contracts/loss-reward/interfaces/ILossRewardPoolV2.sol";
+import {IRewardSwapper} from "../../contracts/loss-reward/interfaces/IRewardSwapper.sol";
+import {IRobinhoodStock, IRobinhoodStockFactory, IRobinhoodAccessControlsRegistry} from "../../contracts/loss-reward/interfaces/IRobinhoodStock.sol";
+import {IUniswapV3PoolMinimal, IWETH9} from "../../contracts/loss-reward/interfaces/IUniswapV3Minimal.sol";
+
+/**
+ * LossRewardPoolV2 on a Robinhood mainnet fork: real StockFactory / access registry / stock tokens /
+ * Uniswap V3 WETH pools. The test contract plays the operator and the launch factory (asset setter).
+ *
+ * Run: forge test --match-path test/foundry/LossRewardPoolV2.t.sol -vv
+ */
+abstract contract V2Base is Test {
+    address constant STOCK_FACTORY = 0x4783C67b63dE2B358Ac5951a7D41F47A38F3C046;
+    address constant ACCESS_REGISTRY = 0xe10b6f6B275de231345c20D14Ab812db62151b00;
+    address constant WETH = 0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73;
+    address constant V3_FACTORY = 0x1f7d7550B1b028f7571E69A784071F0205FD2EfA;
+    address constant AAPL = 0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9;
+    address constant TSLA = 0x322F0929c4625eD5bAd873c95208D54E1c003b2d;
+    address constant NVDA = 0xd0601CE157Db5bdC3162BbaC2a2C8aF5320D9EEC;
+    address constant MSFT = 0xe93237C50D904957Cf27E7B1133b510C669c2e74;
+    address constant FAKE_AAPL = 0x6aD03BEB497caAa5c559d247500165c8F11d1e18; // "AAPL" not from the factory
+    address constant AAPL_POOL = 0x8bb3514e2204E1cDF3Ac149EFEe7Ff04D91B719f;
+    address constant TSLA_POOL = 0xA953CA88ff430e9487c60cA34d757414f4efdA07;
+    address constant NVDA_POOL = 0x62AB521f71431f78ac374CdbadC6cda3c8916b6C;
+
+    bytes32 constant REWARD_PAID_TOPIC = keccak256("RewardPaid(address,address,uint256,address,uint256)");
+    bytes32 constant FALLBACK_TOPIC = keccak256("RewardPaidInEthFallback(address,address,address,uint8,bytes)");
+    bytes32 constant REWARD_CLAIMED_TOPIC = keccak256("RewardClaimed(address,uint256,address,uint256)");
+
+    LossRewardPoolV2 pool;
+    RewardSwapperUniswapV3 swapper;
+
+    address tokenEth = address(0xE1E1);
+    address tokenAapl = address(0xA1A1);
+    address tokenTsla = address(0xB1B1);
+    address user = makeAddr("user");
+    address user2 = makeAddr("user2");
+    address stranger = makeAddr("stranger");
+
+    uint256 constant MIN_STOCK = 0.002 ether;
+
+    function _deployV2() internal {
+        pool = new LossRewardPoolV2(address(this), STOCK_FACTORY, ACCESS_REGISTRY);
+        swapper = new RewardSwapperUniswapV3(address(pool), WETH, V3_FACTORY);
+        _route(AAPL, AAPL_POOL, 500);
+        _route(TSLA, TSLA_POOL, 3000);
+        _route(NVDA, NVDA_POOL, 500);
+        pool.setAssetSetter(address(this), true); // this test plays the launch factory
+        pool.setMinStockReward(MIN_STOCK);
+        pool.setRewardAsset(tokenEth, address(0));
+        pool.setRewardAsset(tokenAapl, AAPL);
+        pool.setRewardAsset(tokenTsla, TSLA);
+    }
+
+    function _route(address asset, address v3Pool, uint24 fee) internal {
+        pool.setAssetRoute(
+            asset,
+            ILossRewardPoolV2.AssetRoute({swapper: address(swapper), pool: v3Pool, fee: fee, twapWindow: 1800, maxDeviationBps: 300, enabled: true})
+        );
+    }
+
+    // ---- Merkle helpers (leaf format identical to V1 / the worker) ----
+    function leaf(address token, uint256 epochId, address claimant, uint256 amount) internal pure returns (bytes32) {
+        return keccak256(bytes.concat(keccak256(abi.encode(token, epochId, claimant, amount))));
+    }
+
+    function pair(bytes32 a, bytes32 b) internal pure returns (bytes32) {
+        return a <= b ? keccak256(abi.encodePacked(a, b)) : keccak256(abi.encodePacked(b, a));
+    }
+
+    function publish1(address token, uint256 epochId, address claimant, uint256 amount) internal {
+        pool.setEpochMerkleRoot(token, epochId, leaf(token, epochId, claimant, amount), amount);
+    }
+
+    /// @dev Two-leaf tree; the proof for each claimant is the other leaf.
+    function publish2(address token, uint256 epochId, address c1, uint256 a1, address c2, uint256 a2, uint256 allocated) internal {
+        pool.setEpochMerkleRoot(token, epochId, pair(leaf(token, epochId, c1, a1), leaf(token, epochId, c2, a2)), allocated);
+    }
+
+    function one(uint256 v) internal pure returns (uint256[] memory a) {
+        a = new uint256[](1);
+        a[0] = v;
+    }
+
+    function noProof() internal pure returns (bytes32[][] memory p) {
+        p = new bytes32[][](1);
+        p[0] = new bytes32[](0);
+    }
+
+    function claimAs(address who, address token, uint256 epochId, uint256 amount, uint256 minOut) internal {
+        vm.prank(who);
+        pool.claimBatchAs(token, one(epochId), one(amount), noProof(), minOut, block.timestamp + 600);
+    }
+
+    function findLog(Vm.Log[] memory logs, address emitter, bytes32 topic0) internal pure returns (Vm.Log memory found, bool ok) {
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].emitter == emitter && logs[i].topics[0] == topic0) return (logs[i], true);
+        }
+    }
+
+    function fallbackReason(Vm.Log[] memory logs) internal view returns (bool found, ILossRewardPoolV2.FallbackReason reason) {
+        (Vm.Log memory l, bool ok) = findLog(logs, address(pool), FALLBACK_TOPIC);
+        if (!ok) return (false, ILossRewardPoolV2.FallbackReason.ForcedEth);
+        (uint8 r,) = abi.decode(l.data, (uint8, bytes));
+        return (true, ILossRewardPoolV2.FallbackReason(r));
+    }
+
+    function rewardPaid(Vm.Log[] memory logs) internal view returns (uint256 ethAmount, address asset, uint256 assetAmount) {
+        (Vm.Log memory l, bool ok) = findLog(logs, address(pool), REWARD_PAID_TOPIC);
+        require(ok, "no RewardPaid");
+        asset = address(uint160(uint256(l.topics[3])));
+        (ethAmount, assetAmount) = abi.decode(l.data, (uint256, uint256));
+    }
+
+    function assertNoCustody() internal view {
+        assertEq(IRobinhoodStock(AAPL).balanceOf(address(pool)), 0, "pool holds no AAPL");
+        assertEq(IRobinhoodStock(TSLA).balanceOf(address(pool)), 0, "pool holds no TSLA");
+        assertEq(IRobinhoodStock(AAPL).balanceOf(address(swapper)), 0, "adapter holds no AAPL");
+        assertEq(IRobinhoodStock(TSLA).balanceOf(address(swapper)), 0, "adapter holds no TSLA");
+        assertEq(IWETH9(WETH).balanceOf(address(swapper)), 0, "adapter holds no WETH");
+        assertEq(address(swapper).balance, 0, "adapter holds no ETH");
+        assertEq(IWETH9(WETH).balanceOf(address(pool)), 0, "pool holds no WETH");
+    }
+
+    function assertInvariant() internal view {
+        uint256 expected = (pool.totalDeposited(tokenEth) - pool.totalClaimed(tokenEth)) + (pool.totalDeposited(tokenAapl) - pool.totalClaimed(tokenAapl))
+            + (pool.totalDeposited(tokenTsla) - pool.totalClaimed(tokenTsla));
+        assertEq(address(pool).balance, expected, "balance == sum(deposited - claimed)");
+    }
+
+    function protocolFloorFor(address v3Pool, uint256 ethIn) internal view returns (uint256 refOut, uint256 floor) {
+        bool ok;
+        (refOut, ok) = swapper.referenceOut(v3Pool, 1800, ethIn);
+        assertTrue(ok, "reference available");
+        floor = refOut * (10_000 - 300) / 10_000;
+    }
+}
+
+/// @dev Re-enters the pool from receive(); `swallow` decides whether the inner failure is propagated.
+contract ReentrantClaimant {
+    LossRewardPoolV2 immutable pool;
+    address immutable token;
+    bool public swallow;
+    bytes public innerError;
+    uint256 public entries;
+
+    constructor(LossRewardPoolV2 _pool, address _token) {
+        pool = _pool;
+        token = _token;
+    }
+
+    function setSwallow(bool s) external {
+        swallow = s;
+    }
+
+    function claim(uint256 epochId, uint256 amount) external {
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = epochId;
+        uint256[] memory amts = new uint256[](1);
+        amts[0] = amount;
+        bytes32[][] memory proofs = new bytes32[][](1);
+        proofs[0] = new bytes32[](0);
+        pool.claimBatchAs(token, ids, amts, proofs, 0, block.timestamp + 600);
+    }
+
+    receive() external payable {
+        entries++;
+        if (entries > 1) return;
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = 1;
+        uint256[] memory amts = new uint256[](1);
+        amts[0] = msg.value;
+        bytes32[][] memory proofs = new bytes32[][](1);
+        proofs[0] = new bytes32[](0);
+        try pool.claimBatchAs(token, ids, amts, proofs, 0, block.timestamp + 600) {
+            revert("re-entry succeeded");
+        } catch (bytes memory err) {
+            innerError = err;
+            if (!swallow) revert("propagate");
+        }
+    }
+}
+
+contract LossRewardPoolV2Test is V2Base {
+    LossRewardPool v1;
+
+    function setUp() public {
+        vm.createSelectFork(vm.rpcUrl("robinhood"));
+        v1 = new LossRewardPool(address(this));
+        _deployV2();
+        vm.deal(address(this), 200 ether);
+    }
+
+    receive() external payable {}
+
+    // ---------------------------------------------------------------------------------------
+    // ETH reward: byte-for-byte parity with V1
+    // ---------------------------------------------------------------------------------------
+    function test_EthClaim_ParityWithV1() public {
+        v1.depositReward{value: 1 ether}(tokenEth);
+        pool.depositReward{value: 1 ether}(tokenEth);
+        uint256 amount = 0.05 ether;
+        bytes32 root = leaf(tokenEth, 1, user, amount);
+        v1.setEpochMerkleRoot(tokenEth, 1, root, amount);
+        pool.setEpochMerkleRoot(tokenEth, 1, root, amount);
+        assertEq(v1.epochMerkleRoots(tokenEth, 1), pool.epochMerkleRoots(tokenEth, 1));
+
+        uint256 before = user.balance;
+        vm.recordLogs();
+        vm.prank(user);
+        v1.claimBatch(tokenEth, one(1), one(amount), noProof());
+        (Vm.Log memory c1,) = findLog(vm.getRecordedLogs(), address(v1), REWARD_CLAIMED_TOPIC);
+        uint256 afterV1 = user.balance;
+
+        vm.recordLogs();
+        vm.prank(user);
+        pool.claimBatch(tokenEth, one(1), one(amount), noProof());
+        (Vm.Log memory c2,) = findLog(vm.getRecordedLogs(), address(pool), REWARD_CLAIMED_TOPIC);
+
+        assertEq(afterV1 - before, amount);
+        assertEq(user.balance - afterV1, amount, "V2 pays the same ETH");
+        assertEq(c1.topics[1], c2.topics[1]);
+        assertEq(c1.topics[2], c2.topics[2]);
+        assertEq(c1.topics[3], c2.topics[3]);
+        assertEq(keccak256(c1.data), keccak256(c2.data), "RewardClaimed identical");
+        assertEq(v1.hasClaimed(tokenEth, 1, user), pool.hasClaimed(tokenEth, 1, user));
+        assertEq(v1.totalClaimed(tokenEth), pool.totalClaimed(tokenEth));
+        assertEq(v1.getUnallocatedBalance(tokenEth), pool.getUnallocatedBalance(tokenEth));
+        // V1-signature single claim also unchanged
+        publish1(tokenEth, 2, user, amount);
+        vm.prank(user);
+        pool.claimReward(tokenEth, 2, amount, new bytes32[](0));
+        assertTrue(pool.hasClaimed(tokenEth, 2, user));
+        assertInvariant();
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // AAPL reward: claim receives AAPL, ETH allocation consumed, nobody but the user holds stock
+    // ---------------------------------------------------------------------------------------
+    function test_StockClaim_AAPL() public {
+        pool.depositReward{value: 1 ether}(tokenAapl);
+        uint256 amount = 0.05 ether;
+        publish1(tokenAapl, 1, user, amount);
+        (uint256 refOut,) = protocolFloorFor(AAPL_POOL, amount);
+        uint256 userMin = refOut * 99 / 100;
+
+        uint256 poolBefore = address(pool).balance;
+        uint256 ethBefore = user.balance;
+        vm.recordLogs();
+        uint256 g0 = gasleft();
+        claimAs(user, tokenAapl, 1, amount, userMin);
+        console2.log("gas: claimBatchAs (1 epoch, AAPL)", g0 - gasleft());
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        (uint256 ethAmount, address asset, uint256 assetAmount) = rewardPaid(logs);
+        assertEq(asset, AAPL);
+        assertEq(ethAmount, amount);
+        assertGt(assetAmount, userMin);
+        assertEq(IRobinhoodStock(AAPL).balanceOf(user), assetAmount, "user received exactly the reported AAPL");
+        assertEq(user.balance, ethBefore, "no ETH paid on the stock path");
+        assertEq(poolBefore - address(pool).balance, amount, "ETH allocation consumed by the swap");
+        assertEq(pool.totalClaimed(tokenAapl), amount);
+        assertTrue(pool.hasClaimed(tokenAapl, 1, user));
+        (bool fb,) = fallbackReason(logs);
+        assertFalse(fb, "no fallback");
+        assertNoCustody();
+        assertInvariant();
+
+        // gas baseline for the ETH path with the same shape
+        pool.depositReward{value: 1 ether}(tokenEth);
+        publish1(tokenEth, 1, user, amount);
+        g0 = gasleft();
+        claimAs(user, tokenEth, 1, amount, 0);
+        console2.log("gas: claimBatchAs (1 epoch, ETH)", g0 - gasleft());
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Two tokens, two assets, same block: no cross-contamination
+    // ---------------------------------------------------------------------------------------
+    function test_TwoAssets_SameBlock_NoCrossContamination() public {
+        pool.depositReward{value: 1 ether}(tokenAapl);
+        pool.depositReward{value: 2 ether}(tokenTsla);
+        publish1(tokenAapl, 1, user, 0.05 ether);
+        publish1(tokenTsla, 1, user, 0.07 ether);
+
+        vm.recordLogs();
+        claimAs(user, tokenAapl, 1, 0.05 ether, 0);
+        (uint256 e1, address a1, uint256 out1) = rewardPaid(vm.getRecordedLogs());
+        vm.recordLogs();
+        claimAs(user, tokenTsla, 1, 0.07 ether, 0);
+        (uint256 e2, address a2, uint256 out2) = rewardPaid(vm.getRecordedLogs());
+
+        assertEq(a1, AAPL);
+        assertEq(a2, TSLA);
+        assertEq(e1, 0.05 ether);
+        assertEq(e2, 0.07 ether);
+        assertEq(IRobinhoodStock(AAPL).balanceOf(user), out1);
+        assertEq(IRobinhoodStock(TSLA).balanceOf(user), out2);
+        assertEq(pool.totalClaimed(tokenAapl), 0.05 ether);
+        assertEq(pool.totalClaimed(tokenTsla), 0.07 ether);
+        assertEq(pool.totalDeposited(tokenAapl), 1 ether);
+        assertEq(pool.totalDeposited(tokenTsla), 2 ether);
+        assertEq(pool.tokenVault(tokenAapl), 0.95 ether);
+        assertEq(pool.tokenVault(tokenTsla), 1.93 ether);
+        assertNoCustody();
+        assertInvariant();
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Authorisation and registry validation
+    // ---------------------------------------------------------------------------------------
+    function test_SetRewardAsset_Authorisation() public {
+        address t = address(0xC1C1);
+        vm.prank(stranger);
+        vm.expectRevert(ILossRewardPoolV2.NotAssetSetter.selector);
+        pool.setRewardAsset(t, AAPL);
+
+        pool.setRewardAsset(t, AAPL);
+        (address a, bool set, bool forced) = pool.rewardAsset(t);
+        assertEq(a, AAPL);
+        assertTrue(set);
+        assertFalse(forced);
+
+        vm.expectRevert(abi.encodeWithSelector(ILossRewardPoolV2.RewardAssetAlreadySet.selector, t));
+        pool.setRewardAsset(t, TSLA); // "creator of A cannot set B's" at the pool: a token's asset is write-once
+        vm.expectRevert(abi.encodeWithSelector(ILossRewardPoolV2.RewardAssetAlreadySet.selector, tokenAapl));
+        pool.setRewardAsset(tokenAapl, address(0));
+    }
+
+    function test_NonRegistryAssetRejected() public {
+        address t = address(0xC2C2);
+        vm.expectRevert(abi.encodeWithSelector(ILossRewardPoolV2.AssetNotSelectable.selector, FAKE_AAPL));
+        pool.setRewardAsset(t, FAKE_AAPL);
+        vm.expectRevert(abi.encodeWithSelector(ILossRewardPoolV2.AssetNotSelectable.selector, stranger));
+        pool.setRewardAsset(t, stranger);
+        vm.expectRevert(abi.encodeWithSelector(ILossRewardPoolV2.AssetNotSelectable.selector, MSFT));
+        pool.setRewardAsset(t, MSFT); // canonical but no route (deferred)
+        assertFalse(pool.isSelectableAsset(MSFT));
+        assertTrue(pool.isSelectableAsset(AAPL));
+
+        // routes: only canonical Uniswap V3 WETH/asset pools, only canonical assets
+        ILossRewardPoolV2.AssetRoute memory r = ILossRewardPoolV2.AssetRoute({swapper: address(swapper), pool: TSLA_POOL, fee: 500, twapWindow: 1800, maxDeviationBps: 300, enabled: true});
+        vm.expectRevert(ILossRewardPoolV2.InvalidRoute.selector);
+        pool.setAssetRoute(AAPL, r); // wrong pool for the asset
+        r.pool = AAPL_POOL;
+        r.fee = 3000;
+        vm.expectRevert(ILossRewardPoolV2.InvalidRoute.selector);
+        pool.setAssetRoute(AAPL, r); // wrong fee tier
+        r.fee = 500;
+        vm.expectRevert(abi.encodeWithSelector(ILossRewardPoolV2.AssetNotSelectable.selector, FAKE_AAPL));
+        pool.setAssetRoute(FAKE_AAPL, r);
+        vm.prank(stranger);
+        vm.expectRevert(ILossRewardPoolV2.Unauthorized.selector);
+        pool.setAssetRoute(AAPL, r);
+        vm.expectRevert(abi.encodeWithSelector(ILossRewardPoolV2.RouteNotConfigured.selector, MSFT));
+        pool.setAssetEnabled(MSFT, true);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Valid at launch, invalid at claim -> ETH fallback + event
+    // ---------------------------------------------------------------------------------------
+    function test_RegistryInvalidAtClaim_FallsBackToEth() public {
+        pool.depositReward{value: 1 ether}(tokenAapl);
+        publish1(tokenAapl, 1, user, 0.05 ether);
+        bytes32 uid = IRobinhoodStock(AAPL).uid();
+        vm.mockCall(STOCK_FACTORY, abi.encodeCall(IRobinhoodStockFactory.tokenAddress, (uid)), abi.encode(address(0)));
+
+        uint256 before = user.balance;
+        vm.recordLogs();
+        claimAs(user, tokenAapl, 1, 0.05 ether, 0);
+        (bool fb, ILossRewardPoolV2.FallbackReason reason) = fallbackReason(vm.getRecordedLogs());
+        assertTrue(fb);
+        assertEq(uint8(reason), uint8(ILossRewardPoolV2.FallbackReason.RegistryMismatch));
+        assertEq(user.balance - before, 0.05 ether, "paid in ETH");
+        assertEq(IRobinhoodStock(AAPL).balanceOf(user), 0);
+        assertNoCustody();
+        assertInvariant();
+    }
+
+    function test_PausedAtClaim_FallsBackToEth() public {
+        pool.depositReward{value: 1 ether}(tokenAapl);
+        publish1(tokenAapl, 1, user, 0.05 ether);
+        vm.mockCall(AAPL, abi.encodeCall(IRobinhoodStock.paused, ()), abi.encode(true));
+
+        uint256 before = user.balance;
+        vm.recordLogs();
+        claimAs(user, tokenAapl, 1, 0.05 ether, 0);
+        (bool fb, ILossRewardPoolV2.FallbackReason reason) = fallbackReason(vm.getRecordedLogs());
+        assertTrue(fb);
+        assertEq(uint8(reason), uint8(ILossRewardPoolV2.FallbackReason.AssetPaused));
+        assertEq(user.balance - before, 0.05 ether);
+        // and a paused asset is not selectable for new launches
+        vm.expectRevert(abi.encodeWithSelector(ILossRewardPoolV2.AssetNotSelectable.selector, AAPL));
+        pool.setRewardAsset(address(0xC3C3), AAPL);
+        assertNoCustody();
+    }
+
+    function test_ClaimantBlocked_FallsBackToEth() public {
+        pool.depositReward{value: 1 ether}(tokenAapl);
+        publish1(tokenAapl, 1, user, 0.05 ether);
+        vm.mockCall(ACCESS_REGISTRY, abi.encodeCall(IRobinhoodAccessControlsRegistry.isBlocked, (user)), abi.encode(true));
+        uint256 before = user.balance;
+        vm.recordLogs();
+        claimAs(user, tokenAapl, 1, 0.05 ether, 0);
+        (bool fb, ILossRewardPoolV2.FallbackReason reason) = fallbackReason(vm.getRecordedLogs());
+        assertTrue(fb);
+        assertEq(uint8(reason), uint8(ILossRewardPoolV2.FallbackReason.ClaimantBlocked));
+        assertEq(user.balance - before, 0.05 ether);
+        assertNoCustody();
+    }
+
+    function test_ThinLiquidity_FallsBackWithoutSwapping() public {
+        pool.depositReward{value: 1 ether}(tokenAapl);
+        publish1(tokenAapl, 1, user, 0.05 ether);
+        vm.mockCall(AAPL_POOL, abi.encodeCall(IUniswapV3PoolMinimal.liquidity, ()), abi.encode(uint128(0)));
+        uint256 before = user.balance;
+        vm.recordLogs();
+        claimAs(user, tokenAapl, 1, 0.05 ether, 0);
+        (bool fb, ILossRewardPoolV2.FallbackReason reason) = fallbackReason(vm.getRecordedLogs());
+        assertTrue(fb);
+        assertEq(uint8(reason), uint8(ILossRewardPoolV2.FallbackReason.NoLiquidity));
+        assertEq(user.balance - before, 0.05 ether);
+        assertEq(IRobinhoodStock(AAPL).balanceOf(user), 0, "no swap attempted");
+        assertNoCustody();
+    }
+
+    function test_AssetDisabled_FallsBack() public {
+        pool.depositReward{value: 1 ether}(tokenAapl);
+        publish1(tokenAapl, 1, user, 0.05 ether);
+        pool.setAssetEnabled(AAPL, false);
+        vm.recordLogs();
+        claimAs(user, tokenAapl, 1, 0.05 ether, 0);
+        (bool fb, ILossRewardPoolV2.FallbackReason reason) = fallbackReason(vm.getRecordedLogs());
+        assertTrue(fb);
+        assertEq(uint8(reason), uint8(ILossRewardPoolV2.FallbackReason.AssetDisabled));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Bounds: user-binding -> revert; protocol-binding -> fallback; distinguishable
+    // ---------------------------------------------------------------------------------------
+    function test_UserBoundBinding_RevertsMinOutNotMet() public {
+        pool.depositReward{value: 1 ether}(tokenAapl);
+        publish1(tokenAapl, 1, user, 0.05 ether);
+        (uint256 refOut,) = protocolFloorFor(AAPL_POOL, 0.05 ether);
+        uint256 userMin = refOut * 2; // above the protocol floor, so the user's bound is the binding one
+        vm.prank(user);
+        vm.expectPartialRevert(ILossRewardPoolV2.MinOutNotMet.selector);
+        pool.claimBatchAs(tokenAapl, one(1), one(0.05 ether), noProof(), userMin, block.timestamp + 600);
+        assertFalse(pool.hasClaimed(tokenAapl, 1, user), "whole claim reverted");
+        assertEq(pool.totalClaimed(tokenAapl), 0);
+        assertEq(IRobinhoodStock(AAPL).balanceOf(user), 0);
+        assertNoCustody();
+    }
+
+    /// @dev Pushes the AAPL/WETH pool far off its 30-minute TWAP inside this block.
+    function _manipulateAapl(uint256 ethIn) internal {
+        IWETH9(WETH).deposit{value: ethIn}();
+        _expected = AAPL_POOL;
+        IUniswapV3PoolMinimal(AAPL_POOL).swap(address(this), true, int256(ethIn), 4295128740, "");
+        _expected = address(0);
+    }
+
+    address private _expected;
+
+    function uniswapV3SwapCallback(int256 amount0Delta, int256, bytes calldata) external {
+        require(msg.sender == _expected, "bad callback");
+        IWETH9(WETH).transfer(msg.sender, uint256(amount0Delta));
+    }
+
+    function test_ProtocolBoundBinding_FallsBack_and_UserBoundStillReverts() public {
+        pool.depositReward{value: 1 ether}(tokenAapl);
+        publish1(tokenAapl, 1, user, 0.05 ether);
+        publish1(tokenAapl, 2, user, 0.05 ether);
+        (, uint256 floor) = protocolFloorFor(AAPL_POOL, 0.05 ether);
+
+        _manipulateAapl(60 ether); // spot now well below the TWAP-implied output
+        (uint256 refAfter,) = swapper.referenceOut(AAPL_POOL, 1800, 0.05 ether);
+        assertApproxEqAbs(refAfter, floor * 10_000 / 9_700, 1, "TWAP unchanged within the block");
+
+        // protocol floor binding (userMin = 0, a buggy frontend): fallback, not a revert
+        uint256 before = user.balance;
+        vm.recordLogs();
+        claimAs(user, tokenAapl, 1, 0.05 ether, 0);
+        (bool fb, ILossRewardPoolV2.FallbackReason reason) = fallbackReason(vm.getRecordedLogs());
+        assertTrue(fb, "fell back");
+        assertEq(uint8(reason), uint8(ILossRewardPoolV2.FallbackReason.BelowProtocolBound));
+        assertEq(user.balance - before, 0.05 ether, "paid in ETH");
+        assertEq(IRobinhoodStock(AAPL).balanceOf(user), 0, "swap unwound, no stock delivered");
+        assertTrue(pool.hasClaimed(tokenAapl, 1, user));
+
+        // user bound binding (userMin > protocol floor): the claim reverts instead
+        vm.prank(user);
+        vm.expectPartialRevert(ILossRewardPoolV2.MinOutNotMet.selector);
+        pool.claimBatchAs(tokenAapl, one(2), one(0.05 ether), noProof(), floor + 1, block.timestamp + 600);
+        assertFalse(pool.hasClaimed(tokenAapl, 2, user));
+        assertNoCustody();
+        assertInvariant();
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Minimum reward applies to the BATCH TOTAL
+    // ---------------------------------------------------------------------------------------
+    function test_MinimumReward_BatchTotal() public {
+        pool.depositReward{value: 1 ether}(tokenAapl);
+        uint256 small = 0.001 ether; // below 0.002 alone
+        publish1(tokenAapl, 1, user, small);
+        publish1(tokenAapl, 2, user, small);
+        publish1(tokenAapl, 3, user, small);
+
+        // one small epoch alone -> ETH (BelowMinimum)
+        uint256 before = user.balance;
+        vm.recordLogs();
+        claimAs(user, tokenAapl, 1, small, 0);
+        (bool fb, ILossRewardPoolV2.FallbackReason reason) = fallbackReason(vm.getRecordedLogs());
+        assertTrue(fb);
+        assertEq(uint8(reason), uint8(ILossRewardPoolV2.FallbackReason.BelowMinimum));
+        assertEq(user.balance - before, small);
+
+        // two small epochs combined reach the minimum -> stock
+        uint256[] memory ids = new uint256[](2);
+        ids[0] = 2;
+        ids[1] = 3;
+        uint256[] memory amts = new uint256[](2);
+        amts[0] = small;
+        amts[1] = small;
+        bytes32[][] memory proofs = new bytes32[][](2);
+        proofs[0] = new bytes32[](0);
+        proofs[1] = new bytes32[](0);
+        vm.recordLogs();
+        vm.prank(user);
+        pool.claimBatchAs(tokenAapl, ids, amts, proofs, 0, block.timestamp + 600);
+        (uint256 eth, address asset, uint256 out) = rewardPaid(vm.getRecordedLogs());
+        assertEq(asset, AAPL);
+        assertEq(eth, 2 * small);
+        assertEq(IRobinhoodStock(AAPL).balanceOf(user), out);
+        assertGt(out, 0);
+        assertNoCustody();
+        assertInvariant();
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // V1 signatures on a stock token
+    // ---------------------------------------------------------------------------------------
+    function test_V1Signatures_OnStockToken() public {
+        pool.depositReward{value: 1 ether}(tokenAapl);
+        publish1(tokenAapl, 1, user, 0.05 ether);  // above minimum -> effective payout is AAPL
+        publish1(tokenAapl, 2, user, 0.001 ether); // below minimum -> effective payout is ETH anyway
+
+        vm.prank(user);
+        vm.expectRevert(ILossRewardPoolV2.UseClaimAs.selector);
+        pool.claimBatch(tokenAapl, one(1), one(0.05 ether), noProof());
+        vm.prank(user);
+        vm.expectRevert(ILossRewardPoolV2.UseClaimAs.selector);
+        pool.claimReward(tokenAapl, 1, 0.05 ether, new bytes32[](0));
+        assertFalse(pool.hasClaimed(tokenAapl, 1, user));
+
+        uint256 before = user.balance;
+        vm.prank(user);
+        pool.claimReward(tokenAapl, 2, 0.001 ether, new bytes32[](0)); // below minimum: allowed, pays ETH
+        assertEq(user.balance - before, 0.001 ether);
+
+        pool.forceEthPayout(tokenAapl);
+        before = user.balance;
+        vm.prank(user);
+        pool.claimBatch(tokenAapl, one(1), one(0.05 ether), noProof()); // forced: allowed, pays ETH
+        assertEq(user.balance - before, 0.05 ether);
+        assertInvariant();
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Reentrancy
+    // ---------------------------------------------------------------------------------------
+    function test_Reentrancy_RevertsAndNeverDoublePays() public {
+        pool.depositReward{value: 1 ether}(tokenEth);
+        ReentrantClaimant attacker = new ReentrantClaimant(pool, tokenEth);
+        publish1(tokenEth, 1, address(attacker), 0.05 ether);
+
+        // (a) re-entry failure propagated: the whole claim reverts, nothing paid, nothing marked
+        vm.expectRevert(ILossRewardPoolV2.EthTransferFailed.selector);
+        attacker.claim(1, 0.05 ether);
+        assertFalse(pool.hasClaimed(tokenEth, 1, address(attacker)));
+        assertEq(address(attacker).balance, 0);
+
+        // (b) re-entry failure swallowed: paid exactly once, inner call rejected by the guard
+        attacker.setSwallow(true);
+        attacker.claim(1, 0.05 ether);
+        assertEq(address(attacker).balance, 0.05 ether, "paid once");
+        assertEq(pool.totalClaimed(tokenEth), 0.05 ether);
+        assertEq(bytes4(attacker.innerError()), ILossRewardPoolV2.ReentrancyGuardReentrantCall.selector);
+        assertInvariant();
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // forceEthPayout
+    // ---------------------------------------------------------------------------------------
+    function test_ForceEthPayout() public {
+        vm.prank(stranger);
+        vm.expectRevert(ILossRewardPoolV2.Unauthorized.selector);
+        pool.forceEthPayout(tokenAapl);
+
+        vm.expectEmit(true, true, false, true, address(pool));
+        emit ILossRewardPoolV2.EthPayoutForced(tokenAapl, AAPL);
+        pool.forceEthPayout(tokenAapl);
+        (address a,, bool forced) = pool.rewardAsset(tokenAapl);
+        assertEq(a, AAPL, "the selection is remembered");
+        assertTrue(forced);
+        assertEq(pool.effectivePayoutAsset(tokenAapl), address(0));
+
+        pool.depositReward{value: 1 ether}(tokenAapl);
+        publish1(tokenAapl, 1, user, 0.05 ether);
+        uint256 before = user.balance;
+        vm.recordLogs();
+        claimAs(user, tokenAapl, 1, 0.05 ether, 0);
+        (bool fb, ILossRewardPoolV2.FallbackReason reason) = fallbackReason(vm.getRecordedLogs());
+        assertTrue(fb);
+        assertEq(uint8(reason), uint8(ILossRewardPoolV2.FallbackReason.ForcedEth));
+        assertEq(user.balance - before, 0.05 ether);
+        // irreversible: there is no function that clears forcedEth; calling again is a no-op
+        pool.forceEthPayout(tokenAapl);
+        (,, forced) = pool.rewardAsset(tokenAapl);
+        assertTrue(forced);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Accounting across a mixed batch
+    // ---------------------------------------------------------------------------------------
+    function test_Accounting_MixedBatch() public {
+        pool.depositReward{value: 1 ether}(tokenEth);
+        pool.depositReward{value: 1 ether}(tokenAapl);
+        pool.depositReward{value: 1 ether}(tokenTsla);
+        publish2(tokenEth, 1, user, 0.03 ether, user2, 0.04 ether, 0.07 ether);
+        publish2(tokenAapl, 1, user, 0.05 ether, user2, 0.001 ether, 0.051 ether);
+        publish2(tokenTsla, 1, user, 0.06 ether, user2, 0.06 ether, 0.12 ether);
+
+        uint256 ethPaid;
+        uint256 ethSwapped;
+        vm.recordLogs();
+        // ETH token, both users, V1 signature
+        vm.prank(user);
+        pool.claimBatch(tokenEth, one(1), one(0.03 ether), _proof(leaf(tokenEth, 1, user2, 0.04 ether)));
+        vm.prank(user2);
+        pool.claimBatch(tokenEth, one(1), one(0.04 ether), _proof(leaf(tokenEth, 1, user, 0.03 ether)));
+        // AAPL token: user -> stock; user2 -> below minimum -> ETH
+        vm.prank(user);
+        pool.claimBatchAs(tokenAapl, one(1), one(0.05 ether), _proof(leaf(tokenAapl, 1, user2, 0.001 ether)), 0, block.timestamp + 600);
+        vm.prank(user2);
+        pool.claimBatchAs(tokenAapl, one(1), one(0.001 ether), _proof(leaf(tokenAapl, 1, user, 0.05 ether)), 0, block.timestamp + 600);
+        // TSLA token: user -> stock; user2 -> paused at claim time -> ETH fallback
+        vm.prank(user);
+        pool.claimBatchAs(tokenTsla, one(1), one(0.06 ether), _proof(leaf(tokenTsla, 1, user2, 0.06 ether)), 0, block.timestamp + 600);
+        vm.mockCall(TSLA, abi.encodeCall(IRobinhoodStock.paused, ()), abi.encode(true));
+        vm.prank(user2);
+        pool.claimBatchAs(tokenTsla, one(1), one(0.06 ether), _proof(leaf(tokenTsla, 1, user, 0.06 ether)), 0, block.timestamp + 600);
+        vm.clearMockedCalls();
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        uint256 paidCount;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].emitter != address(pool) || logs[i].topics[0] != REWARD_PAID_TOPIC) continue;
+            paidCount++;
+            address asset = address(uint160(uint256(logs[i].topics[3])));
+            (uint256 ethAmount,) = abi.decode(logs[i].data, (uint256, uint256));
+            if (asset == address(0)) ethPaid += ethAmount;
+            else ethSwapped += ethAmount;
+        }
+        assertEq(paidCount, 6);
+        assertEq(ethPaid, 0.03 ether + 0.04 ether + 0.001 ether + 0.06 ether);
+        assertEq(ethSwapped, 0.05 ether + 0.06 ether);
+        uint256 claimedAll = pool.totalClaimed(tokenEth) + pool.totalClaimed(tokenAapl) + pool.totalClaimed(tokenTsla);
+        assertEq(ethPaid + ethSwapped, claimedAll, "paid + swapped == claimed");
+        assertEq(address(pool).balance, 3 ether - claimedAll, "remaining == deposited - (paid + swapped)");
+        assertEq(pool.tokenVault(tokenEth), 1 ether - 0.07 ether);
+        assertEq(pool.tokenVault(tokenAapl), 1 ether - 0.051 ether);
+        assertEq(pool.tokenVault(tokenTsla), 1 ether - 0.12 ether);
+        assertGt(IRobinhoodStock(AAPL).balanceOf(user), 0);
+        assertGt(IRobinhoodStock(TSLA).balanceOf(user), 0);
+        assertEq(IRobinhoodStock(TSLA).balanceOf(user2), 0);
+        assertNoCustody();
+        assertInvariant();
+    }
+
+    function _proof(bytes32 sibling) internal pure returns (bytes32[][] memory p) {
+        p = new bytes32[][](1);
+        p[0] = new bytes32[](1);
+        p[0][0] = sibling;
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Strictness: per-epoch cap, bare ETH, deadline, adapter entrypoint
+    // ---------------------------------------------------------------------------------------
+    function test_EpochOverClaimed_PerTokenAccountingIsEnforced() public {
+        pool.depositReward{value: 1 ether}(tokenEth);
+        pool.depositReward{value: 1 ether}(tokenAapl);
+        // a root whose leaves sum to more than the epoch's allocation (a buggy or hostile worker)
+        publish2(tokenEth, 1, user, 0.5 ether, user2, 0.5 ether, 0.5 ether);
+        vm.prank(user);
+        pool.claimBatch(tokenEth, one(1), one(0.5 ether), _proof(leaf(tokenEth, 1, user2, 0.5 ether)));
+        vm.prank(user2);
+        vm.expectRevert(ILossRewardPoolV2.EpochOverClaimed.selector);
+        pool.claimBatch(tokenEth, one(1), one(0.5 ether), _proof(leaf(tokenEth, 1, user, 0.5 ether)));
+        assertEq(pool.tokenVault(tokenAapl), 1 ether, "the other token's ETH is untouchable");
+        assertInvariant();
+    }
+
+    function test_BareEthRejected() public {
+        (bool ok,) = address(pool).call{value: 1 ether}("");
+        assertFalse(ok);
+        assertEq(address(pool).balance, 0);
+    }
+
+    function test_DeadlineExpired() public {
+        pool.depositReward{value: 1 ether}(tokenAapl);
+        publish1(tokenAapl, 1, user, 0.05 ether);
+        vm.prank(user);
+        vm.expectRevert(ILossRewardPoolV2.DeadlineExpired.selector);
+        pool.claimBatchAs(tokenAapl, one(1), one(0.05 ether), noProof(), 0, block.timestamp - 1);
+    }
+
+    function test_AdapterSwapOnlyByPool() public {
+        vm.deal(stranger, 1 ether);
+        vm.prank(stranger);
+        vm.expectRevert(RewardSwapperUniswapV3.OnlyLossRewardPool.selector);
+        swapper.swap{value: 0.01 ether}(AAPL, AAPL_POOL, 0, stranger, block.timestamp + 600);
+        (bool ok,) = address(swapper).call{value: 1}("");
+        assertFalse(ok, "adapter rejects bare ETH");
+    }
+}

--- a/test/foundry/LossRewardPoolV2.t.sol
+++ b/test/foundry/LossRewardPoolV2.t.sol
@@ -479,11 +479,12 @@ contract LossRewardPoolV2Test is V2Base {
         pool.depositReward{value: 1 ether}(tokenAapl);
         publish1(tokenAapl, 1, user, 0.05 ether);
         publish1(tokenAapl, 2, user, 0.05 ether);
-        (, uint256 floor) = protocolFloorFor(AAPL_POOL, 0.05 ether);
+        (uint256 refBefore, uint256 floor) = protocolFloorFor(AAPL_POOL, 0.05 ether);
 
         _manipulateAapl(60 ether); // spot now well below the TWAP-implied output
-        (uint256 refAfter,) = swapper.referenceOut(AAPL_POOL, 1800, 0.05 ether);
-        assertApproxEqAbs(refAfter, floor * 10_000 / 9_700, 1, "TWAP unchanged within the block");
+        (uint256 refAfter, bool okAfter) = swapper.referenceOut(AAPL_POOL, 1800, 0.05 ether);
+        assertTrue(okAfter);
+        assertEq(refAfter, refBefore, "the contract's own TWAP reference is unchanged within the block");
 
         // protocol floor binding (userMin = 0, a buggy frontend): fallback, not a revert
         uint256 before = user.balance;

--- a/test/foundry/LossRewardPoolV2Hook.t.sol
+++ b/test/foundry/LossRewardPoolV2Hook.t.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Test, Vm} from "forge-std/Test.sol";
+import {PoolKey} from "@uniswap/v4-core/src/types/PoolKey.sol";
+import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/src/types/PoolId.sol";
+
+import {LegibleReviewBase} from "./LegiblePoolReview.t.sol";
+import {IncentifiV4LegibleFactory} from "../../contracts/v4/legible/IncentifiV4LegibleFactory.sol";
+import {LossRewardPool} from "../../contracts/LossRewardPool.sol";
+import {LossRewardPoolV2} from "../../contracts/loss-reward/LossRewardPoolV2.sol";
+import {RewardSwapperUniswapV3} from "../../contracts/loss-reward/RewardSwapperUniswapV3.sol";
+import {ILossRewardPoolV2} from "../../contracts/loss-reward/interfaces/ILossRewardPoolV2.sol";
+import {IRobinhoodStock} from "../../contracts/loss-reward/interfaces/IRobinhoodStock.sol";
+import {IncentifiLaunchToken} from "../../contracts/IncentifiLaunchToken.sol";
+
+/**
+ * LossRewardPoolV2 wired to the real launch path (legible hook + factory + converter, PR #17):
+ *   - factory.launchToken(token, AAPL) against V2 records the asset; against V1 it reverts
+ *   - fees collected by the hook land in V2 as depositReward; a stock claim then pays AAPL and
+ *     the creator's ETH pull-payment is untouched
+ *
+ * Run: forge test --match-path test/foundry/LossRewardPoolV2Hook.t.sol -vv
+ */
+contract LossRewardPoolV2HookTest is LegibleReviewBase {
+    using PoolIdLibrary for PoolKey;
+
+    address constant STOCK_FACTORY = 0x4783C67b63dE2B358Ac5951a7D41F47A38F3C046;
+    address constant ACCESS_REGISTRY = 0xe10b6f6B275de231345c20D14Ab812db62151b00;
+    address constant WETH = 0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73;
+    address constant V3_FACTORY = 0x1f7d7550B1b028f7571E69A784071F0205FD2EfA;
+    address constant AAPL = 0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9;
+    address constant MSFT = 0xe93237C50D904957Cf27E7B1133b510C669c2e74;
+    address constant AAPL_POOL = 0x8bb3514e2204E1cDF3Ac149EFEe7Ff04D91B719f;
+    bytes32 constant REWARD_PAID_TOPIC = keccak256("RewardPaid(address,address,uint256,address,uint256)");
+
+    LossRewardPoolV2 v2;
+    RewardSwapperUniswapV3 swapper;
+
+    function setUp() public {
+        vm.createSelectFork(vm.rpcUrl("robinhood"));
+        v2 = new LossRewardPoolV2(address(this), STOCK_FACTORY, ACCESS_REGISTRY);
+        swapper = new RewardSwapperUniswapV3(address(v2), WETH, V3_FACTORY);
+        v2.setAssetRoute(
+            AAPL, ILossRewardPoolV2.AssetRoute({swapper: address(swapper), pool: AAPL_POOL, fee: 500, twapWindow: 1800, maxDeviationBps: 300, enabled: true})
+        );
+        v2.setMinStockReward(0.002 ether);
+        deployTrio(address(v2));
+        v2.setAssetSetter(address(factory), true);
+        vm.deal(buyer, 100 ether);
+    }
+
+    function _newToken(string memory sym) internal returns (IncentifiLaunchToken t) {
+        vm.startPrank(creator);
+        t = new IncentifiLaunchToken(sym, sym, SUPPLY);
+        t.approve(address(factory), SUPPLY);
+        vm.stopPrank();
+    }
+
+    function test_FactoryLaunchWithRewardAsset_AgainstV2_SetsIt() public {
+        IncentifiLaunchToken t = _newToken("APL");
+        vm.prank(creator);
+        factory.launchToken(address(t), AAPL);
+        (address asset, bool set, bool forced) = v2.rewardAsset(address(t));
+        assertEq(asset, AAPL);
+        assertTrue(set);
+        assertFalse(forced);
+
+        // V2's own validation is surfaced by the factory: MSFT has no route yet
+        IncentifiLaunchToken m = _newToken("MSF");
+        vm.prank(creator);
+        vm.expectRevert(abi.encodeWithSelector(ILossRewardPoolV2.AssetNotSelectable.selector, MSFT));
+        factory.launchToken(address(m), MSFT);
+
+        // only the factory can set: the creator cannot bypass it, nor can a stranger
+        vm.prank(creator);
+        vm.expectRevert(ILossRewardPoolV2.NotAssetSetter.selector);
+        v2.setRewardAsset(address(m), AAPL);
+        vm.prank(stranger);
+        vm.expectRevert(ILossRewardPoolV2.NotAssetSetter.selector);
+        v2.setRewardAsset(address(t), address(0));
+    }
+
+    function test_FactoryLaunchWithRewardAsset_AgainstV1_Reverts() public {
+        LossRewardPool v1 = new LossRewardPool(address(this));
+        hook.setLossRewardPool(address(v1));
+        IncentifiLaunchToken t = _newToken("APL");
+        vm.prank(creator);
+        vm.expectRevert(IncentifiV4LegibleFactory.StockRewardsNotAvailable.selector);
+        factory.launchToken(address(t), AAPL);
+        // ETH still launches fine against V1
+        vm.prank(creator);
+        factory.launchToken(address(t), address(0));
+        assertTrue(factory.isLaunched(address(t)));
+    }
+
+    function test_HookFeesFundV2_StockClaim_CreatorEthUntouched() public {
+        IncentifiLaunchToken t = _newToken("APL");
+        vm.prank(creator);
+        factory.launchToken(address(t), AAPL);
+        PoolKey memory k = factory.getPoolKey(address(t));
+
+        botBuy(k, t, buyer, 2 ether);
+        hook.collect(address(t));
+        uint256 deposited = v2.totalDeposited(address(t));
+        assertApproxEqAbs(deposited, 0.02 ether, 1e6, "1% of 2 ETH deposited into V2 by the hook");
+        uint256 creatorEth = hook.creatorBalances(creator);
+        assertApproxEqAbs(creatorEth, 0.02 ether, 1e6, "creator's 1% sits in the hook");
+
+        // operator publishes an epoch for the buyer (this test is the operator)
+        uint256 reward = 0.01 ether;
+        bytes32 l = keccak256(bytes.concat(keccak256(abi.encode(address(t), uint256(1), buyer, reward))));
+        v2.setEpochMerkleRoot(address(t), 1, l, reward);
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = 1;
+        uint256[] memory amts = new uint256[](1);
+        amts[0] = reward;
+        bytes32[][] memory proofs = new bytes32[][](1);
+        proofs[0] = new bytes32[](0);
+        uint256 buyerEth = buyer.balance;
+        vm.recordLogs();
+        vm.prank(buyer);
+        v2.claimBatchAs(address(t), ids, amts, proofs, 0, block.timestamp + 600);
+        (Vm.Log memory paid, bool ok) = findLog(vm.getRecordedLogs(), address(v2), REWARD_PAID_TOPIC);
+        assertTrue(ok);
+        assertEq(address(uint160(uint256(paid.topics[3]))), AAPL);
+        (uint256 ethAmount, uint256 assetAmount) = abi.decode(paid.data, (uint256, uint256));
+        assertEq(ethAmount, reward);
+        assertEq(IRobinhoodStock(AAPL).balanceOf(buyer), assetAmount, "buyer received AAPL");
+        assertGt(assetAmount, 0);
+        assertEq(buyer.balance, buyerEth, "no ETH paid on the stock path");
+        assertEq(v2.totalClaimed(address(t)), reward);
+        assertEq(address(v2).balance, deposited - reward);
+        assertEq(hook.creatorBalances(creator), creatorEth, "creator ETH unaffected by the claim");
+        assertEq(IRobinhoodStock(AAPL).balanceOf(address(v2)), 0);
+        assertEq(IRobinhoodStock(AAPL).balanceOf(address(swapper)), 0);
+        assertEq(IRobinhoodStock(AAPL).balanceOf(address(hook)), 0);
+        // and the creator can still pull their ETH
+        uint256 before = creator.balance;
+        vm.prank(creator);
+        hook.claimCreatorFees();
+        assertEq(creator.balance - before, creatorEth);
+    }
+}


### PR DESCRIPTION
> **Supersedes #18.** GitHub cannot reopen a PR whose base branch (`design/v4-legible-pool`) was deleted when #17 merged, and cannot retarget a closed PR, so this is the same branch (`design/loss-reward-asset`) rebased onto master with the already-merged #17 commits dropped. One rebase conflict: `package.json` test list — resolved as the union of #21's new tests and #18's `fallback-monitor` test. `launch/page.tsx`, `creatorFees.ts`, `evm-indexer.mjs`, `tokenVenue.ts` are untouched by this PR (identical to master); `loss-reward-worker.mjs` auto-merged (#21's legible import + #18's fallback monitor, both kept). Re-run on the rebased branch: `LossRewardPoolV2.t.sol` 21/21, `LossRewardPoolV2Hook.t.sol` 3/3, worker unit tests (fallback-monitor, worker-hardening, balance-guard, indexer-freshness-gate, worker-mixed-hooks) all pass.

## Creator-selected Loss-Reward payout asset (Robinhood stock tokens) — design (Phase B) + implementation (Phase C). **No deployment.**

Stacked on PR #17 (base = `design/v4-legible-pool`) because the launch path uses `launchToken(token, rewardAsset)` and `hook.setLossRewardPool` from there. GitHub retargets to `master` when #17 merges.

### What it is
A new `LossRewardPoolV2` at a new address (V1 is a plain, non-upgradeable contract). Claims pay ETH exactly as today or, when the token's creator picked one at launch, a Robinhood stock (AAPL, TSLA, NVDA; MSFT deferred). The loss calculation, epoch/Merkle mechanism, eligibility, leaf format and operator model are unchanged; Merkle leaves stay ETH-denominated. **Economics, stated everywhere:** your ETH allocation is spent buying the stock at claim time; you receive whatever it buys — no dollar promise, no oracle, no shortfall liability; if it can't be delivered you get the ETH.

### Design decisions (docs/LOSS_REWARD_ASSET_DESIGN.md)
- **Registry**: the docs table is a REST fetch; the real on-chain registry is Robinhood's **StockFactory** `0x4783C67b…C046`. Validation = `IStock(x).uid()` (try/catch) → `StockFactory.tokenAddress(uid) == x`, plus `!paused()`, at selection **and** at claim. The contract never trusts a stored list of names.
- **Custody**: the pool **never holds stock**. A stateless adapter swaps on the canonical V3 WETH pool with `recipient = claimant`; stock flows Uniswap → user. Pre-checks `paused()` / `isBlocked(claimant)` (~15k gas) route the common failures to ETH without a wasted swap.
- **Protection (Amendment A)**: required user `minAssetOut` + `deadline`; protocol floor from the pool's own **30-min TWAP at 3%**; the swap is called with `amountOutMinimum = max(userMin, protocolFloor)` and the check is **inside the swap frame**. On `InsufficientOutput`: protocol floor binding → ETH fallback (`BelowProtocolBound`); user bound binding → claim reverts (`MinOutNotMet`). Any other adapter revert → `SwapFailed` fallback. No post-swap outcome check can fall back; the adapter only asserts zero residual. ETH is `msg.value` of the same call that swaps.
- **Amendment B**: V1 signatures on a stock token revert `UseClaimAs` unless the effective payout is ETH anyway (forced, or below minimum). Gateway relayer path now encodes `claimBatchAs`.
- **Amendment C**: `minStockRewardWei` applies to the **batch total** (three 0.001 ETH epochs: one alone → ETH, two together → AAPL). Default **0.002 ETH**, derived from the measured ≈232k-gas stock-path overhead (5% rule).
- **Per-token asset**: set once at launch by the factory (only authorised setter, write-once). Owner's single one-way `forceEthPayout(token)`.
- **V2 fixes**: `receive()` reverts; per-epoch claimed cap ⇒ `balance == Σ(deposited − claimed)` exactly.
- **Migration**: V1 keeps its ETH and epochs; worker drain-then-switch per token; hook re-pointed last by a separate script. Every hardcoded V1 site listed.
- **Open question answered**: ETH-only deposits, forever.

### Code (`contracts/loss-reward/`, `script/`, gateway)
`LossRewardPoolV2.sol`, `RewardSwapperUniswapV3.sol`, four interfaces, `DeployLossRewardPoolV2.s.sol`, `RepointHookLossRewardPool.s.sol` (deliberate second action), gateway relayer → `claimRewardAs`/`claimBatchAs`. Frontend/worker/indexer changes are specified in §B6/§B7 and are a follow-up PR.

### Tests — Robinhood mainnet fork, real StockFactory / access registry / stock tokens / V3 pools

| Suite | Result |
|---|---|
| `test/foundry/LossRewardPoolV2.t.sol` | **21/21** |
| `test/foundry/LossRewardPoolV2Hook.t.sol` (wired to the #17 hook/factory/converter) | **3/3** |
| `forge script DeployLossRewardPoolV2 --sender 0x1111…` dry run (no broadcast) | routes validated live, all three assets selectable |
| Hardhat compile | clean |

Covers every C4 case plus the additions: user-binding revert vs protocol-binding fallback on the same 60 ETH same-block push (distinguishable); adapter holds zero after success, fallback and revert; V1 signature on stock token reverts / on ETH token unchanged; batch below min → ETH, above → stock, mixed; factory launch with asset against V2 sets it, against V1 reverts. Full mapping in doc §B10.

**Measured (C5):** `claimBatchAs` one epoch — AAPL **352,223 gas** vs ETH **120,144 gas**; overhead ≈ 232k ≈ 0.00007 ETH at 0.305 gwei.

### Not verified / not in this PR
- `RepointHookLossRewardPool.s.sol` was not dry-run: it needs a deployed legible hook (PR #17 is undeployed).
- Chainlink-when-fresh extra check deferred to a later adapter version (interface allows it).
- Worker dual-pool mode, DB migration, frontend dropdown/badge/`uiMultiplier` display: follow-up PR per §B6/§B7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Review notes (approved with five non-blocking notes) — all addressed

| # | Note | What changed |
|---|---|---|
| 1 | `referenceOut()` ignored the pool fee (effective TSLA tolerance ~2.7%) | **Code:** the TWAP reference is now net of the pool's fee tier, so `maxDeviationBps` means what it says. Doc §B4.2. |
| 2 | `poolLiquidity() == 0` is a weak pre-check | **Relabelled** as an *empty-pool* check (interface comment, §B4.3, §B5). Thin liquidity is handled in-swap as `BelowProtocolBound`; a pre-swap quote would cost as much as the swap, so deliberately not added. |
| 3 | Manipulation test used a parallel recomputation with 1-wei tolerance | **Test:** now asserts the contract's own `referenceOut()` before/after the 60 ETH push are equal to the wei. |
| 4 | Confirm `setAssetRoute()` calls `validateRoute()` and rejects on `false` | **Confirmed and stated** in §B11 (it does: `InvalidRoute` on `false`, plus StockFactory round-trip, window ≥ 300 s, 0 < tolerance ≤ 2 000 bps, deployed swapper); covered by the wrong-pool / wrong-fee cases in `test_NonRegistryAssetRejected`. |
| 5 | Runbook: `setAssetSetter` before any stock launch; monitor the fallback rate | **Doc §C6 runbook.** Deploy script prints a WARNING when `ASSET_SETTER` is unset. **Worker:** `monitorFallbackEvents()` polls `RewardPaidInEthFallback` on V2 every run (enabled by `LOSS_REWARD_POOL_V2_ADDRESS`, cursor-based, never throws into the epoch loop) and raises `sendAlert` with a per-reason breakdown for anything other than `ForcedEth` / `BelowMinimum`. `test/fallback-monitor.test.mjs` (in `npm test`) covers summariser, alert gating, cursor and RPC failure. |

Re-run after the changes: `LossRewardPoolV2.t.sol` **21/21**, `LossRewardPoolV2Hook.t.sol` **3/3**, worker unit tests pass, Hardhat compile clean. Review log also recorded in doc §C7. Still **no deploy**.

